### PR TITLE
Update all the things to terra-core

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thanks.
 * Check that the issue has not already been fixed in the `master` branch.
 * Open an issue with a descriptive title and a summary.
 * Please be as clear and explicit as you can in your description of the problem.
-* Please state the version of Operating System, Browser, and terra-ui you are using in the description.
+* Please state the version of Operating System, Browser, and terra-core you are using in the description.
 * Include any relevant code in the issue summary.
 
 ## Pull Requests
@@ -29,7 +29,7 @@ Thanks.
 * Open a [pull request][6].
 * The pull request will be reviewed by the community and merged by the project committers.
 
-[1]: https://github.com/cerner/terra-ui/issues
+[1]: https://github.com/cerner/terra-core/issues
 [2]: http://gun.io/blog/how-to-github-fork-branch-and-pull-request
 [3]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [4]: ./LICENSE

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Terra UI
+# Terra Core
 
 [![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terra UI
 
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 - [Supported Browsers](#supported-browsers)
 - [Contributing](#contributing)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,6 @@ Releasing the project requires these steps:
 3. `npm publish` (make sure it's uploaded to [npm][project-url])
 4. Update to the next minor version in `package.json`
 
-[project-url]: https://www.npmjs.com/package/terra-ui/
+[project-url]: https://www.npmjs.com/package/terra-core/
 [semantic-versioning]: http://semver.org/
 [github-release-url]: https://help.github.com/articles/creating-releases/

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "keywords": [
     "Cerner",
     "Terra",
-    "Terra UI",
+    "Terra Core",
     "terra-core"
   ],
   "author": "Cerner Corporation",

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
-  "name": "terra-ui",
+  "name": "terra-core",
   "private": true,
   "version": "0.1.0",
-  "description": "terra-ui",
+  "description": "terra-core",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
     "Terra",
     "Terra UI",
-    "terra-ui"
+    "terra-core"
   ],
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/packages/terra-application/README.md
+++ b/packages/terra-application/README.md
@@ -2,12 +2,12 @@
 
 
 [![NPM version](http://img.shields.io/npm/v/terra-application.svg)](https://www.npmjs.org/package/terra-application)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The application component sets global styles for the entire application. Global styles include font, colors, margins, and sizes.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-application/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-application/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-application/package.json
+++ b/packages/terra-application/package.json
@@ -6,7 +6,7 @@
   "description": "The application component sets global styles for the entire application. Global styles include font, colors, margins, and sizes.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "devDependencies": {
     "terra-markdown": "^0.0.0"
   },

--- a/packages/terra-arrange/README.md
+++ b/packages/terra-arrange/README.md
@@ -2,12 +2,12 @@
 
 
 [![NPM version](http://img.shields.io/npm/v/terra-arrange.svg)](https://www.npmjs.org/package/terra-arrange)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The arrange component allows an item that has an intrinsic width, such as an icon or an image, to be offset from a group of associated content. When the group of associated content wraps, it will stay aligned next to the offset content rather than wrap below it.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-arrange/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-arrange/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-arrange/package.json
+++ b/packages/terra-arrange/package.json
@@ -6,7 +6,7 @@
   "description": "The arrange component is used for horizontally arranging and vertically aligning a single row of container elements.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",
     "compile:clean": "rm -rf lib",

--- a/packages/terra-badge/README.md
+++ b/packages/terra-badge/README.md
@@ -1,12 +1,12 @@
 # Terra Badge
 
 [![NPM version](http://img.shields.io/npm/v/terra-badge.svg)](https://www.npmjs.org/package/terra-badge)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The terra-badge component displays content classification.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-badge/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-badge/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-badge/package.json
+++ b/packages/terra-badge/package.json
@@ -6,7 +6,7 @@
   "description": "terra-badge",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",
     "compile:clean": "rm -rf lib",

--- a/packages/terra-button/README.md
+++ b/packages/terra-button/README.md
@@ -2,13 +2,13 @@
 
 
 [![NPM version](http://img.shields.io/npm/v/terra-button.svg)](https://www.npmjs.org/package/terra-button)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The terra-button component provides users a way to trigger actions in the UI.
 It can be modified in color, size, and type, and can optionally display an icon.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-button/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-button/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-button/package.json
+++ b/packages/terra-button/package.json
@@ -6,7 +6,7 @@
   "description": "The terra-button component provides users a way to trigger actions in the UI.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Button",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",
     "compile:clean": "rm -rf lib",

--- a/packages/terra-content/README.md
+++ b/packages/terra-content/README.md
@@ -2,12 +2,12 @@
 
 
 [![NPM version](http://img.shields.io/npm/v/terra-content.svg)](https://www.npmjs.org/package/terra-content)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The content component provides styles for commonly used HTML elements such as headers, paragraphs, lists, images, and more. This component ensures consistent styling between different browsers in a similar fashion to normalize.css. These styles are in a component as opposed to being used globally to ensure that Terra is opt in. As a result, other solutions will not be styled by this component.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-content/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-content/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-content/package.json
+++ b/packages/terra-content/package.json
@@ -6,7 +6,7 @@
   "description": "terra-content",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "devDependencies": {
     "terra-markdown": "^0.0.0",
     "terra-toolkit": "^0.1.1"

--- a/packages/terra-grid/README.md
+++ b/packages/terra-grid/README.md
@@ -1,12 +1,12 @@
 # Terra Grid
 
 [![NPM version](http://img.shields.io/npm/v/terra-grid.svg)](https://www.npmjs.org/package/terra-grid)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The terra-grid component provides a flexbox based grid system.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-grid/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-grid/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-grid/package.json
+++ b/packages/terra-grid/package.json
@@ -6,7 +6,7 @@
   "description": "The grid component provides a flexbox based grid system.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",
     "compile:clean": "rm -rf lib",

--- a/packages/terra-icon/README.md
+++ b/packages/terra-icon/README.md
@@ -2,12 +2,12 @@
 
 
 [![NPM version](http://img.shields.io/npm/v/terra-icon.svg)](https://www.npmjs.org/package/terra-icon)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The terra-icon component is used to visually represent a literal or symbolic object intended to initiate an action, communicate a status, or navigate the workflow.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-icon/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-icon/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-icon/package.json
+++ b/packages/terra-icon/package.json
@@ -5,7 +5,7 @@
   "description": "terra-icon",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -17,9 +17,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "devDependencies": {
     "csvtojson": "^1.1.4",
     "jsdom": "^9.11.0",

--- a/packages/terra-image/README.md
+++ b/packages/terra-image/README.md
@@ -2,12 +2,12 @@
 
 
 [![NPM version](http://img.shields.io/npm/v/terra-image.svg)](https://www.npmjs.org/package/terra-image)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The terra-image component provides styling for visual imagery.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-image/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-image/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-image/package.json
+++ b/packages/terra-image/package.json
@@ -6,7 +6,7 @@
   "description": "terra-image",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "devDependencies": {
     "terra-markdown": "^0.0.0",
     "terra-toolkit": "^0.1.1"

--- a/packages/terra-legacy-theme/README.md
+++ b/packages/terra-legacy-theme/README.md
@@ -1,12 +1,12 @@
 # Terra Legacy Theme
 
 [![NPM version](http://img.shields.io/npm/v/terra-legacy-theme.svg)](https://www.npmjs.org/package/terra-legacy-theme)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The legacy-theme component sets global variables for the entire application. Global variables are included for responsive breakpoints, colors, and typography.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-legacy-theme/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-legacy-theme/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-legacy-theme/package.json
+++ b/packages/terra-legacy-theme/package.json
@@ -6,7 +6,7 @@
   "description": "terra-legacy-theme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",
     "compile:clean": "rm -rf lib",

--- a/packages/terra-markdown/README.md
+++ b/packages/terra-markdown/README.md
@@ -2,12 +2,12 @@
 
 
 [![NPM version](http://img.shields.io/npm/v/terra-markdown.svg)](https://www.npmjs.org/package/terra-markdown)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 React component to display the content of markdown files.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-markdown/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-markdown/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-markdown/package.json
+++ b/packages/terra-markdown/package.json
@@ -6,7 +6,7 @@
   "description": "terra-markdown",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "devDependencies": {
     "terra-toolkit": "^0.1.1"
   },

--- a/packages/terra-menu/README.md
+++ b/packages/terra-menu/README.md
@@ -2,12 +2,12 @@
 
 
 [![NPM version](http://img.shields.io/npm/v/terra-menu.svg)](https://www.npmjs.org/package/terra-menu)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The terra-menu component displays grouped navigation actions. It can be used for site wide navigation or for switching between documents in a container.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-menu/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-menu/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-menu/package.json
+++ b/packages/terra-menu/package.json
@@ -6,7 +6,7 @@
   "description": "terra-menu",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "devDependencies": {
     "terra-markdown": "^0.0.0",
     "terra-toolkit": "^0.1.1"

--- a/packages/terra-mixins/README.md
+++ b/packages/terra-mixins/README.md
@@ -2,12 +2,12 @@
 
 
 [![NPM version](http://img.shields.io/npm/v/terra-mixins.svg)](https://www.npmjs.org/package/terra-mixins)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The terra-mixins component supplies global mixins for use throughout the Terra ecosystem.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-mixins/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-mixins/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-mixins/package.json
+++ b/packages/terra-mixins/package.json
@@ -5,7 +5,7 @@
   "description": "terra-mixins",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -17,9 +17,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",
     "compile:clean": "rm -rf lib",

--- a/packages/terra-progress-bar/README.md
+++ b/packages/terra-progress-bar/README.md
@@ -1,14 +1,14 @@
 # Terra Progress Bar
 
 [![NPM version](http://img.shields.io/npm/v/terra-progress-bar.svg)](https://www.npmjs.org/package/terra-progress-bar)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The progress bar component provides users a way to display the progress of process or activity in a graphical manner. It can be modified in height and fill color. Its styling is set such that, the `ProgressBar` element will occupy full width of its parent element and will flex based on the width of the parent container.
 
 Note: The progress bar displays fill with respect to percentage (value between 0 and 100). If `max` isn't specified in the input to the component, then `value` corresponds to a percentage value.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-progress-bar/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-progress-bar/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-progress-bar/package.json
+++ b/packages/terra-progress-bar/package.json
@@ -6,7 +6,7 @@
   "description": "terra-progress-bar",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",
     "compile:clean": "rm -rf lib",

--- a/packages/terra-props-table/README.md
+++ b/packages/terra-props-table/README.md
@@ -2,12 +2,12 @@
 
 
 [![NPM version](http://img.shields.io/npm/v/terra-props-table.svg)](https://www.npmjs.org/package/terra-props-table)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 React component to render a table view for the props metadata of another react component.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-props-table/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-props-table/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-props-table/package.json
+++ b/packages/terra-props-table/package.json
@@ -6,7 +6,7 @@
   "description": "terra-props-table",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "devDependencies": {
     "terra-markdown": "^0.0.0",
     "terra-toolkit": "^0.1.1"

--- a/packages/terra-responsive-element/README.md
+++ b/packages/terra-responsive-element/README.md
@@ -2,13 +2,13 @@
 
 
 [![NPM version](http://img.shields.io/npm/v/terra-responsive-element.svg)](https://www.npmjs.org/package/terra-responsive-element)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The ResponsiveElement conditionally renders components based on viewport size.
 The viewport can be set to the immediate parent or window.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-responsive-element/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-responsive-element/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-responsive-element/package.json
+++ b/packages/terra-responsive-element/package.json
@@ -6,7 +6,7 @@
   "description": "The terra-responsive-element conditionally renders components based on viewport size",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "devDependencies": {
     "terra-markdown": "^0.0.0",
     "terra-props-table": "^0.0.0",

--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -5,14 +5,14 @@
   "description": "Documentation Site for Functional Verification",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "scripts": {
     "start": "webpack-dev-server --hot --inline --display-error-details --progress --colors --host 0.0.0.0",
     "deploy": "webpack --config webpack.prod.config && gh-pages -d build",

--- a/packages/terra-site/src/index.html
+++ b/packages/terra-site/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Terra UI</title>
+    <title>Terra Core</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/terra-site/webpack.config.js
+++ b/packages/terra-site/webpack.config.js
@@ -9,7 +9,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
   entry: {
-    'terra-ui': path.resolve(path.join(__dirname, 'src', 'Index')),
+    'terra-core': path.resolve(path.join(__dirname, 'src', 'Index')),
   },
   resolveLoader: {
     root: path.resolve(path.join(__dirname, 'node_modules')),
@@ -42,7 +42,7 @@ module.exports = {
     new ExtractTextPlugin('[name]-[hash].css'),
     new HtmlWebpackPlugin({
       template: path.join(__dirname, 'src', 'index.html'),
-      chunks: ['terra-ui'],
+      chunks: ['terra-core'],
     }),
   ],
   postcss: [

--- a/packages/terra-slide-panel/README.md
+++ b/packages/terra-slide-panel/README.md
@@ -2,12 +2,12 @@
 
 
 [![NPM version](http://img.shields.io/npm/v/terra-slide-panel.svg)](https://www.npmjs.org/package/terra-slide-panel)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The Terra SlidePanel component is a progressive disclosure mechanism that allows additional content to be shown and hidden in a variety of ways.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-slide-panel/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-slide-panel/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-slide-panel/package.json
+++ b/packages/terra-slide-panel/package.json
@@ -6,7 +6,7 @@
   "description": "terra-slide-panel",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "devDependencies": {
     "terra-markdown": "^0.0.0",
     "terra-props-table": "^0.0.0",

--- a/packages/terra-standout/README.md
+++ b/packages/terra-standout/README.md
@@ -2,12 +2,12 @@
 
 
 [![NPM version](http://img.shields.io/npm/v/terra-standout.svg)](https://www.npmjs.org/package/terra-standout)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 {TBD}
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-standout/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-standout/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-standout/package.json
+++ b/packages/terra-standout/package.json
@@ -6,7 +6,7 @@
   "description": "terra-standout",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",
     "compile:clean": "rm -rf lib",

--- a/packages/terra-status/README.md
+++ b/packages/terra-status/README.md
@@ -1,12 +1,12 @@
 # Terra Status
 
 [![NPM version](http://img.shields.io/npm/v/terra-status.svg)](https://www.npmjs.org/package/terra-status)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The status component provides a customizable color indictor to signify a specific condition.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-status/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-status/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-status/package.json
+++ b/packages/terra-status/package.json
@@ -6,7 +6,7 @@
   "description": "The status component provides a customizable color indictor to signify a specific condition.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",
     "compile:clean": "rm -rf lib",

--- a/packages/terra-title/README.md
+++ b/packages/terra-title/README.md
@@ -1,12 +1,12 @@
 # Terra Title
 
 [![NPM version](http://img.shields.io/npm/v/terra-title.svg)](https://www.npmjs.org/package/terra-title)
-[![Build Status](https://travis-ci.org/cerner/terra-ui.svg?branch=master)](https://travis-ci.org/cerner/terra-ui)
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
 
 The terra-title component provides a short summary of content. It can be modified in size, orientation, and can optionally display a graphic and/or caption.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-title/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-title/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-title/package.json
+++ b/packages/terra-title/package.json
@@ -6,7 +6,7 @@
   "description": "terra-title",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -18,9 +18,9 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
-  "homepage": "https://github.com/cerner/terra-ui#readme",
+  "homepage": "https://github.com/cerner/terra-core#readme",
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",
     "compile:clean": "rm -rf lib",

--- a/packages/terra-toolkit/README.md
+++ b/packages/terra-toolkit/README.md
@@ -7,7 +7,7 @@
 Terra Toolkit is a utility module used to facilitate developmen of Terra projects.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-ui/tree/master/packages/terra-toolkit/docs)
+- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-toolkit/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/packages/terra-toolkit/package.json
+++ b/packages/terra-toolkit/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerner/terra-ui.git"
+    "url": "git+https://github.com/cerner/terra-core.git"
   },
   "keywords": [
     "Cerner",
@@ -27,7 +27,7 @@
   "author": "Cerner Corporation",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/cerner/terra-ui/issues"
+    "url": "https://github.com/cerner/terra-core/issues"
   },
   "devDependencies": {
     "terra-application": "^0.2.0",


### PR DESCRIPTION
### Summary
We recently updated the repo name to terra-core. This PR includes updating all references of `terra-ui` to `terra-core` and `Terra UI` to `Terra Core`