### PR TITLE
Move DetailView examples to site

### DIFF
--- a/packages/terra-detail-view/package.json
+++ b/packages/terra-detail-view/package.json
@@ -33,9 +33,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "react": "^15.4.2",
-    "terra-mixins": "^1.0.0",
-    "terra-props-table": "^0.0.0",
-    "terra-markdown": "^0.0.0"
+    "terra-mixins": "^1.0.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -31,6 +31,7 @@
     "terra-badge": "^0.x",
     "terra-button": "^0.x",
     "terra-content": "^0.x",
+    "terra-detail-view": "^0.x",
     "terra-grid": "^1.0.0",
     "terra-i18n": "^0.x",
     "terra-icon": "^0.x",

--- a/packages/terra-site/src/Index.jsx
+++ b/packages/terra-site/src/Index.jsx
@@ -10,7 +10,7 @@ import ArrangeExamples from './examples/arrange/Index';
 import BadgeExamples from './examples/badge/Index';
 import ButtonExamples from './examples/button/Index';
 import ContentExamples from './examples/content/Index';
-import DetailViewExamples from '../../../packages/terra-detail-view/examples/Index';
+import DetailViewExamples from './examples/detail-view/Index';
 import GridExamples from './examples/grid/Index';
 import I18nExamples from './examples/i18n/Index';
 import IconExamples from './examples/icon/Index';
@@ -26,7 +26,7 @@ import TitleExamples from './examples/title/Index';
 // Test
 /* eslint-disable import/first */
 import ButtonTestRoutes from 'terra-button/tests/nightwatch/ButtonTestRoutes';
-import DetailViewTestRoutes from '../../../packages/terra-detail-view/tests/nightwatch/DetailViewTestRoutes';
+import DetailViewTestRoutes from 'terra-detail-view/tests/nightwatch/DetailViewTestRoutes';
 import I18nTestRoutes from 'terra-i18n/tests/nightwatch/I18nTestRoutes';
 import ResponsiveElementTestRoutes from 'terra-responsive-element/tests/nightwatch/ResponsiveElementTestRoutes';
 import SlidePanelTestRoutes from 'terra-slide-panel/tests/nightwatch/SlidePanelTestRoutes';
@@ -43,6 +43,7 @@ ReactDOM.render((
       <Route path="badge" component={BadgeExamples} />
       <Route path="button" component={ButtonExamples} />
       <Route path="content" component={ContentExamples} />
+      <Route path="detail-view" component={DetailViewExamples} />
       <Route path="grid" component={GridExamples} />
       <Route path="i18n" component={I18nExamples} />
       <Route path="icon" component={IconExamples} />
@@ -54,7 +55,6 @@ ReactDOM.render((
       <Route path="status" component={StatusExamples} />
       <Route path="title" component={TitleExamples} />
       <Route path="responsive-element" component={ResponsiveElementExamples} />
-      <Route path="detail-view" component={DetailViewExamples} />
     </Route>
     <Route path="/tests" component={TestLinks} />
     {ButtonTestRoutes}

--- a/packages/terra-site/src/examples/detail-view/DetailViewDivided.jsx
+++ b/packages/terra-site/src/examples/detail-view/DetailViewDivided.jsx
@@ -1,14 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import Grid from 'terra-grid';
-import DetailView from '../src/DetailView';
+import DetailView from 'terra-detail-view';
 
 const DetailViewDivided = () => (
   <DetailView
     title="Header"
     subtitles={['Subtitle 1', 'Subtitle 2']}
     graph={<div style={{ border: '1px solid black', height: '20em', width: '25em', marginBottom: '0.714rem' }}>This is where any visualizations would go</div>}
-    details={[(
+    details={[
       <Grid key="detailInfo">
         <Grid.Row>
           <Grid.Column col={6}>
@@ -26,10 +26,9 @@ const DetailViewDivided = () => (
             <div>Second Row - Second Column content</div>
           </Grid.Column>
         </Grid.Row>
-      </Grid>
-    )]}
+      </Grid>,
+    ]}
     footer="Footer Text"
-    isDivided={false}
   />
 );
 

--- a/packages/terra-site/src/examples/detail-view/DetailViewNoDivider.jsx
+++ b/packages/terra-site/src/examples/detail-view/DetailViewNoDivider.jsx
@@ -1,14 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import Grid from 'terra-grid';
-import DetailView from '../src/DetailView';
+import DetailView from 'terra-detail-view';
 
 const DetailViewDivided = () => (
   <DetailView
     title="Header"
     subtitles={['Subtitle 1', 'Subtitle 2']}
     graph={<div style={{ border: '1px solid black', height: '20em', width: '25em', marginBottom: '0.714rem' }}>This is where any visualizations would go</div>}
-    details={[
+    details={[(
       <Grid key="detailInfo">
         <Grid.Row>
           <Grid.Column col={6}>
@@ -26,9 +26,10 @@ const DetailViewDivided = () => (
             <div>Second Row - Second Column content</div>
           </Grid.Column>
         </Grid.Row>
-      </Grid>,
-    ]}
+      </Grid>
+    )]}
     footer="Footer Text"
+    isDivided={false}
   />
 );
 

--- a/packages/terra-site/src/examples/detail-view/Index.jsx
+++ b/packages/terra-site/src/examples/detail-view/Index.jsx
@@ -2,10 +2,10 @@
 import React from 'react';
 import PropsTable from 'terra-props-table';
 import Markdown from 'terra-markdown';
-import ReadMe from '../docs/README.md';
+import ReadMe from 'terra-detail-view/docs/README.md';
 // Component Source
 // eslint-disable-next-line import/no-webpack-loader-syntax, import/first, import/no-unresolved, import/extensions
-import DetailViewSrc from '!raw-loader!../src/DetailView.jsx';
+import DetailViewSrc from '!raw-loader!terra-detail-view/src/DetailView.jsx';
 
 // Example files
 import DetailViewDivided from './DetailViewDivided';

--- a/packages/terra-site/src/examples/detail-view/Index.jsx
+++ b/packages/terra-site/src/examples/detail-view/Index.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import PropsTable from 'terra-props-table';
 import Markdown from 'terra-markdown';


### PR DESCRIPTION
### Summary
Moving the examples for detail view from the terra-detail-view to terra-site

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
