### PR TITLE
Release terra-markdown 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 | terra-button       | [![NPM version](http://img.shields.io/npm/v/terra-button.svg)](https://www.npmjs.org/package/terra-button) |
 | terra-grid         | [![NPM version](http://img.shields.io/npm/v/terra-grid.svg)](https://www.npmjs.org/package/terra-grid) |
 | terra-legacy-theme | [![NPM version](http://img.shields.io/npm/v/terra-legacy-theme.svg)](https://www.npmjs.org/package/terra-legacy-theme) |
+| terra-markdown     | [![NPM version](http://img.shields.io/npm/v/terra-markdown.svg)](https://www.npmjs.org/package/terra-markdown) |
 | terra-mixins       | [![NPM version](http://img.shields.io/npm/v/terra-mixins.svg)](https://www.npmjs.org/package/terra-mixins) |
 | terra-table        | [![NPM version](http://img.shields.io/npm/v/terra-table.svg)](https://www.npmjs.org/package/terra-table) |
 | terra-toolkit      | [![NPM version](http://img.shields.io/npm/v/terra-toolkit.svg)](https://www.npmjs.org/package/terra-toolkit) |

--- a/packages/terra-markdown/package.json
+++ b/packages/terra-markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-markdown",
   "main": "lib/Markdown.js",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "terra-markdown",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Summary
:1st_place_medal: Terra-markdown 0.1.0 has been released! :1st_place_medal:  

* Committing version 0.1.0
* Updating Readme with npm version badge

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
