### PR TITLE
Add focus outline fix for Firefox on Windows

### DIFF
--- a/packages/terra-button/lib/Button.scss
+++ b/packages/terra-button/lib/Button.scss
@@ -59,7 +59,7 @@ input[type='submit'].terra-Button {
 
   // Restore the focus styles unset by the previous rule.
   &:-moz-focusring {
-    outline: 1px dotted ButtonText;
+    outline: 1px dotted $terra-dark;
     -moz-outline-radius: 0.25em;
   }
 

--- a/packages/terra-button/lib/Button.scss
+++ b/packages/terra-button/lib/Button.scss
@@ -51,15 +51,16 @@ input[type='submit'].terra-Button {
   vertical-align: middle;
   white-space: normal;
 
-  // Removes extra space Firefox adds to button elements
+  // Remove the inner border and padding in Firefox.
   &::-moz-focus-inner {
     border: 0;
     padding: 0;
   }
 
+  // Restore the focus styles unset by the previous rule.
   &:-moz-focusring {
-    outline: 2px solid -moz-mac-focusring;
-    -moz-outline-radius: 0.45em;
+    outline: 1px dotted ButtonText;
+    -moz-outline-radius: 0.25em;
   }
 
   &:disabled,

--- a/packages/terra-button/src/Button.scss
+++ b/packages/terra-button/src/Button.scss
@@ -59,7 +59,7 @@ input[type='submit'].terra-Button {
 
   // Restore the focus styles unset by the previous rule.
   &:-moz-focusring {
-    outline: 1px dotted ButtonText;
+    outline: 1px dotted $terra-dark;
     -moz-outline-radius: 0.25em;
   }
 

--- a/packages/terra-button/src/Button.scss
+++ b/packages/terra-button/src/Button.scss
@@ -51,15 +51,16 @@ input[type='submit'].terra-Button {
   vertical-align: middle;
   white-space: normal;
 
-  // Removes extra space Firefox adds to button elements
+  // Remove the inner border and padding in Firefox.
   &::-moz-focus-inner {
     border: 0;
     padding: 0;
   }
 
+  // Restore the focus styles unset by the previous rule.
   &:-moz-focusring {
-    outline: 2px solid -moz-mac-focusring;
-    -moz-outline-radius: 0.45em;
+    outline: 1px dotted ButtonText;
+    -moz-outline-radius: 0.25em;
   }
 
   &:disabled,


### PR DESCRIPTION
### Summary
[Issue identified](https://github.com/cerner/terra-core/issues/193) with focus outline in Firefox on Windows.

### Additional Details

#### Before fix
![button-focus-outline-firefox-windows](https://cloud.githubusercontent.com/assets/633148/24636871/bb7cbb4a-18a2-11e7-8ec0-ef18b6d6c6f8.gif)

#### After fix
![button-focus-outline-firefox-windows-fix](https://cloud.githubusercontent.com/assets/633148/24636873/bfbbeadc-18a2-11e7-8d95-29bd83b022cf.gif)

This fix only impacts Firefox in both Windows and Mac operating systems. The solution was pulled from [normalize.css](https://github.com/necolas/normalize.css/blob/master/normalize.css#L284-L293)

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
