### PR TITLE
Update box-sizing on ResponsiveElement examples

### DIFF
--- a/packages/terra-responsive-element/docs/README.md
+++ b/packages/terra-responsive-element/docs/README.md
@@ -3,7 +3,11 @@
 The ResponsiveElement conditionally renders components based on viewport size.
 The viewport can be set to the immediate parent or window.
 
-*Note: It is not necessary to set each breakpoint. If a breakpoint is not set the component will look at each successive smaller breakpoint until one is found.*
+## Additional Notes:
+
+It is not necessary to set each breakpoint. If a breakpoint is not set the component will look at each successive smaller breakpoint until one is found.
+
+The ResponsiveElement observes the available width. Meaning padding, borders, and margins set on the parent are not included in the calculation. Modifying box-sizing will impact how these properties are used in an elements width calculation. For more details see: https://css-tricks.com/almanac/properties/b/box-sizing/
 
 ## Getting Started
 

--- a/packages/terra-site/src/examples/responsive-element/ResponsiveExample.scss
+++ b/packages/terra-site/src/examples/responsive-element/ResponsiveExample.scss
@@ -1,5 +1,6 @@
 .terra-ResponsiveExample-container {
   border: 1px dashed;
+  box-sizing: content-box;
   margin-top: 10px;
   padding: 10px;
   width: $terra-tiny-breakpoint / 2;


### PR DESCRIPTION
### Summary
**Note:** This only affected the Examples, the ResponsiveElement itself remains unchanged and is working as expected. 

The ResponsiveElement calculates only the available space an element could fill. Margins / padding / borders impact this value. 

A recent update to terra-base defaulted the box-sizing of elements to be border-box instead of content-box.

https://github.com/cerner/terra-core/commit/6b2fe080356bc04661eb0a0dea6db27d324b2133#diff-98df4af7659470fa3fb44b30db756e8bR6

This property affects how padding / borders / margin are applied to elements. By default ( content-box ) these properties are applied on top of an element's width. 

Example: adding 20px left padding to an element that is 100px wide will increase that elements total width to 120px. ( But the available width is still 100px )

When set to border-box padding is applied to the existing width. The same example above, but set to border-box, would preserve the elements' 100px width, while also applying 20px left padding. ( But the available width is reduced to 80px)

For more details see: https://css-tricks.com/almanac/properties/b/box-sizing/

After setting the default box-sizing to border-box the available width of the ResponsiveElement example container actually became (width - padding), resulting in the examples always being 1 size smaller than they should be.

![screen shot 2017-04-06 at 5 20 17 pm](https://cloud.githubusercontent.com/assets/6720991/24777929/7bc5dbba-1aed-11e7-80d4-9081ae1e40ae.png)


Fix: Set the ResponsiveElement example container to content-box so the container available width is always set to the breakpoint size.

This issue can be demoed here: http://engineering.cerner.com/terra-core/#/site/responsive-element
Notice the rendered component is always one size smaller than what the dropdown indicates. 

This is because, while box-sizing is set to border-box, the padding reduces the actual *available* width of the container.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
