### PR TITLE
We need to lock down react-docgen since they made a change that is br…

### DIFF
--- a/packages/terra-props-table/package.json
+++ b/packages/terra-props-table/package.json
@@ -29,7 +29,7 @@
     "terra-base": "^0.x"
   },
   "dependencies": {
-    "react-docgen": "^2.13.0",
+    "react-docgen": "2.13.0",
     "terra-markdown": "^0.x"
   },
   "scripts": {


### PR DESCRIPTION
…eaking our builds.

### Summary
We need to lock down react-docgen since there is a change that is breaking.  Here is the line of code causing the problem: https://github.com/reactjs/react-docgen/blob/d65bfc460d7274206c3208fc41518727acd5a490/src/utils/getMemberValuePath.js#L25

This seems to work in chrome, so I'm curious to see if it's purely a problem in phantomJS.  I'm not sure if there's a polyfill or something that we would need to use to allow this syntax.