### PR TITLE
Fix #215 - Update table subcomponets naming

### DIFF
--- a/packages/terra-site/src/examples/table/Index.jsx
+++ b/packages/terra-site/src/examples/table/Index.jsx
@@ -10,10 +10,10 @@ import { version } from 'terra-list/package.json';
 import TableSrc from '!raw-loader!terra-table/src/Table';
 import SingleSelectableRowsSrc from '!raw-loader!terra-table/src/SingleSelectableRows';
 import TableHeaderSrc from '!raw-loader!terra-table/src/TableHeader';
-import TableHeaderContentSrc from '!raw-loader!terra-table/src/TableHeaderContent';
+import TableHeaderCellSrc from '!raw-loader!terra-table/src/TableHeaderCell';
 import TableRowSrc from '!raw-loader!terra-table/src/TableRow';
 import TableRowsSrc from '!raw-loader!terra-table/src/TableRows';
-import TableRowContentSrc from '!raw-loader!terra-table/src/TableRowContent';
+import TableCellSrc from '!raw-loader!terra-table/src/TableCell';
 /* eslint-enable import/no-webpack-loader-syntax, import/first, import/no-unresolved, import/extensions */
 
 import NoStripedTable from './NoStripedTable';
@@ -32,16 +32,16 @@ const TableExamples = () => (
     <PropsTable id="props-table" src={TableSrc} />
     <h2>Table Header</h2>
     <PropsTable id="props-tableHeader" src={TableHeaderSrc} />
-    <h2>Table Header Content</h2>
-    <PropsTable id="props-tableHeaderContent" src={TableHeaderContentSrc} />
+    <h2>Table Header Cell</h2>
+    <PropsTable id="props-tableHeaderCell" src={TableHeaderCellSrc} />
     <h2>Table Rows</h2>
     <PropsTable id="props-tableRows" src={TableRowsSrc} />
     <h2>Single Selectable Table Row</h2>
     <PropsTable id="props-singleSelectableRows" src={SingleSelectableRowsSrc} />
     <h2>Table Row</h2>
     <PropsTable id="props-tableRow" src={TableRowSrc} />
-    <h2>Table Row Content</h2>
-    <PropsTable id="props-tableRowContent" src={TableRowContentSrc} />
+    <h2>Table Cell</h2>
+    <PropsTable id="props-tablecell" src={TableCellSrc} />
     <h2>Table without zebra stripes</h2>
     <NoStripedTable />
     <h2>Table with zebra stripes</h2>

--- a/packages/terra-site/src/examples/table/NoStripedTable.jsx
+++ b/packages/terra-site/src/examples/table/NoStripedTable.jsx
@@ -5,25 +5,25 @@ import Table from 'terra-table';
 const NoStripedTable = () => (
   <Table isStriped={false}>
     <Table.Header>
-      <Table.HeaderContent content={'Name'} key={'NAME'} minWidth={'small'} />
-      <Table.HeaderContent content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
-      <Table.HeaderContent content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
     </Table.Header>
     <Table.Rows>
       <Table.Row key={'PERSON_0'}>
-        <Table.RowContent content="John Smith" key="NAME" />
-        <Table.RowContent content="123 Adams Drive" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_1'}>
-        <Table.RowContent content="Jane Smith" key="NAME" />
-        <Table.RowContent content="321 Drive Street" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_2'}>
-        <Table.RowContent content="Dave Smith" key="NAME" />
-        <Table.RowContent content="213 Raymond Road" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
     </Table.Rows>
   </Table>

--- a/packages/terra-site/src/examples/table/SingleRowSelectableTable.jsx
+++ b/packages/terra-site/src/examples/table/SingleRowSelectableTable.jsx
@@ -5,25 +5,25 @@ import Table from 'terra-table';
 const SingleRowSelectableTable = () => (
   <Table isStriped={false}>
     <Table.Header>
-      <Table.HeaderContent content={'Name'} key={'NAME'} minWidth={'small'} />
-      <Table.HeaderContent content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
-      <Table.HeaderContent content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
     </Table.Header>
     <Table.SingleSelectableRows>
       <Table.Row isSelected key={'PERSON_0'}>
-        <Table.RowContent content="John Smith" key="NAME" />
-        <Table.RowContent content="123 Adams Drive" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_1'}>
-        <Table.RowContent content="Jane Smith" key="NAME" />
-        <Table.RowContent content="321 Drive Street" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_2'}>
-        <Table.RowContent content="Dave Smith" key="NAME" />
-        <Table.RowContent content="213 Raymond Road" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
     </Table.SingleSelectableRows>
   </Table>

--- a/packages/terra-site/src/examples/table/StripedTable.jsx
+++ b/packages/terra-site/src/examples/table/StripedTable.jsx
@@ -5,25 +5,25 @@ import Table from 'terra-table';
 const StripedTable = () => (
   <Table>
     <Table.Header>
-      <Table.HeaderContent content={'Name'} key={'NAME'} minWidth={'small'} />
-      <Table.HeaderContent content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
-      <Table.HeaderContent content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
     </Table.Header>
     <Table.Rows>
       <Table.Row key={'PERSON_0'}>
-        <Table.RowContent content="John Smith" key="NAME" />
-        <Table.RowContent content="123 Adams Drive" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_1'}>
-        <Table.RowContent content="Jane Smith" key="NAME" />
-        <Table.RowContent content="321 Drive Street" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_2'}>
-        <Table.RowContent content="Dave Smith" key="NAME" />
-        <Table.RowContent content="213 Raymond Road" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
     </Table.Rows>
   </Table>

--- a/packages/terra-site/src/examples/table/TableWithHighlightedRows.jsx
+++ b/packages/terra-site/src/examples/table/TableWithHighlightedRows.jsx
@@ -5,35 +5,35 @@ import Table from 'terra-table';
 const TableWithHighlightedRows = () => (
   <Table isStriped={false}>
     <Table.Header>
-      <Table.HeaderContent content={'Name'} key={'NAME'} minWidth={'small'} />
-      <Table.HeaderContent content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
-      <Table.HeaderContent content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
     </Table.Header>
     <Table.Rows>
       <Table.Row isSelected key={'PERSON_0'}>
-        <Table.RowContent content="John Smith" key="NAME" />
-        <Table.RowContent content="123 Adams Drive" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_1'}>
-        <Table.RowContent content="Jane Smith" key="NAME" />
-        <Table.RowContent content="321 Drive Street" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_2'}>
-        <Table.RowContent content="Dave Smith" key="NAME" />
-        <Table.RowContent content="213 Raymond Road" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row isSelected key={'PERSON_3'}>
-        <Table.RowContent content="Mario Smith" key="NAME" />
-        <Table.RowContent content="213 Road" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Mario Smith" key="NAME" />
+        <Table.Cell content="213 Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_4'}>
-        <Table.RowContent content="Louie Smith" key="NAME" />
-        <Table.RowContent content="213 Raymond  St" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Louie Smith" key="NAME" />
+        <Table.Cell content="213 Raymond  St" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
     </Table.Rows>
   </Table>

--- a/packages/terra-site/src/examples/table/TableWithMaxHeight.jsx
+++ b/packages/terra-site/src/examples/table/TableWithMaxHeight.jsx
@@ -5,25 +5,25 @@ import Table from 'terra-table';
 const TableWithMaxHeight = () => (
   <Table isStriped={false}>
     <Table.Header height={'small'}>
-      <Table.HeaderContent content={'Column Heading 1'} key={'COLUMN_0'} minWidth={'small'} />
-      <Table.HeaderContent content={'Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header End Header'} key={'COLUMN_1'} minWidth={'medium'} />
-      <Table.HeaderContent content={'Column Heading 3'} key={'COLUMN_2'} minWidth={'large'} />
+      <Table.HeaderCell content={'Column Heading 1'} key={'COLUMN_0'} minWidth={'small'} />
+      <Table.HeaderCell content={'Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header End Header'} key={'COLUMN_1'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Column Heading 3'} key={'COLUMN_2'} minWidth={'large'} />
     </Table.Header>
     <Table.SingleSelectableRows height={'small'}>
       <Table.Row key={'ROW_0'}>
-        <Table.RowContent content={'Table Data'} key={'COLUMN_0'} />
-        <Table.RowContent content={'Table Data'} key={'COLUMN_1'} />
-        <Table.RowContent content={'Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text End table text'} key={'COLUMN_2'} />
+        <Table.Cell content={'Table Data'} key={'COLUMN_0'} />
+        <Table.Cell content={'Table Data'} key={'COLUMN_1'} />
+        <Table.Cell content={'Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text End table text'} key={'COLUMN_2'} />
       </Table.Row>
       <Table.Row key={'ROW_1'}>
-        <Table.RowContent content={'Table Data'} key={'COLUMN_0'} />
-        <Table.RowContent content={'Table Data'} key={'COLUMN_1'} />
-        <Table.RowContent content={'Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text End table text'} key={'COLUMN_2'} />
+        <Table.Cell content={'Table Data'} key={'COLUMN_0'} />
+        <Table.Cell content={'Table Data'} key={'COLUMN_1'} />
+        <Table.Cell content={'Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text End table text'} key={'COLUMN_2'} />
       </Table.Row>
       <Table.Row key={'ROW_2'}>
-        <Table.RowContent content={'Table Data'} key={'COLUMN_0'} />
-        <Table.RowContent content={'Table Data'} key={'COLUMN_1'} />
-        <Table.RowContent content={'Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text End table text'} key={'COLUMN_2'} />
+        <Table.Cell content={'Table Data'} key={'COLUMN_0'} />
+        <Table.Cell content={'Table Data'} key={'COLUMN_1'} />
+        <Table.Cell content={'Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text Very long table text End table text'} key={'COLUMN_2'} />
       </Table.Row>
     </Table.SingleSelectableRows>
   </Table>

--- a/packages/terra-site/src/examples/table/TableWithNonSelectableRow.jsx
+++ b/packages/terra-site/src/examples/table/TableWithNonSelectableRow.jsx
@@ -5,25 +5,25 @@ import Table from 'terra-table';
 const TableWithNonSelectableRow = () => (
   <Table isStriped={false}>
     <Table.Header>
-      <Table.HeaderContent content={'Name'} key={'NAME'} minWidth={'small'} />
-      <Table.HeaderContent content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
-      <Table.HeaderContent content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
     </Table.Header>
     <Table.SingleSelectableRows>
       <Table.Row isSelected key={'PERSON_0'}>
-        <Table.RowContent content="John Smith" key="NAME" />
-        <Table.RowContent content="123 Adams Drive" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row isSelectable={false} key={'PERSON_1'}>
-        <Table.RowContent content="Jane Smith" key="NAME" />
-        <Table.RowContent content="321 Drive Street" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_2'}>
-        <Table.RowContent content="Dave Smith" key="NAME" />
-        <Table.RowContent content="213 Raymond Road" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
     </Table.SingleSelectableRows>
   </Table>

--- a/packages/terra-site/src/examples/table/TableWithSortingIndicator.jsx
+++ b/packages/terra-site/src/examples/table/TableWithSortingIndicator.jsx
@@ -5,25 +5,25 @@ import Table from 'terra-table';
 const TableWithSortingIndicator = () => (
   <Table isStriped={false}>
     <Table.Header>
-      <Table.HeaderContent content={'Name'} key={'NAME'} minWidth={'small'} />
-      <Table.HeaderContent content={'Address'} key={'ADDRESS'} minWidth={'medium'} sort={'asc'} />
-      <Table.HeaderContent content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} sort={'asc'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
     </Table.Header>
     <Table.SingleSelectableRows>
       <Table.Row key={'PERSON_0'}>
-        <Table.RowContent content="John Smith" key="NAME" />
-        <Table.RowContent content="123 Adams Drive" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_1'}>
-        <Table.RowContent content="Jane Smith" key="NAME" />
-        <Table.RowContent content="321 Drive Street" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_2'}>
-        <Table.RowContent content="Dave Smith" key="NAME" />
-        <Table.RowContent content="213 Raymond Road" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
     </Table.SingleSelectableRows>
   </Table>

--- a/packages/terra-table/docs/README.md
+++ b/packages/terra-table/docs/README.md
@@ -17,25 +17,25 @@ import Table from 'terra-table';
 
 <Table isStriped={false}>
   <Table.Header>
-    <Table.HeaderContent content={'Column Heading 1'} key={'COLUMN_0'} minWidth={'small'} />
-    <Table.HeaderContent content={'Column Heading 2'} key={'COLUMN_1'} minWidth={'medium'} />
-    <Table.HeaderContent content={'Column Heading 3'} key={'COLUMN_2'} minWidth={'large'} />
+    <Table.HeaderCell content={'Column Heading 1'} key={'COLUMN_0'} minWidth={'small'} />
+    <Table.HeaderCell content={'Column Heading 2'} key={'COLUMN_1'} minWidth={'medium'} />
+    <Table.HeaderCell content={'Column Heading 3'} key={'COLUMN_2'} minWidth={'large'} />
   </Table.Header>
   <Table.Rows>
     <Table.Row key={'ROW_0'}>
-      <Table.RowContent content={'Table Data'} key={'COLUMN_0'} />
-      <Table.RowContent content={'Table Data'} key={'COLUMN_1'} />
-      <Table.RowContent content={'Table Data'} key={'COLUMN_2'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_0'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_1'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_2'} />
     </Table.Row>
     <Table.Row key={1}>
-      <Table.RowContent content={'Table Data'} key={'COLUMN_0'} />
-      <Table.RowContent content={'Table Data'} key={'COLUMN_1'} />
-      <Table.RowContent content={'Table Data'} key={'COLUMN_2'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_0'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_1'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_2'} />
     </Table.Row>
     <Table.Row key={2}>
-      <Table.RowContent content={'Table Data'} key={'COLUMN_0'} />
-      <Table.RowContent content={'Table Data'} key={'COLUMN_1'} />
-      <Table.RowContent content={'Table Data'} key={'COLUMN_2'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_0'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_1'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_2'} />
     </Table.Row>
   </Table.Rows>
 </Table>
@@ -47,25 +47,25 @@ import Table from 'terra-table';
 
 <Table isStriped={false}>
   <Table.Header>
-    <Table.HeaderContent content={'Column Heading 1'} key={'COLUMN_0'} minWidth={'small'} />
-    <Table.HeaderContent content={'Column Heading 2'} key={'COLUMN_1'} minWidth={'medium'} />
-    <Table.HeaderContent content={'Column Heading 3'} key={'COLUMN_2'} minWidth={'large'} />
+    <Table.HeaderCell content={'Column Heading 1'} key={'COLUMN_0'} minWidth={'small'} />
+    <Table.HeaderCell content={'Column Heading 2'} key={'COLUMN_1'} minWidth={'medium'} />
+    <Table.HeaderCell content={'Column Heading 3'} key={'COLUMN_2'} minWidth={'large'} />
   </Table.Header>
   <Table.SingleSelectableRows>
     <Table.Row isSelected={true} key={'ROW_0'}>
-      <Table.RowContent content={'Table Data'} key={'COLUMN_0'} />
-      <Table.RowContent content={'Table Data'} key={'COLUMN_1'} />
-      <Table.RowContent content={'Table Data'} key={'COLUMN_2'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_0'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_1'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_2'} />
     </Table.Row>
     <Table.Row key={'ROW_1'}>
-      <Table.RowContent content={'Table Data'} key={'COLUMN_0'} />
-      <Table.RowContent content={'Table Data'} key={'COLUMN_1'} />
-      <Table.RowContent content={'Table Data'} key={'COLUMN_2'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_0'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_1'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_2'} />
     </Table.Row>
     <Table.Row key={'ROW_2'}>
-      <Table.RowContent content={'Table Data'} key={'COLUMN_0'} />
-      <Table.RowContent content={'Table Data'} key={'COLUMN_1'} />
-      <Table.RowContent content={'Table Data'} key={'COLUMN_2'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_0'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_1'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_2'} />
     </Table.Row>
   </Table.SingleSelectableRows>
 </Table>

--- a/packages/terra-table/lib/Table.js
+++ b/packages/terra-table/lib/Table.js
@@ -18,9 +18,9 @@ var _TableHeader = require('./TableHeader');
 
 var _TableHeader2 = _interopRequireDefault(_TableHeader);
 
-var _TableHeaderContent = require('./TableHeaderContent');
+var _TableHeaderCell = require('./TableHeaderCell');
 
-var _TableHeaderContent2 = _interopRequireDefault(_TableHeaderContent);
+var _TableHeaderCell2 = _interopRequireDefault(_TableHeaderCell);
 
 var _TableRows = require('./TableRows');
 
@@ -30,9 +30,9 @@ var _TableRow = require('./TableRow');
 
 var _TableRow2 = _interopRequireDefault(_TableRow);
 
-var _TableRowContent = require('./TableRowContent');
+var _TableCell = require('./TableCell');
 
-var _TableRowContent2 = _interopRequireDefault(_TableRowContent);
+var _TableCell2 = _interopRequireDefault(_TableCell);
 
 var _SingleSelectableRows = require('./SingleSelectableRows');
 
@@ -76,9 +76,9 @@ Table.propTypes = propTypes;
 Table.defaultProps = defaultProps;
 Table.Rows = _TableRows2.default;
 Table.Header = _TableHeader2.default;
-Table.HeaderContent = _TableHeaderContent2.default;
+Table.HeaderCell = _TableHeaderCell2.default;
 Table.Row = _TableRow2.default;
-Table.RowContent = _TableRowContent2.default;
+Table.Cell = _TableCell2.default;
 Table.SingleSelectableRows = _SingleSelectableRows2.default;
 
 exports.default = Table;

--- a/packages/terra-table/lib/TableCell.js
+++ b/packages/terra-table/lib/TableCell.js
@@ -31,7 +31,7 @@ var propTypes = {
   height: _react.PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge'])
 };
 
-var TableRowContent = function TableRowContent(_ref) {
+var TableCell = function TableCell(_ref) {
   var content = _ref.content,
       height = _ref.height,
       customProps = _objectWithoutProperties(_ref, ['content', 'height']);
@@ -49,6 +49,6 @@ var TableRowContent = function TableRowContent(_ref) {
   );
 };
 
-TableRowContent.propTypes = propTypes;
+TableCell.propTypes = propTypes;
 
-exports.default = TableRowContent;
+exports.default = TableCell;

--- a/packages/terra-table/lib/TableHeader.js
+++ b/packages/terra-table/lib/TableHeader.js
@@ -8,9 +8,9 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _TableHeaderContent = require('./TableHeaderContent');
+var _TableHeaderCell = require('./TableHeaderCell');
 
-var _TableHeaderContent2 = _interopRequireDefault(_TableHeaderContent);
+var _TableHeaderCell2 = _interopRequireDefault(_TableHeaderCell);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -49,7 +49,7 @@ function cloneChildItems(children, height, onClick) {
   return childrenArray.filter(function (child, index) {
     return index < 16;
   }).map(function (child) {
-    if (child.type === _TableHeaderContent2.default) {
+    if (child.type === _TableHeaderCell2.default) {
       return _react2.default.cloneElement(child, newProps);
     }
     return child;

--- a/packages/terra-table/lib/TableHeaderCell.js
+++ b/packages/terra-table/lib/TableHeaderCell.js
@@ -54,7 +54,7 @@ var defaultProps = {
 var iconDown = _react2.default.createElement(_IconCaretDown2.default, null);
 var iconUp = _react2.default.createElement(_IconCaretUp2.default, null);
 
-var TableHeaderContent = function TableHeaderContent(_ref) {
+var TableHeaderCell = function TableHeaderCell(_ref) {
   var content = _ref.content,
       height = _ref.height,
       minWidth = _ref.minWidth,
@@ -94,7 +94,7 @@ var TableHeaderContent = function TableHeaderContent(_ref) {
   );
 };
 
-TableHeaderContent.propTypes = propTypes;
-TableHeaderContent.defaultProps = defaultProps;
+TableHeaderCell.propTypes = propTypes;
+TableHeaderCell.defaultProps = defaultProps;
 
-exports.default = TableHeaderContent;
+exports.default = TableHeaderCell;

--- a/packages/terra-table/lib/TableRow.js
+++ b/packages/terra-table/lib/TableRow.js
@@ -14,9 +14,9 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
-var _TableRowContent = require('./TableRowContent');
+var _TableCell = require('./TableCell');
 
-var _TableRowContent2 = _interopRequireDefault(_TableRowContent);
+var _TableCell2 = _interopRequireDefault(_TableCell);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -54,7 +54,7 @@ function cloneChildItems(children, height) {
   return childrenArray.filter(function (child, index) {
     return index < 16;
   }).map(function (child) {
-    if (child.type === _TableRowContent2.default) {
+    if (child.type === _TableCell2.default) {
       return _react2.default.cloneElement(child, { height: height });
     }
     return child;

--- a/packages/terra-table/src/Table.jsx
+++ b/packages/terra-table/src/Table.jsx
@@ -1,10 +1,10 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import TableHeader from './TableHeader';
-import TableHeaderContent from './TableHeaderContent';
+import TableHeaderCell from './TableHeaderCell';
 import TableRows from './TableRows';
 import TableRow from './TableRow';
-import TableRowContent from './TableRowContent';
+import TableCell from './TableCell';
 import TableSingleSelectableRows from './SingleSelectableRows';
 import './Table.scss';
 
@@ -44,9 +44,9 @@ Table.propTypes = propTypes;
 Table.defaultProps = defaultProps;
 Table.Rows = TableRows;
 Table.Header = TableHeader;
-Table.HeaderContent = TableHeaderContent;
+Table.HeaderCell = TableHeaderCell;
 Table.Row = TableRow;
-Table.RowContent = TableRowContent;
+Table.Cell = TableCell;
 Table.SingleSelectableRows = TableSingleSelectableRows;
 
 export default Table;

--- a/packages/terra-table/src/TableCell.jsx
+++ b/packages/terra-table/src/TableCell.jsx
@@ -12,7 +12,7 @@ const propTypes = {
   height: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge']),
 };
 
-const TableRowContent = ({
+const TableCell = ({
   content,
   height,
   ...customProps
@@ -30,6 +30,6 @@ const TableRowContent = ({
   );
 };
 
-TableRowContent.propTypes = propTypes;
+TableCell.propTypes = propTypes;
 
-export default TableRowContent;
+export default TableCell;

--- a/packages/terra-table/src/TableHeader.jsx
+++ b/packages/terra-table/src/TableHeader.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import TableHeaderContent from './TableHeaderContent';
+import TableHeaderCell from './TableHeaderCell';
 
 const propTypes = {
   /**
@@ -32,7 +32,7 @@ function cloneChildItems(children, height, onClick) {
   }
   // Filtering children to render only 16 columns
   return childrenArray.filter((child, index) => index < 16).map((child) => {
-    if (child.type === TableHeaderContent) {
+    if (child.type === TableHeaderCell) {
       return React.cloneElement(child, newProps);
     }
     return child;

--- a/packages/terra-table/src/TableHeaderCell.jsx
+++ b/packages/terra-table/src/TableHeaderCell.jsx
@@ -29,7 +29,7 @@ const defaultProps = {
 const iconDown = <IconDown />;
 const iconUp = <IconUp />;
 
-const TableHeaderContent = ({
+const TableHeaderCell = ({
   content,
   height,
   minWidth,
@@ -64,7 +64,7 @@ const TableHeaderContent = ({
   );
 };
 
-TableHeaderContent.propTypes = propTypes;
-TableHeaderContent.defaultProps = defaultProps;
+TableHeaderCell.propTypes = propTypes;
+TableHeaderCell.defaultProps = defaultProps;
 
-export default TableHeaderContent;
+export default TableHeaderCell;

--- a/packages/terra-table/src/TableRow.jsx
+++ b/packages/terra-table/src/TableRow.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import TableRowContent from './TableRowContent';
+import TableCell from './TableCell';
 
 const propTypes = {
   /**
@@ -32,7 +32,7 @@ function cloneChildItems(children, height) {
     console.log(`Number of Columns are ${React.Children.count(children)}. This is more than columns limit`);
   }
   return childrenArray.filter((child, index) => index < 16).map((child) => {
-    if (child.type === TableRowContent) {
+    if (child.type === TableCell) {
       return React.cloneElement(child, { height });
     }
     return child;

--- a/packages/terra-table/tests/jest/SingleSelectableRows.test.jsx
+++ b/packages/terra-table/tests/jest/SingleSelectableRows.test.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import Table from '../../src/Table';
 
 // Constants
-const cellData1 = <Table.RowContent content={'John Smith'} key={'NAME'} />;
-const cellData2 = <Table.RowContent content={'123 Adams Drive'} key={'ADDRESS'} />;
-const cellData3 = <Table.RowContent content={'111-222-3333'} key={'PHONE_NUMBER'} />;
+const cellData1 = <Table.Cell content={'John Smith'} key={'NAME'} />;
+const cellData2 = <Table.Cell content={'123 Adams Drive'} key={'ADDRESS'} />;
+const cellData3 = <Table.Cell content={'111-222-3333'} key={'PHONE_NUMBER'} />;
 const rowData = [cellData1, cellData2, cellData3];
 const row1 = <Table.Row key={'PERSON_0'}>{rowData}</Table.Row>;
 const row2 = <Table.Row key={'PERSON_1'}>{rowData}</Table.Row>;

--- a/packages/terra-table/tests/jest/Table.test.jsx
+++ b/packages/terra-table/tests/jest/Table.test.jsx
@@ -2,16 +2,16 @@ import React from 'react';
 import Table from '../../src/Table';
 
 // Constants
-const cellData1 = <Table.RowContent content={'John Smith'} key={'NAME'} />;
-const cellData2 = <Table.RowContent content={'123 Adams Drive'} key={'ADDRESS'} />;
-const cellData3 = <Table.RowContent content={'111-222-3333'} key={'PHONE_NUMBER'} />;
+const cellData1 = <Table.Cell content={'John Smith'} key={'NAME'} />;
+const cellData2 = <Table.Cell content={'123 Adams Drive'} key={'ADDRESS'} />;
+const cellData3 = <Table.Cell content={'111-222-3333'} key={'PHONE_NUMBER'} />;
 const rowData = [cellData1, cellData2, cellData3];
 const row1 = <Table.Row key={'PERSON_0'}>{rowData}</Table.Row>;
 const row2 = <Table.Row key={'PERSON_1'}>{rowData}</Table.Row>;
 const rows = [row1, row2];
-const headerData1 = <Table.HeaderContent content={'Name'} key={'NAME'} />;
-const headerData2 = <Table.HeaderContent content={'Address'} key={'ADDRESS'} />;
-const headerData3 = <Table.HeaderContent content={'Phone Number'} key={'PHONE_NUMBER'} />;
+const headerData1 = <Table.HeaderCell content={'Name'} key={'NAME'} />;
+const headerData2 = <Table.HeaderCell content={'Address'} key={'ADDRESS'} />;
+const headerData3 = <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} />;
 const header = [headerData1, headerData2, headerData3];
 
 // Snapshot test

--- a/packages/terra-table/tests/jest/TableHeader.test.jsx
+++ b/packages/terra-table/tests/jest/TableHeader.test.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import Table from '../../src/Table';
 
 // Constants
-const headerData1 = <Table.HeaderContent content={'Name'} key={'NAME'} />;
-const headerData2 = <Table.HeaderContent content={'Address'} key={'ADDRESS'} />;
-const headerData3 = <Table.HeaderContent content={'Phone Number'} key={'PHONE_NUMBER'} />;
+const headerData1 = <Table.HeaderCell content={'Name'} key={'NAME'} />;
+const headerData2 = <Table.HeaderCell content={'Address'} key={'ADDRESS'} />;
+const headerData3 = <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} />;
 const header = [headerData1, headerData2, headerData3];
 
 // Snapshot test

--- a/packages/terra-table/tests/jest/TableHeaderContent.test.jsx
+++ b/packages/terra-table/tests/jest/TableHeaderContent.test.jsx
@@ -3,25 +3,25 @@ import Table from '../../src/Table';
 
 // Snapshot test
 it('should render default table header content tag', () => {
-  const defaultTableHeaderContent = <Table.HeaderContent content={'Column Heading'} />;
+  const defaultTableHeaderContent = <Table.HeaderCell content={'Column Heading'} />;
   const tableHeaderContent = shallow(defaultTableHeaderContent);
   expect(tableHeaderContent).toMatchSnapshot();
 });
 
 it('should render table header content tag with ascending sort indicator', () => {
-  const tableHeaderContentTag = <Table.HeaderContent content={'Column Heading'} sort={'asc'} />;
+  const tableHeaderContentTag = <Table.HeaderCell content={'Column Heading'} sort={'asc'} />;
   const tableHeaderContent = shallow(tableHeaderContentTag);
   expect(tableHeaderContent).toMatchSnapshot();
 });
 
 it('should render table header content tag with descending sort indicator', () => {
-  const tableHeaderContentTag = <Table.HeaderContent content={'Column Heading'} sort={'desc'} />;
+  const tableHeaderContentTag = <Table.HeaderCell content={'Column Heading'} sort={'desc'} />;
   const tableHeaderContent = shallow(tableHeaderContentTag);
   expect(tableHeaderContent).toMatchSnapshot();
 });
 
 it('should render table header content tag with maximum height fixed', () => {
-  const defaultTableHeaderContent = <Table.HeaderContent content={'Column Heading'} height={'small'} />;
+  const defaultTableHeaderContent = <Table.HeaderCell content={'Column Heading'} height={'small'} />;
   const tableHeaderContent = shallow(defaultTableHeaderContent);
   expect(tableHeaderContent).toMatchSnapshot();
 });

--- a/packages/terra-table/tests/jest/TableRow.test.jsx
+++ b/packages/terra-table/tests/jest/TableRow.test.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import Table from '../../src/Table';
 
 // Constants
-const cellData1 = <Table.RowContent content={'John Smith'} key={'NAME'} />;
-const cellData2 = <Table.RowContent content={'123 Adams Drive'} key={'ADDRESS'} />;
-const cellData3 = <Table.RowContent content={'111-222-3333'} key={'PHONE_NUMBER'} />;
+const cellData1 = <Table.Cell content={'John Smith'} key={'NAME'} />;
+const cellData2 = <Table.Cell content={'123 Adams Drive'} key={'ADDRESS'} />;
+const cellData3 = <Table.Cell content={'111-222-3333'} key={'PHONE_NUMBER'} />;
 const rowData = [cellData1, cellData2, cellData3];
 
 // Snapshot test

--- a/packages/terra-table/tests/jest/TableRowContent.test.jsx
+++ b/packages/terra-table/tests/jest/TableRowContent.test.jsx
@@ -3,13 +3,13 @@ import Table from '../../src/Table';
 
 // Snapshot test
 it('should render a default table row content', () => {
-  const defaultTableRowContent = <Table.RowContent content={'Table Data'} />;
+  const defaultTableRowContent = <Table.Cell content={'Table Data'} />;
   const tableRowContent = shallow(defaultTableRowContent);
   expect(tableRowContent).toMatchSnapshot();
 });
 
 it('should render a table row content with maximum height', () => {
-  const tableRowContentTag = <Table.RowContent content={'Table Data'} height={'small'} />;
+  const tableRowContentTag = <Table.Cell content={'Table Data'} height={'small'} />;
   const tableRowContent = shallow(tableRowContentTag);
   expect(tableRowContent).toMatchSnapshot();
 });

--- a/packages/terra-table/tests/jest/TableRows.test.jsx
+++ b/packages/terra-table/tests/jest/TableRows.test.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import Table from '../../src/Table';
 
 // Constants
-const cellData1 = <Table.RowContent content={'John Smith'} key={'NAME'} />;
-const cellData2 = <Table.RowContent content={'123 Adams Drive'} key={'ADDRESS'} />;
-const cellData3 = <Table.RowContent content={'111-222-3333'} key={'PHONE_NUMBER'} />;
+const cellData1 = <Table.Cell content={'John Smith'} key={'NAME'} />;
+const cellData2 = <Table.Cell content={'123 Adams Drive'} key={'ADDRESS'} />;
+const cellData3 = <Table.Cell content={'111-222-3333'} key={'PHONE_NUMBER'} />;
 const rowData = [cellData1, cellData2, cellData3];
 const row1 = <Table.Row key={'PERSON_0'}>{rowData}</Table.Row>;
 const row2 = <Table.Row key={'PERSON_1'}>{rowData}</Table.Row>;

--- a/packages/terra-table/tests/jest/__snapshots__/SingleSelectableRows.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/SingleSelectableRows.test.jsx.snap
@@ -6,11 +6,11 @@ exports[`test should render SingleSelectableRows tag 1`] = `
     onClick={[Function]}
     onKeyDown={[Function]}
     tabIndex="0">
-    <TableRowContent
+    <TableCell
       content="John Smith" />
-    <TableRowContent
+    <TableCell
       content="123 Adams Drive" />
-    <TableRowContent
+    <TableCell
       content="111-222-3333" />
   </TableRow>
   <TableRow
@@ -19,11 +19,11 @@ exports[`test should render SingleSelectableRows tag 1`] = `
     onClick={[Function]}
     onKeyDown={[Function]}
     tabIndex="0">
-    <TableRowContent
+    <TableCell
       content="John Smith" />
-    <TableRowContent
+    <TableCell
       content="123 Adams Drive" />
-    <TableRowContent
+    <TableCell
       content="111-222-3333" />
   </TableRow>
 </TableRows>
@@ -38,11 +38,11 @@ exports[`test should render SingleSelectableRows with maximum height set 1`] = `
     onClick={[Function]}
     onKeyDown={[Function]}
     tabIndex="0">
-    <TableRowContent
+    <TableCell
       content="John Smith" />
-    <TableRowContent
+    <TableCell
       content="123 Adams Drive" />
-    <TableRowContent
+    <TableCell
       content="111-222-3333" />
   </TableRow>
   <TableRow
@@ -51,11 +51,11 @@ exports[`test should render SingleSelectableRows with maximum height set 1`] = `
     onClick={[Function]}
     onKeyDown={[Function]}
     tabIndex="0">
-    <TableRowContent
+    <TableCell
       content="John Smith" />
-    <TableRowContent
+    <TableCell
       content="123 Adams Drive" />
-    <TableRowContent
+    <TableCell
       content="111-222-3333" />
   </TableRow>
 </TableRows>

--- a/packages/terra-table/tests/jest/__snapshots__/Table.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/Table.test.jsx.snap
@@ -2,33 +2,33 @@ exports[`test should render a default table 1`] = `
 <table
   className="terra-Table terra-Table--striped">
   <TableHeader>
-    <TableHeaderContent
+    <TableHeaderCell
       content="Name"
       minWidth="small" />
-    <TableHeaderContent
+    <TableHeaderCell
       content="Address"
       minWidth="small" />
-    <TableHeaderContent
+    <TableHeaderCell
       content="Phone Number"
       minWidth="small" />
   </TableHeader>
   <TableRows>
     <TableRow
       isSelected={false}>
-      <TableRowContent
+      <TableCell
         content="John Smith" />
-      <TableRowContent
+      <TableCell
         content="123 Adams Drive" />
-      <TableRowContent
+      <TableCell
         content="111-222-3333" />
     </TableRow>
     <TableRow
       isSelected={false}>
-      <TableRowContent
+      <TableCell
         content="John Smith" />
-      <TableRowContent
+      <TableCell
         content="123 Adams Drive" />
-      <TableRowContent
+      <TableCell
         content="111-222-3333" />
     </TableRow>
   </TableRows>
@@ -39,33 +39,33 @@ exports[`test should render a table without zebra stripes 1`] = `
 <table
   className="terra-Table">
   <TableHeader>
-    <TableHeaderContent
+    <TableHeaderCell
       content="Name"
       minWidth="small" />
-    <TableHeaderContent
+    <TableHeaderCell
       content="Address"
       minWidth="small" />
-    <TableHeaderContent
+    <TableHeaderCell
       content="Phone Number"
       minWidth="small" />
   </TableHeader>
   <TableRows>
     <TableRow
       isSelected={false}>
-      <TableRowContent
+      <TableCell
         content="John Smith" />
-      <TableRowContent
+      <TableCell
         content="123 Adams Drive" />
-      <TableRowContent
+      <TableCell
         content="111-222-3333" />
     </TableRow>
     <TableRow
       isSelected={false}>
-      <TableRowContent
+      <TableCell
         content="John Smith" />
-      <TableRowContent
+      <TableCell
         content="123 Adams Drive" />
-      <TableRowContent
+      <TableCell
         content="111-222-3333" />
     </TableRow>
   </TableRows>

--- a/packages/terra-table/tests/jest/__snapshots__/TableHeader.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableHeader.test.jsx.snap
@@ -1,13 +1,13 @@
 exports[`test should render table header tag 1`] = `
 <thead>
   <tr>
-    <TableHeaderContent
+    <TableHeaderCell
       content="Name"
       minWidth="small" />
-    <TableHeaderContent
+    <TableHeaderCell
       content="Address"
       minWidth="small" />
-    <TableHeaderContent
+    <TableHeaderCell
       content="Phone Number"
       minWidth="small" />
   </tr>

--- a/packages/terra-table/tests/jest/__snapshots__/TableRow.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableRow.test.jsx.snap
@@ -2,11 +2,11 @@ exports[`test should render a default table row 1`] = `
 <tr
   aria-selected={false}
   className="terra-Table-row">
-  <TableRowContent
+  <TableCell
     content="John Smith" />
-  <TableRowContent
+  <TableCell
     content="123 Adams Drive" />
-  <TableRowContent
+  <TableCell
     content="111-222-3333" />
 </tr>
 `;
@@ -15,11 +15,11 @@ exports[`test should render a selectable table row 1`] = `
 <tr
   aria-selected={false}
   className="terra-Table--isSelectable terra-Table-row">
-  <TableRowContent
+  <TableCell
     content="John Smith" />
-  <TableRowContent
+  <TableCell
     content="123 Adams Drive" />
-  <TableRowContent
+  <TableCell
     content="111-222-3333" />
 </tr>
 `;
@@ -28,11 +28,11 @@ exports[`test should render a selected table row 1`] = `
 <tr
   aria-selected={true}
   className="terra-Table--isSelected terra-Table-row">
-  <TableRowContent
+  <TableCell
     content="John Smith" />
-  <TableRowContent
+  <TableCell
     content="123 Adams Drive" />
-  <TableRowContent
+  <TableCell
     content="111-222-3333" />
 </tr>
 `;

--- a/packages/terra-table/tests/jest/__snapshots__/TableRows.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableRows.test.jsx.snap
@@ -2,20 +2,20 @@ exports[`test should render TableRows tag 1`] = `
 <tbody>
   <TableRow
     isSelected={false}>
-    <TableRowContent
+    <TableCell
       content="John Smith" />
-    <TableRowContent
+    <TableCell
       content="123 Adams Drive" />
-    <TableRowContent
+    <TableCell
       content="111-222-3333" />
   </TableRow>
   <TableRow
     isSelected={false}>
-    <TableRowContent
+    <TableCell
       content="John Smith" />
-    <TableRowContent
+    <TableCell
       content="123 Adams Drive" />
-    <TableRowContent
+    <TableCell
       content="111-222-3333" />
   </TableRow>
 </tbody>

--- a/packages/terra-table/tests/nightwatch/components/NoStripedTable.jsx
+++ b/packages/terra-table/tests/nightwatch/components/NoStripedTable.jsx
@@ -4,25 +4,25 @@ import Table from '../../../lib/Table';
 const NoStripedTable = () => (
   <Table isStriped={false}>
     <Table.Header>
-      <Table.HeaderContent content={'Name'} key={'NAME'} minWidth={'small'} />
-      <Table.HeaderContent content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
-      <Table.HeaderContent content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
     </Table.Header>
     <Table.Rows>
       <Table.Row key={'PERSON_0'}>
-        <Table.RowContent content="John Smith" key="NAME" />
-        <Table.RowContent content="123 Adams Drive" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_1'}>
-        <Table.RowContent content="Jane Smith" key="NAME" />
-        <Table.RowContent content="321 Drive Street" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_2'}>
-        <Table.RowContent content="Dave Smith" key="NAME" />
-        <Table.RowContent content="213 Raymond Road" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
     </Table.Rows>
   </Table>

--- a/packages/terra-table/tests/nightwatch/components/SingleRowSelectableTable.jsx
+++ b/packages/terra-table/tests/nightwatch/components/SingleRowSelectableTable.jsx
@@ -4,25 +4,25 @@ import Table from '../../../lib/Table';
 const SingleRowSelectableTable = () => (
   <Table isStriped={false}>
     <Table.Header>
-      <Table.HeaderContent content={'Name'} key={'NAME'} minWidth={'small'} />
-      <Table.HeaderContent content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
-      <Table.HeaderContent content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
     </Table.Header>
     <Table.SingleSelectableRows>
       <Table.Row isSelected key={'PERSON_0'}>
-        <Table.RowContent content="John Smith" key="NAME" />
-        <Table.RowContent content="123 Adams Drive" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_1'}>
-        <Table.RowContent content="Jane Smith" key="NAME" />
-        <Table.RowContent content="321 Drive Street" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_2'}>
-        <Table.RowContent content="Dave Smith" key="NAME" />
-        <Table.RowContent content="213 Raymond Road" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
     </Table.SingleSelectableRows>
   </Table>

--- a/packages/terra-table/tests/nightwatch/components/StripedTable.jsx
+++ b/packages/terra-table/tests/nightwatch/components/StripedTable.jsx
@@ -4,25 +4,25 @@ import Table from '../../../lib/Table';
 const StripedTable = () => (
   <Table>
     <Table.Header>
-      <Table.HeaderContent content={'Name'} key={'NAME'} minWidth={'small'} />
-      <Table.HeaderContent content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
-      <Table.HeaderContent content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
     </Table.Header>
     <Table.Rows>
       <Table.Row key={'PERSON_0'}>
-        <Table.RowContent content="John Smith" key="NAME" />
-        <Table.RowContent content="123 Adams Drive" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_1'}>
-        <Table.RowContent content="Jane Smith" key="NAME" />
-        <Table.RowContent content="321 Drive Street" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_2'}>
-        <Table.RowContent content="Dave Smith" key="NAME" />
-        <Table.RowContent content="213 Raymond Road" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
     </Table.Rows>
   </Table>

--- a/packages/terra-table/tests/nightwatch/components/TableWithHighlightedRows.jsx
+++ b/packages/terra-table/tests/nightwatch/components/TableWithHighlightedRows.jsx
@@ -4,35 +4,35 @@ import Table from '../../../lib/Table';
 const TableWithHighlightedRows = () => (
   <Table isStriped={false}>
     <Table.Header>
-      <Table.HeaderContent content={'Name'} key={'NAME'} minWidth={'small'} />
-      <Table.HeaderContent content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
-      <Table.HeaderContent content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
     </Table.Header>
     <Table.Rows>
       <Table.Row isSelected key={'PERSON_0'}>
-        <Table.RowContent content="John Smith" key="NAME" />
-        <Table.RowContent content="123 Adams Drive" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_1'}>
-        <Table.RowContent content="Jane Smith" key="NAME" />
-        <Table.RowContent content="321 Drive Street" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_2'}>
-        <Table.RowContent content="Dave Smith" key="NAME" />
-        <Table.RowContent content="213 Raymond Road" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row isSelected key={'PERSON_3'}>
-        <Table.RowContent content="Mario Smith" key="NAME" />
-        <Table.RowContent content="213 Road" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Mario Smith" key="NAME" />
+        <Table.Cell content="213 Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_4'}>
-        <Table.RowContent content="Louie Smith" key="NAME" />
-        <Table.RowContent content="213 Raymond  St" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Louie Smith" key="NAME" />
+        <Table.Cell content="213 Raymond  St" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
     </Table.Rows>
   </Table>

--- a/packages/terra-table/tests/nightwatch/components/TableWithSortIndicator.jsx
+++ b/packages/terra-table/tests/nightwatch/components/TableWithSortIndicator.jsx
@@ -5,25 +5,25 @@ import Table from '../../../lib/Table';
 const TableWithSortingIndicator = () => (
   <Table isStriped={false}>
     <Table.Header>
-      <Table.HeaderContent content={'Name'} key={'NAME'} minWidth={'small'} />
-      <Table.HeaderContent content={'Address'} key={'ADDRESS'} minWidth={'medium'} sort={'asc'} />
-      <Table.HeaderContent content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} sort={'asc'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
     </Table.Header>
     <Table.SingleSelectableRows>
       <Table.Row key={'PERSON_0'}>
-        <Table.RowContent content="John Smith" key="NAME" />
-        <Table.RowContent content="123 Adams Drive" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_1'}>
-        <Table.RowContent content="Jane Smith" key="NAME" />
-        <Table.RowContent content="321 Drive Street" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
       <Table.Row key={'PERSON_2'}>
-        <Table.RowContent content="Dave Smith" key="NAME" />
-        <Table.RowContent content="213 Raymond Road" key="ADDRESS" />
-        <Table.RowContent content="111-222-3333" key="PHONE_NUMBER" />
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
     </Table.SingleSelectableRows>
   </Table>


### PR DESCRIPTION
### Summary
This PR resolves #215 - Rename <Table.HeaderContent> and <Table.RowContent> to <Table.HeaderCell> and <Table.Cell>

Changes include:
* Updating all instances of `Table.HeaderContent` to `Table.HeaderCell` 
* Updating all instances of `Table.RowContent` to `Table.Cell` 

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
