### PR TITLE
Content code example is missing a closing bracket

### DIFF
--- a/packages/terra-site/src/examples/content/Index.jsx
+++ b/packages/terra-site/src/examples/content/Index.jsx
@@ -92,9 +92,7 @@ const ContentExamples = () => (
       <p>Code element inside of pre element</p>
       <pre>
         <code>
-          {`a {
-            color: @link-color;
-          `}
+          {'a {\n  color: @link-color;\n}'}
         </code>
       </pre>
     </div>


### PR DESCRIPTION
### Summary

Content code example is missing a closing bracket. ( It just looked goofy in the examples and made my editor (Atom) a little nervous )

![screen shot 2017-04-17 at 3 22 02 pm](https://cloud.githubusercontent.com/assets/6720991/25103487/5cd7e5c0-2382-11e7-95ff-40d85fafb87d.png)

<img width="493" alt="screen shot 2017-04-17 at 3 24 40 pm" src="https://cloud.githubusercontent.com/assets/6720991/25103491/61e5242e-2382-11e7-9fa7-bc5851f982cc.png">

```
      <p>Code element inside of pre element</p>
      <pre>
        <code>
          {`a {
            color: @link-color;
          `}
        </code>
      </pre>
    </div>
  </div>
);

export default ContentExamples;
```

### Steps to Reproduce the Issue
1. Scroll to the bottom of: http://engineering.cerner.com/terra-core/#/site/content

### After this change is applied:
![screen shot 2017-04-17 at 3 32 11 pm](https://cloud.githubusercontent.com/assets/6720991/25103684/166f6f3a-2383-11e7-9be4-4e82de01aa0a.png)


Fixes: #229.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
