### PR TITLE
Table - Adding prop-controlled padding and removing row height props

### DIFF
--- a/packages/terra-site/src/examples/table/Index.jsx
+++ b/packages/terra-site/src/examples/table/Index.jsx
@@ -17,12 +17,14 @@ import TableCellSrc from '!raw-loader!terra-table/src/TableCell';
 /* eslint-enable import/no-webpack-loader-syntax, import/first, import/no-unresolved, import/extensions */
 
 import NoStripedTable from './NoStripedTable';
+import NoPaddingTable from './NoPaddingTable';
 import StripedTable from './StripedTable';
 import TableWithHighlightedRows from './TableWithHighlightedRows';
 import SingleRowSelectableTable from './SingleRowSelectableTable';
 import TableWithNonSelectableRow from './TableWithNonSelectableRow';
 import TableWithSortingIndicator from './TableWithSortingIndicator';
-import TableWithMaxHeight from './TableWithMaxHeight';
+import TableWithLongContent from './TableWithLongContent';
+import TableWithCustomCells from './TableWithCustomCells';
 
 const TableExamples = () => (
   <div>
@@ -44,18 +46,30 @@ const TableExamples = () => (
     <PropsTable id="props-tablecell" src={TableCellSrc} />
     <h2>Table without zebra stripes</h2>
     <NoStripedTable />
+    <br />
     <h2>Table with zebra stripes</h2>
     <StripedTable />
+    <br />
+    <h2>Table without padding</h2>
+    <NoPaddingTable />
+    <br />
     <h2>Table with some rows selected. Table will not select or deselect any row</h2>
     <TableWithHighlightedRows />
+    <br />
     <h2>Selectable table. Only one row can be selected</h2>
     <SingleRowSelectableTable />
+    <br />
     <h2>Selectable table with second row as non selectable</h2>
     <TableWithNonSelectableRow />
+    <br />
     <h2>Table with sorting indicator</h2>
     <TableWithSortingIndicator />
-    <h2>Table with maximum height set on row and header</h2>
-    <TableWithMaxHeight />
+    <br />
+    <h2>Table with long content</h2>
+    <TableWithLongContent />
+    <br />
+    <h2>Table with custom cells</h2>
+    <TableWithCustomCells />
   </div>
 );
 

--- a/packages/terra-site/src/examples/table/NoPaddingTable.jsx
+++ b/packages/terra-site/src/examples/table/NoPaddingTable.jsx
@@ -1,0 +1,32 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import Table from 'terra-table';
+
+const NoPaddingTable = () => (
+  <Table isPadded={false}>
+    <Table.Header>
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+    </Table.Header>
+    <Table.Rows>
+      <Table.Row key={'PERSON_0'}>
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Row key={'PERSON_1'}>
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Row key={'PERSON_2'}>
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+    </Table.Rows>
+  </Table>
+);
+
+export default NoPaddingTable;

--- a/packages/terra-site/src/examples/table/TableWithCustomCells.jsx
+++ b/packages/terra-site/src/examples/table/TableWithCustomCells.jsx
@@ -1,0 +1,44 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React, { PropTypes } from 'react';
+import Table from 'terra-table';
+
+const CustomCell = props => (
+  <div>
+    <h3>{props.text}</h3>
+    {props.subtext ? <h4 style={{ color: 'grey' }}>{props.subtext}</h4> : null}
+  </div>
+);
+
+CustomCell.propTypes = {
+  text: PropTypes.string,
+  subtext: PropTypes.string,
+};
+
+const TableWithCustomCells = () => (
+  <Table>
+    <Table.Header>
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+    </Table.Header>
+    <Table.SingleSelectableRows>
+      <Table.Row isSelected key={'PERSON_0'}>
+        <Table.Cell content={<CustomCell text="John Smith" subtext="Super Cool Person" />} key="NAME" />
+        <Table.Cell content={<CustomCell text="123 Adams Drive" subtext="Missouri" />} key="ADDRESS" />
+        <Table.Cell content={<CustomCell text="111-222-3333" subtext="Home" />} key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Row key={'PERSON_1'}>
+        <Table.Cell content={<CustomCell text="Jane Smith" subtext="Super Cool Person" />} key="NAME" />
+        <Table.Cell content={<CustomCell text="321 Drive Street" subtext="Kansas" />} key="ADDRESS" />
+        <Table.Cell content={<CustomCell text="111-222-3333" subtext="Cell" />} key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Row key={'PERSON_2'}>
+        <Table.Cell content={<CustomCell text="Dave Smith" subtext="Not Super Cool At All" />} key="NAME" />
+        <Table.Cell content={<CustomCell text="213 Raymond Road" subtext="Alaska" />} key="ADDRESS" />
+        <Table.Cell content={<CustomCell text="111-222-3333" subtext="Work" />} key="PHONE_NUMBER" />
+      </Table.Row>
+    </Table.SingleSelectableRows>
+  </Table>
+);
+
+export default TableWithCustomCells;

--- a/packages/terra-site/src/examples/table/TableWithLongContent.jsx
+++ b/packages/terra-site/src/examples/table/TableWithLongContent.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import Table from 'terra-table';
 
-const TableWithMaxHeight = () => (
+const TableWithLongContent = () => (
   <Table isStriped={false}>
     <Table.Header height={'small'}>
       <Table.HeaderCell content={'Column Heading 1'} key={'COLUMN_0'} minWidth={'small'} />
@@ -29,4 +29,4 @@ const TableWithMaxHeight = () => (
   </Table>
 );
 
-export default TableWithMaxHeight;
+export default TableWithLongContent;

--- a/packages/terra-table/lib/SingleSelectableRows.js
+++ b/packages/terra-table/lib/SingleSelectableRows.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
@@ -35,10 +33,6 @@ var propTypes = {
    * The children passed to the component
    */
   children: _react.PropTypes.node,
-  /**
-   * The maximum height for all the rows in a table
-   */
-  height: _react.PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge']),
   /**
    * A callback function for onClick action
    */
@@ -172,8 +166,7 @@ var SingleSelectableRows = function (_React$Component) {
     value: function render() {
       var _props = this.props,
           children = _props.children,
-          height = _props.height,
-          customProps = _objectWithoutProperties(_props, ['children', 'height']);
+          customProps = _objectWithoutProperties(_props, ['children']);
 
       var clonedChilItems = this.clonedChildItems(children);
       if ('onClick' in customProps) {
@@ -184,7 +177,7 @@ var SingleSelectableRows = function (_React$Component) {
       }
       return _react2.default.createElement(
         _TableRows2.default,
-        _extends({ height: height }, customProps),
+        customProps,
         clonedChilItems
       );
     }

--- a/packages/terra-table/lib/Table.js
+++ b/packages/terra-table/lib/Table.js
@@ -52,19 +52,22 @@ var propTypes = {
   /**
    * Whether or not the rows should be zebra striped
    */
-  isStriped: _react.PropTypes.bool
+  isStriped: _react.PropTypes.bool,
+  isPadded: _react.PropTypes.bool
 };
 
 var defaultProps = {
-  isStriped: true
+  isStriped: true,
+  isPadded: true
 };
 
 var Table = function Table(_ref) {
   var children = _ref.children,
       isStriped = _ref.isStriped,
-      customProps = _objectWithoutProperties(_ref, ['children', 'isStriped']);
+      isPadded = _ref.isPadded,
+      customProps = _objectWithoutProperties(_ref, ['children', 'isStriped', 'isPadded']);
 
-  var tableClassNames = (0, _classnames2.default)(['terra-Table', { 'terra-Table--striped': isStriped }, customProps.className]);
+  var tableClassNames = (0, _classnames2.default)(['terra-Table', { 'terra-Table--striped': isStriped }, { 'terra-Table--padded': isPadded }, customProps.className]);
   return _react2.default.createElement(
     'table',
     _extends({}, customProps, { className: tableClassNames }),

--- a/packages/terra-table/lib/Table.js
+++ b/packages/terra-table/lib/Table.js
@@ -53,6 +53,9 @@ var propTypes = {
    * Whether or not the rows should be zebra striped
    */
   isStriped: _react.PropTypes.bool,
+  /**
+   * Whether or not the table cells should be padded
+   */
   isPadded: _react.PropTypes.bool
 };
 

--- a/packages/terra-table/lib/Table.scss
+++ b/packages/terra-table/lib/Table.scss
@@ -18,14 +18,11 @@
 
   th,
   td {
-    @include terra-padding-horizontal($terra-table-cell-padding-left, $terra-table-cell-padding-right);
     @include terra-text-align-start;
 
     border: $terra-table-cell-border-width solid $terra-table-cell-border-color;
     border-bottom: 0;
     display: block;
-    padding-bottom: $terra-table-cell-padding-bottom;
-    padding-top: $terra-table-cell-padding-top;
 
     &::before {
       content: attr(data-heading);
@@ -102,13 +99,13 @@
   }
 }
 
-.terra-Table--small {
+.terra-Table--padded {
   th,
   td {
     @include terra-padding-horizontal($terra-table-cell-padding-left, $terra-table-cell-padding-right);
 
-    padding-bottom: $terra-table-cell-small-padding-bottom;
-    padding-top: $terra-table-cell-small-padding-top;
+    padding-bottom: $terra-table-cell-padding-bottom;
+    padding-top: $terra-table-cell-padding-top;
   }
 }
 
@@ -125,7 +122,7 @@
     tbody tr:nth-of-type(even) {
       background-color: $terra-table-row-striped-background-color;
     }
-    
+
     /* Compound selector depth required for specificity */
     /* stylelint-disable-next-line selector-max-compound-selectors */
     tbody tr:nth-of-type(even) th {
@@ -165,55 +162,55 @@
   min-width: $terra-table-cell-min-width-huge;
 }
 
-.terra-Table-header-max-height--tiny > div {
-  max-height: $terra-table-header-max-height-tiny;
-  overflow: auto;
-}
+// .terra-Table-header-max-height--tiny > div {
+//   max-height: $terra-table-header-max-height-tiny;
+//   overflow: auto;
+// }
 
-.terra-Table-header-max-height--small > div {
-  max-height: $terra-table-header-max-height-small;
-  overflow: auto;
-}
+// .terra-Table-header-max-height--small > div {
+//   max-height: $terra-table-header-max-height-small;
+//   overflow: auto;
+// }
 
-.terra-Table-header-max-height--medium > div {
-  max-height: $terra-table-header-max-height-medium;
-  overflow: auto;
-}
+// .terra-Table-header-max-height--medium > div {
+//   max-height: $terra-table-header-max-height-medium;
+//   overflow: auto;
+// }
 
-.terra-Table-header-max-height--large > div {
-  max-height: $terra-table-header-max-height-large;
-  overflow: auto;
-}
+// .terra-Table-header-max-height--large > div {
+//   max-height: $terra-table-header-max-height-large;
+//   overflow: auto;
+// }
 
-.terra-Table-header-max-height--huge > div {
-  max-height: $terra-table-header-max-height-huge;
-  overflow: auto;
-}
+// .terra-Table-header-max-height--huge > div {
+//   max-height: $terra-table-header-max-height-huge;
+//   overflow: auto;
+// }
 
-.terra-Table-row-max-height--tiny > div {
-  max-height: $terra-table-row-max-height-tiny;
-  overflow: auto;
-}
+// .terra-Table-row-max-height--tiny > div {
+//   max-height: $terra-table-row-max-height-tiny;
+//   overflow: auto;
+// }
 
-.terra-Table-row-max-height--small > div {
-  max-height: $terra-table-row-max-height-small;
-  overflow: auto;
-}
+// .terra-Table-row-max-height--small > div {
+//   max-height: $terra-table-row-max-height-small;
+//   overflow: auto;
+// }
 
-.terra-Table-row-max-height--medium > div {
-  max-height: $terra-table-row-max-height-medium;
-  overflow: auto;
-}
+// .terra-Table-row-max-height--medium > div {
+//   max-height: $terra-table-row-max-height-medium;
+//   overflow: auto;
+// }
 
-.terra-Table-row-max-height--large > div {
-  max-height: $terra-table-row-max-height-large;
-  overflow: auto;
-}
+// .terra-Table-row-max-height--large > div {
+//   max-height: $terra-table-row-max-height-large;
+//   overflow: auto;
+// }
 
-.terra-Table-row-max-height--huge > div {
-  max-height: $terra-table-row-max-height-huge;
-  overflow: auto;
-}
+// .terra-Table-row-max-height--huge > div {
+//   max-height: $terra-table-row-max-height-huge;
+//   overflow: auto;
+// }
 
 .terra-Table--isSelected {
   background-color: $terra-blue-20 !important;

--- a/packages/terra-table/lib/Table.scss
+++ b/packages/terra-table/lib/Table.scss
@@ -162,56 +162,6 @@
   min-width: $terra-table-cell-min-width-huge;
 }
 
-// .terra-Table-header-max-height--tiny > div {
-//   max-height: $terra-table-header-max-height-tiny;
-//   overflow: auto;
-// }
-
-// .terra-Table-header-max-height--small > div {
-//   max-height: $terra-table-header-max-height-small;
-//   overflow: auto;
-// }
-
-// .terra-Table-header-max-height--medium > div {
-//   max-height: $terra-table-header-max-height-medium;
-//   overflow: auto;
-// }
-
-// .terra-Table-header-max-height--large > div {
-//   max-height: $terra-table-header-max-height-large;
-//   overflow: auto;
-// }
-
-// .terra-Table-header-max-height--huge > div {
-//   max-height: $terra-table-header-max-height-huge;
-//   overflow: auto;
-// }
-
-// .terra-Table-row-max-height--tiny > div {
-//   max-height: $terra-table-row-max-height-tiny;
-//   overflow: auto;
-// }
-
-// .terra-Table-row-max-height--small > div {
-//   max-height: $terra-table-row-max-height-small;
-//   overflow: auto;
-// }
-
-// .terra-Table-row-max-height--medium > div {
-//   max-height: $terra-table-row-max-height-medium;
-//   overflow: auto;
-// }
-
-// .terra-Table-row-max-height--large > div {
-//   max-height: $terra-table-row-max-height-large;
-//   overflow: auto;
-// }
-
-// .terra-Table-row-max-height--huge > div {
-//   max-height: $terra-table-row-max-height-huge;
-//   overflow: auto;
-// }
-
 .terra-Table--isSelected {
   background-color: $terra-blue-20 !important;
 }

--- a/packages/terra-table/lib/TableCell.js
+++ b/packages/terra-table/lib/TableCell.js
@@ -16,36 +16,25 @@ var _classnames2 = _interopRequireDefault(_classnames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
 var propTypes = {
   /**
    * Content to be displayed for the row cell
    */
-  content: _react.PropTypes.any.isRequired,
-  /**
-   * The maximum height for the cell content in a table
-   */
-  height: _react.PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge'])
+  content: _react.PropTypes.any.isRequired
 };
 
 var TableCell = function TableCell(_ref) {
   var content = _ref.content,
-      height = _ref.height,
-      customProps = _objectWithoutProperties(_ref, ['content', 'height']);
+      customProps = _objectWithoutProperties(_ref, ['content']);
 
-  var contentClassName = (0, _classnames2.default)([_defineProperty({}, 'terra-Table-row-max-height--' + height, height), 'terra-Table-cell', customProps.className]);
+  var contentClassName = (0, _classnames2.default)(['terra-Table-cell', customProps.className]);
 
   return _react2.default.createElement(
     'td',
     _extends({}, customProps, { className: contentClassName }),
-    _react2.default.createElement(
-      'div',
-      null,
-      content
-    )
+    content
   );
 };
 

--- a/packages/terra-table/lib/TableHeader.js
+++ b/packages/terra-table/lib/TableHeader.js
@@ -24,20 +24,15 @@ var propTypes = {
   /**
    * A callback function for onClick action
    */
-  onClick: _react.PropTypes.func,
-  /**
-   * The maximum height for the header in a table
-   */
-  height: _react.PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge'])
+  onClick: _react.PropTypes.func
 };
 
 var defaultProps = {
   onClick: undefined
 };
 
-function cloneChildItems(children, height, onClick) {
+function cloneChildItems(children, onClick) {
   var newProps = {
-    height: height,
     onClick: onClick
   };
   var childrenArray = _react2.default.Children.toArray(children);
@@ -58,11 +53,10 @@ function cloneChildItems(children, height, onClick) {
 
 var TableHeader = function TableHeader(_ref) {
   var children = _ref.children,
-      height = _ref.height,
       onClick = _ref.onClick,
-      customProps = _objectWithoutProperties(_ref, ['children', 'height', 'onClick']);
+      customProps = _objectWithoutProperties(_ref, ['children', 'onClick']);
 
-  var cloneChildren = cloneChildItems(children, height, onClick);
+  var cloneChildren = cloneChildItems(children, onClick);
   return _react2.default.createElement(
     'thead',
     customProps,

--- a/packages/terra-table/lib/TableHeaderCell.js
+++ b/packages/terra-table/lib/TableHeaderCell.js
@@ -40,11 +40,7 @@ var propTypes = {
   /**
    * Whether or not data in table is sorted
    */
-  sort: _react.PropTypes.oneOf(['asc', 'desc']),
-  /**
-   * The maximum height for the cell content in a table
-   */
-  height: _react.PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge'])
+  sort: _react.PropTypes.oneOf(['asc', 'desc'])
 };
 
 var defaultProps = {
@@ -56,12 +52,11 @@ var iconUp = _react2.default.createElement(_IconCaretUp2.default, null);
 
 var TableHeaderCell = function TableHeaderCell(_ref) {
   var content = _ref.content,
-      height = _ref.height,
       minWidth = _ref.minWidth,
       sort = _ref.sort,
-      customProps = _objectWithoutProperties(_ref, ['content', 'height', 'minWidth', 'sort']);
+      customProps = _objectWithoutProperties(_ref, ['content', 'minWidth', 'sort']);
 
-  var contentClassName = (0, _classnames2.default)([_defineProperty({}, 'terra-Table-min-width--' + minWidth, minWidth), _defineProperty({}, 'terra-Table-header-max-height--' + height, height), 'terra-Table-header', customProps.className]);
+  var contentClassName = (0, _classnames2.default)([_defineProperty({}, 'terra-Table-min-width--' + minWidth, minWidth), 'terra-Table-header', customProps.className]);
 
   var dataSort = {
     'data-sort': sort
@@ -85,12 +80,8 @@ var TableHeaderCell = function TableHeaderCell(_ref) {
   return _react2.default.createElement(
     'th',
     _extends({}, customProps, { className: contentClassName }, dataSort),
-    _react2.default.createElement(
-      'div',
-      null,
-      content,
-      sortIndicator
-    )
+    content,
+    sortIndicator
   );
 };
 

--- a/packages/terra-table/lib/TableRow.js
+++ b/packages/terra-table/lib/TableRow.js
@@ -14,10 +14,6 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
-var _TableCell = require('./TableCell');
-
-var _TableCell2 = _interopRequireDefault(_TableCell);
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
@@ -32,10 +28,6 @@ var propTypes = {
    */
   isSelected: _react.PropTypes.bool,
   /**
-   * The maximum height for the row in a table
-   */
-  height: _react.PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge']),
-  /**
    * Whether or not row is selectable
    */
   isSelectable: _react.PropTypes.bool
@@ -45,36 +37,24 @@ var defaultProps = {
   isSelected: false
 };
 
-function cloneChildItems(children, height) {
+var TableRow = function TableRow(_ref) {
+  var children = _ref.children,
+      isSelected = _ref.isSelected,
+      isSelectable = _ref.isSelectable,
+      customProps = _objectWithoutProperties(_ref, ['children', 'isSelected', 'isSelectable']);
+
+  var rowClassNames = (0, _classnames2.default)([{ 'terra-Table--isSelected': isSelected }, { 'terra-Table--isSelectable': isSelectable }, 'terra-Table-row', customProps.className]);
+
   var childrenArray = _react2.default.Children.toArray(children);
   if (childrenArray.length > 16) {
     // eslint-disable-next-line no-console
     console.log('Number of Columns are ' + _react2.default.Children.count(children) + '. This is more than columns limit');
   }
-  return childrenArray.filter(function (child, index) {
-    return index < 16;
-  }).map(function (child) {
-    if (child.type === _TableCell2.default) {
-      return _react2.default.cloneElement(child, { height: height });
-    }
-    return child;
-  });
-}
 
-var TableRow = function TableRow(_ref) {
-  var children = _ref.children,
-      isSelected = _ref.isSelected,
-      isSelectable = _ref.isSelectable,
-      height = _ref.height,
-      customProps = _objectWithoutProperties(_ref, ['children', 'isSelected', 'isSelectable', 'height']);
-
-  var rowClassNames = (0, _classnames2.default)([{ 'terra-Table--isSelected': isSelected }, { 'terra-Table--isSelectable': isSelectable }, 'terra-Table-row', customProps.className]);
-
-  var cloneChildren = cloneChildItems(children, height);
   return _react2.default.createElement(
     'tr',
     _extends({}, customProps, { 'aria-selected': isSelected, className: rowClassNames }),
-    cloneChildren
+    children
   );
 };
 

--- a/packages/terra-table/lib/TableRows.js
+++ b/packages/terra-table/lib/TableRows.js
@@ -22,10 +22,6 @@ var propTypes = {
    */
   children: _react.PropTypes.node,
   /**
-   * The maximum height for all the rows in a table
-   */
-  height: _react.PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge']),
-  /**
    * A callback function for onClick action
    */
   onClick: _react.PropTypes.func,
@@ -40,9 +36,9 @@ var defaultProps = {
   onKeyDown: undefined
 };
 
-function cloneChildItems(children, height, onClick, onKeyDown) {
+function cloneChildItems(children, onClick, onKeyDown) {
   return children.map(function (child) {
-    var newProps = { height: height };
+    var newProps = {};
     if (onClick) {
       newProps.onClick = onClick;
     }
@@ -58,12 +54,11 @@ function cloneChildItems(children, height, onClick, onKeyDown) {
 
 var TableRows = function TableRows(_ref) {
   var children = _ref.children,
-      height = _ref.height,
       onClick = _ref.onClick,
       onKeyDown = _ref.onKeyDown,
-      customProps = _objectWithoutProperties(_ref, ['children', 'height', 'onClick', 'onKeyDown']);
+      customProps = _objectWithoutProperties(_ref, ['children', 'onClick', 'onKeyDown']);
 
-  var cloneChildren = cloneChildItems(children, height, onClick, onKeyDown);
+  var cloneChildren = cloneChildItems(children, onClick, onKeyDown);
   return _react2.default.createElement(
     'tbody',
     customProps,

--- a/packages/terra-table/src/SingleSelectableRows.jsx
+++ b/packages/terra-table/src/SingleSelectableRows.jsx
@@ -11,10 +11,6 @@ const propTypes = {
    */
   children: PropTypes.node,
   /**
-   * The maximum height for all the rows in a table
-   */
-  height: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge']),
-  /**
    * A callback function for onClick action
    */
   onClick: PropTypes.func,
@@ -122,7 +118,7 @@ class SingleSelectableRows extends React.Component {
   }
 
   render() {
-    const { children, height, ...customProps } = this.props;
+    const { children, ...customProps } = this.props;
     const clonedChilItems = this.clonedChildItems(children);
     if ('onClick' in customProps) {
       delete customProps.onClick;
@@ -131,7 +127,7 @@ class SingleSelectableRows extends React.Component {
       delete customProps.onKeyDown;
     }
     return (
-      <TableRows height={height} {...customProps}>
+      <TableRows {...customProps}>
         {clonedChilItems}
       </TableRows>
     );

--- a/packages/terra-table/src/Table.jsx
+++ b/packages/terra-table/src/Table.jsx
@@ -17,6 +17,9 @@ const propTypes = {
    * Whether or not the rows should be zebra striped
    */
   isStriped: PropTypes.bool,
+  /**
+   * Whether or not the table cells should be padded
+   */
   isPadded: PropTypes.bool,
 };
 

--- a/packages/terra-table/src/Table.jsx
+++ b/packages/terra-table/src/Table.jsx
@@ -17,20 +17,24 @@ const propTypes = {
    * Whether or not the rows should be zebra striped
    */
   isStriped: PropTypes.bool,
+  isPadded: PropTypes.bool,
 };
 
 const defaultProps = {
   isStriped: true,
+  isPadded: true,
 };
 
 const Table = ({
   children,
   isStriped,
+  isPadded,
   ...customProps
   }) => {
   const tableClassNames = classNames([
     'terra-Table',
     { 'terra-Table--striped': isStriped },
+    { 'terra-Table--padded': isPadded },
     customProps.className,
   ]);
   return (

--- a/packages/terra-table/src/Table.scss
+++ b/packages/terra-table/src/Table.scss
@@ -18,14 +18,11 @@
 
   th,
   td {
-    @include terra-padding-horizontal($terra-table-cell-padding-left, $terra-table-cell-padding-right);
     @include terra-text-align-start;
 
     border: $terra-table-cell-border-width solid $terra-table-cell-border-color;
     border-bottom: 0;
     display: block;
-    padding-bottom: $terra-table-cell-padding-bottom;
-    padding-top: $terra-table-cell-padding-top;
 
     &::before {
       content: attr(data-heading);
@@ -102,13 +99,13 @@
   }
 }
 
-.terra-Table--small {
+.terra-Table--padded {
   th,
   td {
     @include terra-padding-horizontal($terra-table-cell-padding-left, $terra-table-cell-padding-right);
 
-    padding-bottom: $terra-table-cell-small-padding-bottom;
-    padding-top: $terra-table-cell-small-padding-top;
+    padding-bottom: $terra-table-cell-padding-bottom;
+    padding-top: $terra-table-cell-padding-top;
   }
 }
 
@@ -125,7 +122,7 @@
     tbody tr:nth-of-type(even) {
       background-color: $terra-table-row-striped-background-color;
     }
-    
+
     /* Compound selector depth required for specificity */
     /* stylelint-disable-next-line selector-max-compound-selectors */
     tbody tr:nth-of-type(even) th {
@@ -165,55 +162,55 @@
   min-width: $terra-table-cell-min-width-huge;
 }
 
-.terra-Table-header-max-height--tiny > div {
-  max-height: $terra-table-header-max-height-tiny;
-  overflow: auto;
-}
+// .terra-Table-header-max-height--tiny > div {
+//   max-height: $terra-table-header-max-height-tiny;
+//   overflow: auto;
+// }
 
-.terra-Table-header-max-height--small > div {
-  max-height: $terra-table-header-max-height-small;
-  overflow: auto;
-}
+// .terra-Table-header-max-height--small > div {
+//   max-height: $terra-table-header-max-height-small;
+//   overflow: auto;
+// }
 
-.terra-Table-header-max-height--medium > div {
-  max-height: $terra-table-header-max-height-medium;
-  overflow: auto;
-}
+// .terra-Table-header-max-height--medium > div {
+//   max-height: $terra-table-header-max-height-medium;
+//   overflow: auto;
+// }
 
-.terra-Table-header-max-height--large > div {
-  max-height: $terra-table-header-max-height-large;
-  overflow: auto;
-}
+// .terra-Table-header-max-height--large > div {
+//   max-height: $terra-table-header-max-height-large;
+//   overflow: auto;
+// }
 
-.terra-Table-header-max-height--huge > div {
-  max-height: $terra-table-header-max-height-huge;
-  overflow: auto;
-}
+// .terra-Table-header-max-height--huge > div {
+//   max-height: $terra-table-header-max-height-huge;
+//   overflow: auto;
+// }
 
-.terra-Table-row-max-height--tiny > div {
-  max-height: $terra-table-row-max-height-tiny;
-  overflow: auto;
-}
+// .terra-Table-row-max-height--tiny > div {
+//   max-height: $terra-table-row-max-height-tiny;
+//   overflow: auto;
+// }
 
-.terra-Table-row-max-height--small > div {
-  max-height: $terra-table-row-max-height-small;
-  overflow: auto;
-}
+// .terra-Table-row-max-height--small > div {
+//   max-height: $terra-table-row-max-height-small;
+//   overflow: auto;
+// }
 
-.terra-Table-row-max-height--medium > div {
-  max-height: $terra-table-row-max-height-medium;
-  overflow: auto;
-}
+// .terra-Table-row-max-height--medium > div {
+//   max-height: $terra-table-row-max-height-medium;
+//   overflow: auto;
+// }
 
-.terra-Table-row-max-height--large > div {
-  max-height: $terra-table-row-max-height-large;
-  overflow: auto;
-}
+// .terra-Table-row-max-height--large > div {
+//   max-height: $terra-table-row-max-height-large;
+//   overflow: auto;
+// }
 
-.terra-Table-row-max-height--huge > div {
-  max-height: $terra-table-row-max-height-huge;
-  overflow: auto;
-}
+// .terra-Table-row-max-height--huge > div {
+//   max-height: $terra-table-row-max-height-huge;
+//   overflow: auto;
+// }
 
 .terra-Table--isSelected {
   background-color: $terra-blue-20 !important;

--- a/packages/terra-table/src/Table.scss
+++ b/packages/terra-table/src/Table.scss
@@ -162,56 +162,6 @@
   min-width: $terra-table-cell-min-width-huge;
 }
 
-// .terra-Table-header-max-height--tiny > div {
-//   max-height: $terra-table-header-max-height-tiny;
-//   overflow: auto;
-// }
-
-// .terra-Table-header-max-height--small > div {
-//   max-height: $terra-table-header-max-height-small;
-//   overflow: auto;
-// }
-
-// .terra-Table-header-max-height--medium > div {
-//   max-height: $terra-table-header-max-height-medium;
-//   overflow: auto;
-// }
-
-// .terra-Table-header-max-height--large > div {
-//   max-height: $terra-table-header-max-height-large;
-//   overflow: auto;
-// }
-
-// .terra-Table-header-max-height--huge > div {
-//   max-height: $terra-table-header-max-height-huge;
-//   overflow: auto;
-// }
-
-// .terra-Table-row-max-height--tiny > div {
-//   max-height: $terra-table-row-max-height-tiny;
-//   overflow: auto;
-// }
-
-// .terra-Table-row-max-height--small > div {
-//   max-height: $terra-table-row-max-height-small;
-//   overflow: auto;
-// }
-
-// .terra-Table-row-max-height--medium > div {
-//   max-height: $terra-table-row-max-height-medium;
-//   overflow: auto;
-// }
-
-// .terra-Table-row-max-height--large > div {
-//   max-height: $terra-table-row-max-height-large;
-//   overflow: auto;
-// }
-
-// .terra-Table-row-max-height--huge > div {
-//   max-height: $terra-table-row-max-height-huge;
-//   overflow: auto;
-// }
-
 .terra-Table--isSelected {
   background-color: $terra-blue-20 !important;
 }

--- a/packages/terra-table/src/TableCell.jsx
+++ b/packages/terra-table/src/TableCell.jsx
@@ -6,26 +6,20 @@ const propTypes = {
    * Content to be displayed for the row cell
    */
   content: PropTypes.any.isRequired,
-  /**
-   * The maximum height for the cell content in a table
-   */
-  height: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge']),
 };
 
 const TableCell = ({
   content,
-  height,
   ...customProps
   }) => {
   const contentClassName = classNames([
-    { [`terra-Table-row-max-height--${height}`]: height },
     'terra-Table-cell',
     customProps.className,
   ]);
 
   return (
     <td {...customProps} className={contentClassName}>
-      <div>{content}</div>
+      {content}
     </td>
   );
 };

--- a/packages/terra-table/src/TableHeader.jsx
+++ b/packages/terra-table/src/TableHeader.jsx
@@ -10,19 +10,14 @@ const propTypes = {
    * A callback function for onClick action
    */
   onClick: PropTypes.func,
-  /**
-   * The maximum height for the header in a table
-   */
-  height: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge']),
 };
 
 const defaultProps = {
   onClick: undefined,
 };
 
-function cloneChildItems(children, height, onClick) {
+function cloneChildItems(children, onClick) {
   const newProps = {
-    height,
     onClick,
   };
   const childrenArray = React.Children.toArray(children);
@@ -41,11 +36,10 @@ function cloneChildItems(children, height, onClick) {
 
 const TableHeader = ({
   children,
-  height,
   onClick,
   ...customProps
   }) => {
-  const cloneChildren = cloneChildItems(children, height, onClick);
+  const cloneChildren = cloneChildItems(children, onClick);
   return (
     <thead {...customProps}>
       <tr>

--- a/packages/terra-table/src/TableHeaderCell.jsx
+++ b/packages/terra-table/src/TableHeaderCell.jsx
@@ -16,10 +16,6 @@ const propTypes = {
    * Whether or not data in table is sorted
    */
   sort: PropTypes.oneOf(['asc', 'desc']),
-  /**
-   * The maximum height for the cell content in a table
-   */
-  height: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge']),
 };
 
 const defaultProps = {
@@ -31,14 +27,12 @@ const iconUp = <IconUp />;
 
 const TableHeaderCell = ({
   content,
-  height,
   minWidth,
   sort,
   ...customProps
   }) => {
   const contentClassName = classNames([
     { [`terra-Table-min-width--${minWidth}`]: minWidth },
-    { [`terra-Table-header-max-height--${height}`]: height },
     'terra-Table-header',
     customProps.className,
   ]);
@@ -56,10 +50,8 @@ const TableHeaderCell = ({
 
   return (
     <th {...customProps} className={contentClassName} {...dataSort}>
-      <div>
-        {content}
-        {sortIndicator}
-      </div>
+      {content}
+      {sortIndicator}
     </th>
   );
 };

--- a/packages/terra-table/src/TableRow.jsx
+++ b/packages/terra-table/src/TableRow.jsx
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import TableCell from './TableCell';
 
 const propTypes = {
   /**
@@ -12,10 +11,6 @@ const propTypes = {
    */
   isSelected: PropTypes.bool,
   /**
-   * The maximum height for the row in a table
-   */
-  height: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge']),
-  /**
    * Whether or not row is selectable
    */
   isSelectable: PropTypes.bool,
@@ -25,25 +20,10 @@ const defaultProps = {
   isSelected: false,
 };
 
-function cloneChildItems(children, height) {
-  const childrenArray = React.Children.toArray(children);
-  if (childrenArray.length > 16) {
-    // eslint-disable-next-line no-console
-    console.log(`Number of Columns are ${React.Children.count(children)}. This is more than columns limit`);
-  }
-  return childrenArray.filter((child, index) => index < 16).map((child) => {
-    if (child.type === TableCell) {
-      return React.cloneElement(child, { height });
-    }
-    return child;
-  });
-}
-
 const TableRow = ({
   children,
   isSelected,
   isSelectable,
-  height,
   ...customProps
   }) => {
   const rowClassNames = classNames([
@@ -53,10 +33,15 @@ const TableRow = ({
     customProps.className,
   ]);
 
-  const cloneChildren = cloneChildItems(children, height);
+  const childrenArray = React.Children.toArray(children);
+  if (childrenArray.length > 16) {
+    // eslint-disable-next-line no-console
+    console.log(`Number of Columns are ${React.Children.count(children)}. This is more than columns limit`);
+  }
+
   return (
     <tr {...customProps} aria-selected={isSelected} className={rowClassNames}>
-      {cloneChildren}
+      {children}
     </tr>
   );
 };

--- a/packages/terra-table/src/TableRows.jsx
+++ b/packages/terra-table/src/TableRows.jsx
@@ -7,10 +7,6 @@ const propTypes = {
    */
   children: PropTypes.node,
   /**
-   * The maximum height for all the rows in a table
-   */
-  height: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge']),
-  /**
    * A callback function for onClick action
    */
   onClick: PropTypes.func,
@@ -25,9 +21,9 @@ const defaultProps = {
   onKeyDown: undefined,
 };
 
-function cloneChildItems(children, height, onClick, onKeyDown) {
+function cloneChildItems(children, onClick, onKeyDown) {
   return children.map((child) => {
-    const newProps = { height };
+    const newProps = {};
     if (onClick) {
       newProps.onClick = onClick;
     }
@@ -43,12 +39,11 @@ function cloneChildItems(children, height, onClick, onKeyDown) {
 
 const TableRows = ({
   children,
-  height,
   onClick,
   onKeyDown,
   ...customProps
 }) => {
-  const cloneChildren = cloneChildItems(children, height, onClick, onKeyDown);
+  const cloneChildren = cloneChildItems(children, onClick, onKeyDown);
   return (
     <tbody {...customProps}>
       {cloneChildren}

--- a/packages/terra-table/tests/jest/Table.test.jsx
+++ b/packages/terra-table/tests/jest/Table.test.jsx
@@ -36,3 +36,14 @@ it('should render a table without zebra stripes', () => {
   const table = shallow(defaultTable);
   expect(table).toMatchSnapshot();
 });
+
+it('should render a table without padding', () => {
+  const defaultTable = (
+    <Table isPadded={false}>
+      <Table.Header>{header}</Table.Header>
+      <Table.Rows>{rows}</Table.Rows>
+    </Table>
+    );
+  const table = shallow(defaultTable);
+  expect(table).toMatchSnapshot();
+});

--- a/packages/terra-table/tests/jest/__snapshots__/Table.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/Table.test.jsx.snap
@@ -1,5 +1,42 @@
 exports[`test should render a default table 1`] = `
 <table
+  className="terra-Table terra-Table--striped terra-Table--padded">
+  <TableHeader>
+    <TableHeaderCell
+      content="Name"
+      minWidth="small" />
+    <TableHeaderCell
+      content="Address"
+      minWidth="small" />
+    <TableHeaderCell
+      content="Phone Number"
+      minWidth="small" />
+  </TableHeader>
+  <TableRows>
+    <TableRow
+      isSelected={false}>
+      <TableCell
+        content="John Smith" />
+      <TableCell
+        content="123 Adams Drive" />
+      <TableCell
+        content="111-222-3333" />
+    </TableRow>
+    <TableRow
+      isSelected={false}>
+      <TableCell
+        content="John Smith" />
+      <TableCell
+        content="123 Adams Drive" />
+      <TableCell
+        content="111-222-3333" />
+    </TableRow>
+  </TableRows>
+</table>
+`;
+
+exports[`test should render a table without padding 1`] = `
+<table
   className="terra-Table terra-Table--striped">
   <TableHeader>
     <TableHeaderCell
@@ -37,7 +74,7 @@ exports[`test should render a default table 1`] = `
 
 exports[`test should render a table without zebra stripes 1`] = `
 <table
-  className="terra-Table">
+  className="terra-Table terra-Table--padded">
   <TableHeader>
     <TableHeaderCell
       content="Name"

--- a/packages/terra-table/tests/jest/__snapshots__/TableHeaderContent.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableHeaderContent.test.jsx.snap
@@ -1,9 +1,7 @@
 exports[`test should render default table header content tag 1`] = `
 <th
   className="terra-Table-min-width--small terra-Table-header">
-  <div>
-    Column Heading
-  </div>
+  Column Heading
 </th>
 `;
 
@@ -11,17 +9,15 @@ exports[`test should render table header content tag with ascending sort indicat
 <th
   className="terra-Table-min-width--small terra-Table-header"
   data-sort="asc">
-  <div>
-    Column Heading
-    <span
-      className="terra-Table-sort-indicator">
-      <IconCaretUp
-        className=""
-        isBidi={true}
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg" />
-    </span>
-  </div>
+  Column Heading
+  <span
+    className="terra-Table-sort-indicator">
+    <IconCaretUp
+      className=""
+      isBidi={true}
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg" />
+  </span>
 </th>
 `;
 
@@ -29,25 +25,22 @@ exports[`test should render table header content tag with descending sort indica
 <th
   className="terra-Table-min-width--small terra-Table-header"
   data-sort="desc">
-  <div>
-    Column Heading
-    <span
-      className="terra-Table-sort-indicator">
-      <IconCaretDown
-        className=""
-        isBidi={true}
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg" />
-    </span>
-  </div>
+  Column Heading
+  <span
+    className="terra-Table-sort-indicator">
+    <IconCaretDown
+      className=""
+      isBidi={true}
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg" />
+  </span>
 </th>
 `;
 
 exports[`test should render table header content tag with maximum height fixed 1`] = `
 <th
-  className="terra-Table-min-width--small terra-Table-header-max-height--small terra-Table-header">
-  <div>
-    Column Heading
-  </div>
+  className="terra-Table-min-width--small terra-Table-header"
+  height="small">
+  Column Heading
 </th>
 `;

--- a/packages/terra-table/tests/jest/__snapshots__/TableRowContent.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableRowContent.test.jsx.snap
@@ -1,17 +1,14 @@
 exports[`test should render a default table row content 1`] = `
 <td
   className="terra-Table-cell">
-  <div>
-    Table Data
-  </div>
+  Table Data
 </td>
 `;
 
 exports[`test should render a table row content with maximum height 1`] = `
 <td
-  className="terra-Table-row-max-height--small terra-Table-cell">
-  <div>
-    Table Data
-  </div>
+  className="terra-Table-cell"
+  height="small">
+  Table Data
 </td>
 `;

--- a/packages/terra-table/tests/nightwatch/TableTestRoutes.jsx
+++ b/packages/terra-table/tests/nightwatch/TableTestRoutes.jsx
@@ -5,6 +5,7 @@ import { Route } from 'react-router';
 import TableTests from './TableTests';
 import DefaultTable from './components/StripedTable';
 import NoStripedTable from './components/NoStripedTable';
+import NoPaddingTable from './components/NoPaddingTable';
 import SingleRowSelectableTable from './components/SingleRowSelectableTable';
 import TableWithHighlightedRows from './components/TableWithHighlightedRows';
 import TableWithSortIndicator from './components/TableWithSortIndicator';
@@ -14,6 +15,7 @@ const routes = (
     <Route path="/tests/table-tests" component={TableTests} />
     <Route path="/tests/table-tests/default" component={DefaultTable} />
     <Route path="/tests/table-tests/no-striped" component={NoStripedTable} />
+    <Route path="/tests/table-tests/no-padding" component={NoPaddingTable} />
     <Route path="/tests/table-tests/selectable-table" component={SingleRowSelectableTable} />
     <Route path="/tests/table-tests/table-highlighted-rows" component={TableWithHighlightedRows} />
     <Route path="/tests/table-tests/table-sort-indicator" component={TableWithSortIndicator} />

--- a/packages/terra-table/tests/nightwatch/TableTests.jsx
+++ b/packages/terra-table/tests/nightwatch/TableTests.jsx
@@ -8,6 +8,7 @@ const TableTests = () => (
     <ul>
       <li><Link to="/tests/table-tests/default">Default Table</Link></li>
       <li><Link to="/tests/table-tests/no-striped">No Striped Table</Link></li>
+      <li><Link to="/tests/table-tests/no-padding">No Padding Table</Link></li>
       <li><Link to="/tests/table-tests/selectable-table">Selectable Table</Link></li>
       <li><Link to="/tests/table-tests/table-highlighted-rows">Highlighted Rows Table</Link></li>
       <li><Link to="/tests/table-tests/table-sort-indicator">Sort Indicator Table Header</Link></li>

--- a/packages/terra-table/tests/nightwatch/components/NoPaddingTable.jsx
+++ b/packages/terra-table/tests/nightwatch/components/NoPaddingTable.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Table from '../../../lib/Table';
+
+const NoPaddingTable = () => (
+  <Table isPadded={false}>
+    <Table.Header>
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+    </Table.Header>
+    <Table.Rows>
+      <Table.Row key={'PERSON_0'}>
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Row key={'PERSON_1'}>
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Row key={'PERSON_2'}>
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+    </Table.Rows>
+  </Table>
+);
+
+export default NoPaddingTable;

--- a/packages/terra-table/tests/nightwatch/table-spec.js
+++ b/packages/terra-table/tests/nightwatch/table-spec.js
@@ -45,6 +45,13 @@ module.exports = {
       .assert.cssClassNotPresent('.terra-Table', '.terra-Table--striped');
   },
 
+  'Displays a table without padding': (browser) => {
+    browser
+      .url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/table-tests/no-padding`)
+      .assert.elementPresent('.terra-Table')
+      .assert.cssClassNotPresent('.terra-Table', '.terra-Table--padded');
+  },
+
   'Display a sorting indicator': (browser) => {
     browser
       .url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/table-tests/table-sort-indicator`)


### PR DESCRIPTION
There were concerns with the amount of styling that was being done to the th/tds, especially regarding the padding. I added a prop to enable/disable it.

Also, the row height props were found to be confusing in functional validation, so they are being removed. We will rely on consumers to size their cell content appropriately. This should resolve the overflowing cell issue.