### PR TITLE
Removing a few straggling height props from Table examples and tests

### DIFF
--- a/packages/terra-site/src/examples/table/TableWithLongContent.jsx
+++ b/packages/terra-site/src/examples/table/TableWithLongContent.jsx
@@ -4,12 +4,12 @@ import Table from 'terra-table';
 
 const TableWithLongContent = () => (
   <Table isStriped={false}>
-    <Table.Header height={'small'}>
+    <Table.Header>
       <Table.HeaderCell content={'Column Heading 1'} key={'COLUMN_0'} minWidth={'small'} />
       <Table.HeaderCell content={'Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header Very long table header End Header'} key={'COLUMN_1'} minWidth={'medium'} />
       <Table.HeaderCell content={'Column Heading 3'} key={'COLUMN_2'} minWidth={'large'} />
     </Table.Header>
-    <Table.SingleSelectableRows height={'small'}>
+    <Table.SingleSelectableRows>
       <Table.Row key={'ROW_0'}>
         <Table.Cell content={'Table Data'} key={'COLUMN_0'} />
         <Table.Cell content={'Table Data'} key={'COLUMN_1'} />

--- a/packages/terra-table/tests/jest/SingleSelectableRows.test.jsx
+++ b/packages/terra-table/tests/jest/SingleSelectableRows.test.jsx
@@ -18,7 +18,7 @@ it('should render SingleSelectableRows tag', () => {
 });
 
 it('should render SingleSelectableRows with maximum height set', () => {
-  const defaultTableRows = <Table.SingleSelectableRows height={'medium'}>{rows}</Table.SingleSelectableRows>;
+  const defaultTableRows = <Table.SingleSelectableRows>{rows}</Table.SingleSelectableRows>;
   const tableRows = shallow(defaultTableRows);
   expect(tableRows).toMatchSnapshot();
 });

--- a/packages/terra-table/tests/jest/TableHeaderContent.test.jsx
+++ b/packages/terra-table/tests/jest/TableHeaderContent.test.jsx
@@ -21,7 +21,7 @@ it('should render table header content tag with descending sort indicator', () =
 });
 
 it('should render table header content tag with maximum height fixed', () => {
-  const defaultTableHeaderContent = <Table.HeaderCell content={'Column Heading'} height={'small'} />;
+  const defaultTableHeaderContent = <Table.HeaderCell content={'Column Heading'} />;
   const tableHeaderContent = shallow(defaultTableHeaderContent);
   expect(tableHeaderContent).toMatchSnapshot();
 });

--- a/packages/terra-table/tests/jest/TableRowContent.test.jsx
+++ b/packages/terra-table/tests/jest/TableRowContent.test.jsx
@@ -9,7 +9,7 @@ it('should render a default table row content', () => {
 });
 
 it('should render a table row content with maximum height', () => {
-  const tableRowContentTag = <Table.Cell content={'Table Data'} height={'small'} />;
+  const tableRowContentTag = <Table.Cell content={'Table Data'} />;
   const tableRowContent = shallow(tableRowContentTag);
   expect(tableRowContent).toMatchSnapshot();
 });

--- a/packages/terra-table/tests/jest/__snapshots__/SingleSelectableRows.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/SingleSelectableRows.test.jsx.snap
@@ -30,8 +30,7 @@ exports[`test should render SingleSelectableRows tag 1`] = `
 `;
 
 exports[`test should render SingleSelectableRows with maximum height set 1`] = `
-<TableRows
-  height="medium">
+<TableRows>
   <TableRow
     isSelectable={true}
     isSelected={false}

--- a/packages/terra-table/tests/jest/__snapshots__/TableHeaderContent.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableHeaderContent.test.jsx.snap
@@ -39,8 +39,7 @@ exports[`test should render table header content tag with descending sort indica
 
 exports[`test should render table header content tag with maximum height fixed 1`] = `
 <th
-  className="terra-Table-min-width--small terra-Table-header"
-  height="small">
+  className="terra-Table-min-width--small terra-Table-header">
   Column Heading
 </th>
 `;

--- a/packages/terra-table/tests/jest/__snapshots__/TableRowContent.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableRowContent.test.jsx.snap
@@ -7,8 +7,7 @@ exports[`test should render a default table row content 1`] = `
 
 exports[`test should render a table row content with maximum height 1`] = `
 <td
-  className="terra-Table-cell"
-  height="small">
+  className="terra-Table-cell">
   Table Data
 </td>
 `;


### PR DESCRIPTION
I accidentally left a height prop on a few example/test components. There's no impact to the build, but it'd be nice to get these out of here.