### PR TITLE
Make base dependency explicit

### DIFF
--- a/packages/terra-arrange/lib/Arrange.js
+++ b/packages/terra-arrange/lib/Arrange.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 require('./Arrange.scss');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/packages/terra-arrange/package.json
+++ b/packages/terra-arrange/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/terra-arrange/src/Arrange.jsx
+++ b/packages/terra-arrange/src/Arrange.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 import './Arrange.scss';
 
 const alignmentTypes = ['center', 'bottom', 'stretch'];

--- a/packages/terra-badge/lib/Badge.js
+++ b/packages/terra-badge/lib/Badge.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 require('./Badge.scss');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/packages/terra-badge/package.json
+++ b/packages/terra-badge/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/terra-badge/src/Badge.jsx
+++ b/packages/terra-badge/src/Badge.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-
+import 'terra-base/lib/baseStyles';
 import './Badge.scss';
 
 const propTypes = {

--- a/packages/terra-base/lib/Base.js
+++ b/packages/terra-base/lib/Base.js
@@ -4,23 +4,15 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-require('./Base.scss');
+require('./baseStyles');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var propTypes = {
   /**
@@ -29,50 +21,16 @@ var propTypes = {
   children: _react.PropTypes.node.isRequired
 };
 
-var Base = function (_React$Component) {
-  _inherits(Base, _React$Component);
+var Base = function Base(_ref) {
+  var children = _ref.children,
+      customProps = _objectWithoutProperties(_ref, ['children']);
 
-  function Base() {
-    _classCallCheck(this, Base);
-
-    return _possibleConstructorReturn(this, (Base.__proto__ || Object.getPrototypeOf(Base)).apply(this, arguments));
-  }
-
-  _createClass(Base, [{
-    key: 'componentDidMount',
-    value: function componentDidMount() {
-      // Checks to run when not in production
-      if (process.env.NODE_ENV !== 'production') {
-        // Check to ensure terra-Base class is set on html element
-        if (!new RegExp('(^|\\s)terra-Base(\\s|$)').test(document.documentElement.className)) {
-          // eslint-disable-next-line
-          console.warn('The html element is missing the terra-Base class.');
-        }
-
-        // Check to ensure dir attribute is set on html element
-        if (!document.documentElement.hasAttribute('dir')) {
-          // eslint-disable-next-line
-          console.warn('The html element is missing the dir attribute. For terra directionality based styles to render correctly, add dir="ltr" or dir="rtl" to the html element.');
-        }
-      }
-    }
-  }, {
-    key: 'render',
-    value: function render() {
-      var _props = this.props,
-          children = _props.children,
-          customProps = _objectWithoutProperties(_props, ['children']);
-
-      return _react2.default.createElement(
-        'div',
-        customProps,
-        children
-      );
-    }
-  }]);
-
-  return Base;
-}(_react2.default.Component);
+  return _react2.default.createElement(
+    'div',
+    customProps,
+    children
+  );
+};
 
 Base.propTypes = propTypes;
 

--- a/packages/terra-base/lib/baseStyles.js
+++ b/packages/terra-base/lib/baseStyles.js
@@ -1,12 +1,17 @@
 'use strict';
 
+/**
+ * The following code is used to ensure global styles are loaded only once in an app
+ * that consumes terra components.
+ */
 if (!global.baseStylesLoaded) {
-  console.log('base styles');
-
-  // eslint-disable-next-line
+  /* eslint-disable global-require */
   require('./Base.scss');
 }
 
+/**
+ * Once global styles are loaded, set global to prevent duplication of global styles
+ */
 global.baseStylesLoaded = true;
 
 // Checks to run when not in production

--- a/packages/terra-base/lib/baseStyles.js
+++ b/packages/terra-base/lib/baseStyles.js
@@ -1,18 +1,6 @@
 'use strict';
 
-/**
- * The following code is used to ensure global styles are loaded only once in an app
- * that consumes terra components.
- */
-if (!global.baseStylesLoaded) {
-  /* eslint-disable global-require */
-  require('./Base.scss');
-}
-
-/**
- * Once global styles are loaded, set global to prevent duplication of global styles
- */
-global.baseStylesLoaded = true;
+require('./Base.scss');
 
 // Checks to run when not in production
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/terra-base/lib/baseStyles.js
+++ b/packages/terra-base/lib/baseStyles.js
@@ -1,0 +1,25 @@
+'use strict';
+
+if (!global.baseStylesLoaded) {
+  console.log('base styles');
+
+  // eslint-disable-next-line
+  require('./Base.scss');
+}
+
+global.baseStylesLoaded = true;
+
+// Checks to run when not in production
+if (process.env.NODE_ENV !== 'production') {
+  // Check to ensure terra-Base class is set on html element
+  if (!new RegExp('(^|\\s)terra-Base(\\s|$)').test(document.documentElement.className)) {
+    // eslint-disable-next-line
+    console.warn('The html element is missing the terra-Base class.');
+  }
+
+  // Check to ensure dir attribute is set on html element
+  if (!document.documentElement.hasAttribute('dir')) {
+    // eslint-disable-next-line
+    console.warn('The html element is missing the dir attribute. For terra directionality based styles to render correctly, add dir="ltr" or dir="rtl" to the html element.');
+  }
+}

--- a/packages/terra-base/src/Base.jsx
+++ b/packages/terra-base/src/Base.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import './Base.scss';
+import './baseStyles';
 
 const propTypes = {
   /**
@@ -8,30 +8,11 @@ const propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-class Base extends React.Component {
-
-  componentDidMount() {
-    // Checks to run when not in production
-    if (process.env.NODE_ENV !== 'production') {
-      // Check to ensure terra-Base class is set on html element
-      if (!new RegExp('(^|\\s)terra-Base(\\s|$)').test(document.documentElement.className)) {
-        // eslint-disable-next-line
-        console.warn('The html element is missing the terra-Base class.');
-      }
-
-      // Check to ensure dir attribute is set on html element
-      if (!document.documentElement.hasAttribute('dir')) {
-        // eslint-disable-next-line
-        console.warn('The html element is missing the dir attribute. For terra directionality based styles to render correctly, add dir="ltr" or dir="rtl" to the html element.');
-      }
-    }
-  }
-
-  render() {
-    const { children, ...customProps } = this.props;
-    return <div {...customProps}>{children}</div>;
-  }
-}
+const Base = ({ children, ...customProps }) => (
+  <div {...customProps}>
+    {children}
+  </div>
+);
 
 Base.propTypes = propTypes;
 

--- a/packages/terra-base/src/baseStyles.js
+++ b/packages/terra-base/src/baseStyles.js
@@ -1,0 +1,23 @@
+if (!global.baseStylesLoaded) {
+  console.log('base styles');
+
+  // eslint-disable-next-line
+  require('./Base.scss');
+}
+
+global.baseStylesLoaded = true;
+
+// Checks to run when not in production
+if (process.env.NODE_ENV !== 'production') {
+  // Check to ensure terra-Base class is set on html element
+  if (!new RegExp('(^|\\s)terra-Base(\\s|$)').test(document.documentElement.className)) {
+    // eslint-disable-next-line
+    console.warn('The html element is missing the terra-Base class.');
+  }
+
+  // Check to ensure dir attribute is set on html element
+  if (!document.documentElement.hasAttribute('dir')) {
+    // eslint-disable-next-line
+    console.warn('The html element is missing the dir attribute. For terra directionality based styles to render correctly, add dir="ltr" or dir="rtl" to the html element.');
+  }
+}

--- a/packages/terra-base/src/baseStyles.js
+++ b/packages/terra-base/src/baseStyles.js
@@ -1,10 +1,15 @@
+/**
+ * The following code is used to ensure global styles are loaded only once in an app
+ * that consumes terra components.
+ */
 if (!global.baseStylesLoaded) {
-  console.log('base styles');
-
-  // eslint-disable-next-line
+  /* eslint-disable global-require */
   require('./Base.scss');
 }
 
+/**
+ * Once global styles are loaded, set global to prevent duplication of global styles
+ */
 global.baseStylesLoaded = true;
 
 // Checks to run when not in production

--- a/packages/terra-base/src/baseStyles.js
+++ b/packages/terra-base/src/baseStyles.js
@@ -1,16 +1,4 @@
-/**
- * The following code is used to ensure global styles are loaded only once in an app
- * that consumes terra components.
- */
-if (!global.baseStylesLoaded) {
-  /* eslint-disable global-require */
-  require('./Base.scss');
-}
-
-/**
- * Once global styles are loaded, set global to prevent duplication of global styles
- */
-global.baseStylesLoaded = true;
+import './Base.scss';
 
 // Checks to run when not in production
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/terra-button-group/lib/ButtonGroup.js
+++ b/packages/terra-button-group/lib/ButtonGroup.js
@@ -16,6 +16,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 var _ButtonGroupButton = require('./ButtonGroupButton');
 
 var _ButtonGroupButton2 = _interopRequireDefault(_ButtonGroupButton);

--- a/packages/terra-button-group/lib/ButtonGroupButton.js
+++ b/packages/terra-button-group/lib/ButtonGroupButton.js
@@ -18,6 +18,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 require('./ButtonGroupButton.scss');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/packages/terra-button-group/package.json
+++ b/packages/terra-button-group/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0",
     "terra-button": "^0.x"
   },

--- a/packages/terra-button-group/src/ButtonGroup.jsx
+++ b/packages/terra-button-group/src/ButtonGroup.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-
+import 'terra-base/lib/baseStyles';
 import ButtonGroupButton from './ButtonGroupButton';
 import './ButtonGroup.scss';
 
@@ -140,4 +140,3 @@ ButtonGroup.defaultProps = defaultProps;
 ButtonGroup.Button = ButtonGroupButton;
 
 export default ButtonGroup;
-

--- a/packages/terra-button-group/src/ButtonGroupButton.jsx
+++ b/packages/terra-button-group/src/ButtonGroupButton.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import Button from 'terra-button';
 import classNames from 'classnames';
-
+import 'terra-base/lib/baseStyles';
 import './ButtonGroupButton.scss';
 
 const propTypes = {

--- a/packages/terra-button/lib/Button.js
+++ b/packages/terra-button/lib/Button.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 require('./Button.scss');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/packages/terra-button/package.json
+++ b/packages/terra-button/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   }
 }

--- a/packages/terra-button/src/Button.jsx
+++ b/packages/terra-button/src/Button.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 import './Button.scss';
 
 const propTypes = {

--- a/packages/terra-content-container/lib/ContentContainer.js
+++ b/packages/terra-content-container/lib/ContentContainer.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 require('./ContentContainer.scss');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/packages/terra-content-container/package.json
+++ b/packages/terra-content-container/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   },
   "scripts": {

--- a/packages/terra-content-container/src/ContentContainer.jsx
+++ b/packages/terra-content-container/src/ContentContainer.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 import './ContentContainer.scss';
 
 const propTypes = {

--- a/packages/terra-content/package.json
+++ b/packages/terra-content/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   },
   "scripts": {

--- a/packages/terra-date-picker/lib/DateInput.js
+++ b/packages/terra-date-picker/lib/DateInput.js
@@ -10,6 +10,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+require('terra-base/lib/baseStyles');
+
 var _terraButton = require('terra-button');
 
 var _terraButton2 = _interopRequireDefault(_terraButton);

--- a/packages/terra-date-picker/lib/DatePicker.js
+++ b/packages/terra-date-picker/lib/DatePicker.js
@@ -20,6 +20,8 @@ var _moment = require('moment');
 
 var _moment2 = _interopRequireDefault(_moment);
 
+require('terra-base/lib/baseStyles');
+
 var _terraResponsiveElement = require('terra-responsive-element');
 
 var _terraResponsiveElement2 = _interopRequireDefault(_terraResponsiveElement);

--- a/packages/terra-date-picker/lib/DateRange.js
+++ b/packages/terra-date-picker/lib/DateRange.js
@@ -12,6 +12,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+require('terra-base/lib/baseStyles');
+
 var _DatePicker = require('./DatePicker');
 
 var _DatePicker2 = _interopRequireDefault(_DatePicker);

--- a/packages/terra-date-picker/package.json
+++ b/packages/terra-date-picker/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "moment": "^2.17.1",
     "react-datepicker": "^0.44.0",
+    "terra-base": "^0.x",
     "terra-button": "^0.x",
     "terra-icon": "^0.x",
     "terra-mixins": "^1.0.0",

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import 'terra-base/lib/baseStyles';
 import Button from 'terra-button';
 import IconCalendar from 'terra-icon/lib/icon/IconCalendar';
 

--- a/packages/terra-date-picker/src/DatePicker.jsx
+++ b/packages/terra-date-picker/src/DatePicker.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import ReactDatePicker from 'react-datepicker';
 import moment from 'moment';
+import 'terra-base/lib/baseStyles';
 import ResponsiveElement from 'terra-responsive-element';
 import DateInput from './DateInput';
 import './DatePicker.scss';

--- a/packages/terra-date-picker/src/DateRange.jsx
+++ b/packages/terra-date-picker/src/DateRange.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import 'terra-base/lib/baseStyles';
 import DatePicker from './DatePicker';
 
 const propTypes = {

--- a/packages/terra-grid/lib/Grid.js
+++ b/packages/terra-grid/lib/Grid.js
@@ -8,6 +8,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+require('terra-base/lib/baseStyles');
+
 var _GridRow = require('./GridRow');
 
 var _GridRow2 = _interopRequireDefault(_GridRow);

--- a/packages/terra-grid/lib/GridColumn.js
+++ b/packages/terra-grid/lib/GridColumn.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }

--- a/packages/terra-grid/lib/GridRow.js
+++ b/packages/terra-grid/lib/GridRow.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }

--- a/packages/terra-grid/package.json
+++ b/packages/terra-grid/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   }
 }

--- a/packages/terra-grid/src/Grid.jsx
+++ b/packages/terra-grid/src/Grid.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-
+import 'terra-base/lib/baseStyles';
 import GridRow from './GridRow';
 import GridColumn from './GridColumn';
 

--- a/packages/terra-grid/src/GridColumn.jsx
+++ b/packages/terra-grid/src/GridColumn.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 
 const columnRange = (props, propName) => {
   if (props[propName]) {

--- a/packages/terra-grid/src/GridRow.jsx
+++ b/packages/terra-grid/src/GridRow.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 
 const propTypes = {
   /**

--- a/packages/terra-i18n/package.json
+++ b/packages/terra-i18n/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "intl": "^1.2.5",
-    "react-intl": "^2.2.3"
+    "react-intl": "^2.2.3",
+    "terra-base": "^0.x"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-icon/lib/IconBase.js
+++ b/packages/terra-icon/lib/IconBase.js
@@ -14,11 +14,14 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 require('./Icon.scss');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
 // eslint-disable-next-line import/no-unresolved, import/no-webpack-loader-syntax
 
 

--- a/packages/terra-icon/package.json
+++ b/packages/terra-icon/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   },
   "scripts": {

--- a/packages/terra-icon/src/IconBase.jsx
+++ b/packages/terra-icon/src/IconBase.jsx
@@ -1,5 +1,7 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
+
 // eslint-disable-next-line import/no-unresolved, import/no-webpack-loader-syntax
 import './Icon.scss';
 

--- a/packages/terra-image/lib/Image.js
+++ b/packages/terra-image/lib/Image.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 require('./Image.scss');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/packages/terra-image/package.json
+++ b/packages/terra-image/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   }
 }

--- a/packages/terra-image/src/Image.jsx
+++ b/packages/terra-image/src/Image.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 import './Image.scss';
 
 const propTypes = {

--- a/packages/terra-list/lib/List.js
+++ b/packages/terra-list/lib/List.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 require('./List.scss');
 
 var _ListItem = require('./ListItem');

--- a/packages/terra-list/lib/ListItem.js
+++ b/packages/terra-list/lib/ListItem.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 var _IconChevronRight = require('terra-icon/lib/icon/IconChevronRight');
 
 var _IconChevronRight2 = _interopRequireDefault(_IconChevronRight);

--- a/packages/terra-list/lib/MultiSelectList.js
+++ b/packages/terra-list/lib/MultiSelectList.js
@@ -12,6 +12,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+require('terra-base/lib/baseStyles');
+
 var _List = require('./List');
 
 var _List2 = _interopRequireDefault(_List);

--- a/packages/terra-list/lib/SingleSelectList.js
+++ b/packages/terra-list/lib/SingleSelectList.js
@@ -12,6 +12,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+require('terra-base/lib/baseStyles');
+
 var _List = require('./List');
 
 var _List2 = _interopRequireDefault(_List);

--- a/packages/terra-list/package.json
+++ b/packages/terra-list/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "terra-base": "^0.x",
     "terra-icon": "^0.x",
     "terra-mixins": "^1.0.0"
   },

--- a/packages/terra-list/src/List.jsx
+++ b/packages/terra-list/src/List.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 import './List.scss';
 import ListItem from './ListItem';
 

--- a/packages/terra-list/src/ListItem.jsx
+++ b/packages/terra-list/src/ListItem.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 import ChevronRight from 'terra-icon/lib/icon/IconChevronRight';
 import './ListItem.scss';
 

--- a/packages/terra-list/src/MultiSelectList.jsx
+++ b/packages/terra-list/src/MultiSelectList.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import 'terra-base/lib/baseStyles';
 import List from './List';
 
 const propTypes = {

--- a/packages/terra-list/src/SingleSelectList.jsx
+++ b/packages/terra-list/src/SingleSelectList.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import 'terra-base/lib/baseStyles';
 import List from './List';
 
 const propTypes = {

--- a/packages/terra-markdown/lib/Markdown.js
+++ b/packages/terra-markdown/lib/Markdown.js
@@ -12,6 +12,8 @@ var _marked = require('marked');
 
 var _marked2 = _interopRequireDefault(_marked);
 
+require('terra-base/lib/baseStyles');
+
 require('github-markdown-css');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/packages/terra-markdown/package.json
+++ b/packages/terra-markdown/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "marked": "^0.3.6",
-    "github-markdown-css": "^2.4.1"
+    "github-markdown-css": "^2.4.1",
+    "terra-base": "^0.x"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-markdown/src/Markdown.jsx
+++ b/packages/terra-markdown/src/Markdown.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import marked from 'marked';
+import 'terra-base/lib/baseStyles';
 // eslint-disable-next-line import/extensions
 import 'github-markdown-css';
 

--- a/packages/terra-progress-bar/lib/ProgressBar.js
+++ b/packages/terra-progress-bar/lib/ProgressBar.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 require('./ProgressBar.scss');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/packages/terra-progress-bar/package.json
+++ b/packages/terra-progress-bar/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   }
 }

--- a/packages/terra-progress-bar/src/ProgressBar.jsx
+++ b/packages/terra-progress-bar/src/ProgressBar.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 import './ProgressBar.scss';
 
 const propTypes = {

--- a/packages/terra-props-table/package.json
+++ b/packages/terra-props-table/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "react-docgen": "2.13.0",
+    "terra-base": "^0.x",
     "terra-markdown": "^0.x"
   },
   "scripts": {

--- a/packages/terra-responsive-element/lib/ResponsiveElement.js
+++ b/packages/terra-responsive-element/lib/ResponsiveElement.js
@@ -16,6 +16,8 @@ var _resizeObserverPolyfill = require('resize-observer-polyfill');
 
 var _resizeObserverPolyfill2 = _interopRequireDefault(_resizeObserverPolyfill);
 
+require('terra-base/lib/baseStyles');
+
 var _breakpoints = require('./breakpoints');
 
 var _breakpoints2 = _interopRequireDefault(_breakpoints);

--- a/packages/terra-responsive-element/package.json
+++ b/packages/terra-responsive-element/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "resize-observer-polyfill": "^1.4.1",
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   },
   "scripts": {

--- a/packages/terra-responsive-element/src/ResponsiveElement.jsx
+++ b/packages/terra-responsive-element/src/ResponsiveElement.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import ResizeObserver from 'resize-observer-polyfill';
+import 'terra-base/lib/baseStyles';
 import getBreakpoints from './breakpoints';
 
 const propTypes = {

--- a/packages/terra-site/src/App.jsx
+++ b/packages/terra-site/src/App.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import Base from 'terra-base';
 import React from 'react';
 import { Link } from 'react-router';
 import './site.scss';
@@ -9,7 +8,7 @@ const propTypes = {
 };
 
 const App = props => (
-  <Base>
+  <div>
     <div dir="ltr">
       <button onClick={() => document.getElementsByTagName('html')[0].setAttribute('dir', 'ltr')} >ltr</button>
       <button onClick={() => document.getElementsByTagName('html')[0].setAttribute('dir', 'rtl')} >rtl</button>
@@ -39,7 +38,7 @@ const App = props => (
       <li><Link to="/tests">Tests</Link></li>
     </ul>
     {props.children}
-  </Base>
+  </div>
 );
 
 App.propTypes = propTypes;

--- a/packages/terra-slide-panel/lib/SlidePanel.js
+++ b/packages/terra-slide-panel/lib/SlidePanel.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 require('./SlidePanel.scss');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/packages/terra-slide-panel/package.json
+++ b/packages/terra-slide-panel/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   },
   "scripts": {

--- a/packages/terra-slide-panel/src/SlidePanel.jsx
+++ b/packages/terra-slide-panel/src/SlidePanel.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 import './SlidePanel.scss';
 
 const propTypes = {

--- a/packages/terra-standout/package.json
+++ b/packages/terra-standout/package.json
@@ -42,6 +42,7 @@
     "terra-mixins": "^1.0.0"
   },
   "dependencies": {
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   }
 }

--- a/packages/terra-status/lib/Status.js
+++ b/packages/terra-status/lib/Status.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 require('./Status.scss');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/packages/terra-status/package.json
+++ b/packages/terra-status/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   }
 }

--- a/packages/terra-status/src/Status.jsx
+++ b/packages/terra-status/src/Status.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 import './Status.scss';
 
 const propTypes = {

--- a/packages/terra-table/lib/SingleSelectableRows.js
+++ b/packages/terra-table/lib/SingleSelectableRows.js
@@ -10,6 +10,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+require('terra-base/lib/baseStyles');
+
 var _TableRows = require('./TableRows');
 
 var _TableRows2 = _interopRequireDefault(_TableRows);

--- a/packages/terra-table/lib/Table.js
+++ b/packages/terra-table/lib/Table.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 var _TableHeader = require('./TableHeader');
 
 var _TableHeader2 = _interopRequireDefault(_TableHeader);

--- a/packages/terra-table/lib/TableCell.js
+++ b/packages/terra-table/lib/TableCell.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }

--- a/packages/terra-table/lib/TableHeader.js
+++ b/packages/terra-table/lib/TableHeader.js
@@ -8,6 +8,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+require('terra-base/lib/baseStyles');
+
 var _TableHeaderCell = require('./TableHeaderCell');
 
 var _TableHeaderCell2 = _interopRequireDefault(_TableHeaderCell);

--- a/packages/terra-table/lib/TableHeaderCell.js
+++ b/packages/terra-table/lib/TableHeaderCell.js
@@ -22,6 +22,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }

--- a/packages/terra-table/lib/TableRow.js
+++ b/packages/terra-table/lib/TableRow.js
@@ -14,6 +14,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+require('terra-base/lib/baseStyles');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }

--- a/packages/terra-table/lib/TableRows.js
+++ b/packages/terra-table/lib/TableRows.js
@@ -8,6 +8,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+require('terra-base/lib/baseStyles');
+
 var _TableRow = require('./TableRow');
 
 var _TableRow2 = _interopRequireDefault(_TableRow);

--- a/packages/terra-table/package.json
+++ b/packages/terra-table/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "terra-base": "^0.x",
     "terra-icon": "^0.x",
     "terra-mixins": "^1.0.0"
   },

--- a/packages/terra-table/src/SingleSelectableRows.jsx
+++ b/packages/terra-table/src/SingleSelectableRows.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import 'terra-base/lib/baseStyles';
 import TableRows from './TableRows';
 
 const KEYCODES = {

--- a/packages/terra-table/src/Table.jsx
+++ b/packages/terra-table/src/Table.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 import TableHeader from './TableHeader';
 import TableHeaderCell from './TableHeaderCell';
 import TableRows from './TableRows';

--- a/packages/terra-table/src/TableCell.jsx
+++ b/packages/terra-table/src/TableCell.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 
 const propTypes = {
   /**

--- a/packages/terra-table/src/TableHeader.jsx
+++ b/packages/terra-table/src/TableHeader.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import 'terra-base/lib/baseStyles';
 import TableHeaderCell from './TableHeaderCell';
 
 const propTypes = {

--- a/packages/terra-table/src/TableHeaderCell.jsx
+++ b/packages/terra-table/src/TableHeaderCell.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import IconDown from 'terra-icon/lib/icon/IconCaretDown';
 import IconUp from 'terra-icon/lib/icon/IconCaretUp';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 
 const propTypes = {
   /**

--- a/packages/terra-table/src/TableRow.jsx
+++ b/packages/terra-table/src/TableRow.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 
 const propTypes = {
   /**

--- a/packages/terra-table/src/TableRows.jsx
+++ b/packages/terra-table/src/TableRows.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import 'terra-base/lib/baseStyles';
 import TableRow from './TableRow';
 
 const propTypes = {

--- a/packages/terra-title/package.json
+++ b/packages/terra-title/package.json
@@ -42,6 +42,7 @@
     "terra-mixins": "^1.0.0"
   },
   "dependencies": {
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   }
 }


### PR DESCRIPTION
### Summary
Currently our `<Base />` component is used to set minimal global styles for an application. This includes CSS to help normalize box-sizing, reset margins/paddings, and define global font styles. For it to work as intended, it requires consumers to import `terra-base` before the other terra components in their app. This is to help ensure that these styles are defined at the beginning of the extracted stylesheet and are inherited down to the other terra components correctly. 

This is an implicit dependency that is hard to define and communicate to consumers. We've used peerDependencies to make consumers aware when they download a component like terra-button, it has a theres a relation to terra-base. But it requires them to go read the [terra-base doc](http://engineering.cerner.com/terra-core/#/site/base) and have some understanding of how CSS inheritance works (setting fonts on html to set fonts for all elements) and webpack's text extract plugin behavior. We talked about using react's context API to warn users if terra components are rendered outside of `<Base>` but quickly realized how much of pain this would be to maintain / write up for each component.

This code change in this PR works to make the dependency more explicit and allow components to be rendered independently of being within `<Base>`. This is achieved by adding terra-base as a dependency to all terra component's package.json file. In addition, a JS file has been imported into all terra components that will load the base styles / check HTML element for proper attribute (terra-Base class and dir attribute). This file contains a check to ensure that global styles are only loaded once in an application when a consumer uses a terra component.

The impact of this change is a consumer can use any terra component, button, form, table and the base styles will be loaded correctly in the CSS file coming before the component styles. And these base styles will only be loaded once per application. The consumer no longer needs to be as aware of the dependency of the base styles and the component styles.

This change makes the react `<Base />` component of little value, however we've discussed using as a entry point for setting locale, translations, and possibly themes. For the time being, I'm keeping it around, mainly to maintain passivity and to hold on to it until we decide more of what we are gonna do with i18n.

If you pull down this branch and run the webpack dev server, note that none of the components are rendered within `<Base>`, though base styles are style added to the CSS file.


Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
