### PR TITLE
ButtonGroup focus ring fix.

### DIFF
--- a/packages/terra-button-group/lib/ButtonGroup.scss
+++ b/packages/terra-button-group/lib/ButtonGroup.scss
@@ -2,5 +2,6 @@
 
 .terra-ButtonGroup {
   display: inline-block;
+  position: relative;
   white-space: nowrap;
 }

--- a/packages/terra-button-group/lib/ButtonGroupButton.scss
+++ b/packages/terra-button-group/lib/ButtonGroupButton.scss
@@ -9,7 +9,12 @@
   border-width: 1px;
   margin-bottom: 0;
   margin-top: 0;
-  outline: 0;
+  position: relative;
+
+  &:focus {
+    // A z-index needs to be added on focus so that the focus ring does not get hidden behind adjacent buttons
+    z-index: $terra-z-index-1;
+  }
 }
 
 .terra-ButtonGroupButton + .terra-ButtonGroupButton {

--- a/packages/terra-button-group/src/ButtonGroup.scss
+++ b/packages/terra-button-group/src/ButtonGroup.scss
@@ -2,5 +2,6 @@
 
 .terra-ButtonGroup {
   display: inline-block;
+  position: relative;
   white-space: nowrap;
 }

--- a/packages/terra-button-group/src/ButtonGroupButton.scss
+++ b/packages/terra-button-group/src/ButtonGroupButton.scss
@@ -9,7 +9,12 @@
   border-width: 1px;
   margin-bottom: 0;
   margin-top: 0;
-  outline: 0;
+  position: relative;
+
+  &:focus {
+    // A z-index needs to be added on focus so that the focus ring does not get hidden behind adjacent buttons
+    z-index: $terra-z-index-1;
+  }
 }
 
 .terra-ButtonGroupButton + .terra-ButtonGroupButton {


### PR DESCRIPTION
### Summary
Allow default browser focus ring to show. A z-index is needed on focus so that parts of the focus ring do not get hidden behind adjacent ButtonGroup.Buttons

@cerner/terra
