### PR TITLE
Add layout / homepage content to terra-site

### DIFF
--- a/packages/terra-site/README.md
+++ b/packages/terra-site/README.md
@@ -1,1 +1,40 @@
-# Terra Site
+<!-- Logo -->
+<p align="center">
+  <img height="128" width="128" src="https://github.com/cerner/terra-core/raw/master/terra.png">
+</p>
+
+<!-- Name -->
+<h1 align="center">
+  Terra Core
+</h1>
+
+[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
+
+- [Supported Browsers](#supported-browsers)
+- [Contributing](#contributing)
+- [LICENSE](#license)
+
+
+## Supported Browsers
+
+| Browser                     | Version |
+|-----------------------------|---------|
+| Chrome & Chrome for Android | Current |
+| Edge                        | Current |
+| Firefox                     | Current |
+| Internet Explorer           | 10 & 11 |
+| Safari & Mobile Safari      | Current |
+
+## Contributing
+
+Please read through our [contributing guidelines](https://github.com/cerner/terra-core/blob/master/CONTRIBUTING.md). Included are directions for issue reporting and pull requests.
+
+## LICENSE
+
+Copyright 2017 Cerner Innovation, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+&nbsp;&nbsp;&nbsp;&nbsp;http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/packages/terra-site/src/App.jsx
+++ b/packages/terra-site/src/App.jsx
@@ -2,6 +2,8 @@
 import Base from 'terra-base';
 import React from 'react';
 import { Link } from 'react-router';
+import Grid from 'terra-grid';
+import List from 'terra-list';
 import './site.scss';
 
 const propTypes = {
@@ -10,35 +12,43 @@ const propTypes = {
 
 const App = props => (
   <Base>
-    <div dir="ltr">
-      <button onClick={() => document.getElementsByTagName('html')[0].setAttribute('dir', 'ltr')} >ltr</button>
-      <button onClick={() => document.getElementsByTagName('html')[0].setAttribute('dir', 'rtl')} >rtl</button>
-    </div>
-    <ul dir="ltr">
-      <li><Link to="/">Home</Link></li>
-      <li><Link to="/site/arrange">Arrange</Link></li>
-      <li><Link to="/site/base">Base</Link></li>
-      <li><Link to="/site/badge">Badge</Link></li>
-      <li><Link to="/site/button">Button</Link></li>
-      <li><Link to="/site/button-group">Button Group</Link></li>
-      <li><Link to="/site/content">Content</Link></li>
-      <li><Link to="/site/content-container">Content Container</Link></li>
-      <li><Link to="/site/datepicker">Date Picker</Link></li>
-      <li><Link to="/site/grid">Grid</Link></li>
-      <li><Link to="/site/i18n">I18n</Link></li>
-      <li><Link to="/site/icon">Icon</Link></li>
-      <li><Link to="/site/image">Image</Link></li>
-      <li><Link to="/site/list">List</Link></li>
-      <li><Link to="/site/progress-bar">Progress Bar</Link></li>
-      <li><Link to="/site/responsive-element">Responsive Element</Link></li>
-      <li><Link to="/site/slide-panel">Slide Panel</Link></li>
-      <li><Link to="/site/standout">Standout</Link></li>
-      <li><Link to="/site/status">Status</Link></li>
-      <li><Link to="/site/table">Table</Link></li>
-      <li><Link to="/site/title">Title</Link></li>
-      <li><Link to="/tests">Tests</Link></li>
-    </ul>
-    {props.children}
+    <Grid>
+      <Grid.Row>
+        <Grid.Column small={2}>
+          <div dir="ltr">
+            <button onClick={() => document.getElementsByTagName('html')[0].setAttribute('dir', 'ltr')} >ltr</button>
+            <button onClick={() => document.getElementsByTagName('html')[0].setAttribute('dir', 'rtl')} >rtl</button>
+          </div>
+          <List className="site-nav">
+            <List.Item content={<Link to="/">Home</Link>} />
+            <List.Item content={<Link to="/site/arrange">Arrange</Link>} />
+            <List.Item content={<Link to="/site/base">Base</Link>} />
+            <List.Item content={<Link to="/site/badge">Badge</Link>} />
+            <List.Item content={<Link to="/site/button">Button</Link>} />
+            <List.Item content={<Link to="/site/button-group">Button Group</Link>} />
+            <List.Item content={<Link to="/site/content">Content</Link>} />
+            <List.Item content={<Link to="/site/content-container">Content Container</Link>} />
+            <List.Item content={<Link to="/site/datepicker">Date Picker</Link>} />
+            <List.Item content={<Link to="/site/grid">Grid</Link>} />
+            <List.Item content={<Link to="/site/i18n">I18n</Link>} />
+            <List.Item content={<Link to="/site/icon">Icon</Link>} />
+            <List.Item content={<Link to="/site/image">Image</Link>} />
+            <List.Item content={<Link to="/site/list">List</Link>} />
+            <List.Item content={<Link to="/site/progress-bar">Progress Bar</Link>} />
+            <List.Item content={<Link to="/site/responsive-element">Responsive Element</Link>} />
+            <List.Item content={<Link to="/site/slide-panel">Slide Panel</Link>} />
+            <List.Item content={<Link to="/site/standout">Standout</Link>} />
+            <List.Item content={<Link to="/site/status">Status</Link>} />
+            <List.Item content={<Link to="/site/table">Table</Link>} />
+            <List.Item content={<Link to="/site/title">Title</Link>} />
+            <List.Item content={<Link to="/tests">Tests</Link>} />
+          </List>
+        </Grid.Column>
+        <Grid.Column small={10}>
+          {props.children}
+        </Grid.Column>
+      </Grid.Row>
+    </Grid>
   </Base>
 );
 

--- a/packages/terra-site/src/site.scss
+++ b/packages/terra-site/src/site.scss
@@ -13,3 +13,10 @@
   background-color: #eee;
   padding: 10px;
 }
+
+.site-nav {
+  & > li {
+    font-size: 1.25rem;
+    padding: 0.5rem 0;
+  }
+}


### PR DESCRIPTION
### Summary
Updated functional site to use Grid for temporary layout and added more content to homepage to prevent Chrome from incorrectly detecting the page's default language.

## Before
<img width="1421" alt="screen shot 2017-04-21 at 1 29 14 pm" src="https://cloud.githubusercontent.com/assets/633148/25291162/8b986daa-2696-11e7-8cb7-7b1d74223354.png">

## After
<img width="1440" alt="screen shot 2017-04-21 at 1 27 26 pm" src="https://cloud.githubusercontent.com/assets/633148/25291149/7e07ee0e-2696-11e7-8961-3356e3c433b2.png">


Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
