### PR TITLE
Fix clean:install error with removing rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "clean:all": "rimraf ./node_modules && rimraf ./packages/*/node_modules",
+    "clean:all": "rimraf ./packages/*/node_modules && rimraf ./node_modules",
     "clean:install": "npm run clean:all && npm install",
     "clean:obsolete-snapshots": "npm test -- -u",
     "compile": "lerna run compile",


### PR DESCRIPTION
### Summary
When running `npm run clean:install`, the command removes the `node_modules` dir in the root directory and then runs a command that uses a package that was in the `node_modules` dir in the root directory. This results in an error of `rimraf` not being found since it is removed by first command that removes the `node_modules` dir in the root directory. 

By flipping the order of the commands, it ensures the rimraf package is available for all commands in the `npm run clean:install` script.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
