### PR TITLE
Fix Table.Rows Rendering Error for One Child

### DIFF
--- a/packages/terra-table/lib/TableRows.js
+++ b/packages/terra-table/lib/TableRows.js
@@ -39,7 +39,7 @@ var defaultProps = {
 };
 
 function cloneChildItems(children, onClick, onKeyDown) {
-  return children.map(function (child) {
+  return _react2.default.Children.map(children, function (child) {
     var newProps = {};
     if (onClick) {
       newProps.onClick = onClick;

--- a/packages/terra-table/src/TableRows.jsx
+++ b/packages/terra-table/src/TableRows.jsx
@@ -23,7 +23,7 @@ const defaultProps = {
 };
 
 function cloneChildItems(children, onClick, onKeyDown) {
-  return children.map((child) => {
+  return React.Children.map(children, (child) => {
     const newProps = {};
     if (onClick) {
       newProps.onClick = onClick;

--- a/packages/terra-table/tests/jest/TableRows.test.jsx
+++ b/packages/terra-table/tests/jest/TableRows.test.jsx
@@ -16,3 +16,15 @@ it('should render TableRows tag', () => {
   const tableRows = shallow(defaultTableRows);
   expect(tableRows).toMatchSnapshot();
 });
+
+it('should render with one row', () => {
+  const defaultTableRows = <Table.Rows>{[row1]}</Table.Rows>;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+});
+
+it('should render with multiple rows', () => {
+  const defaultTableRows = <Table.Rows>{rows}</Table.Rows>;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+});

--- a/packages/terra-table/tests/jest/__snapshots__/TableRows.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableRows.test.jsx.snap
@@ -20,3 +20,40 @@ exports[`test should render TableRows tag 1`] = `
   </TableRow>
 </tbody>
 `;
+
+exports[`test should render with multiple rows 1`] = `
+<tbody>
+  <TableRow
+    isSelected={false}>
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    isSelected={false}>
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</tbody>
+`;
+
+exports[`test should render with one row 1`] = `
+<tbody>
+  <TableRow
+    isSelected={false}>
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</tbody>
+`;

--- a/packages/terra-table/tests/nightwatch/TableTestRoutes.jsx
+++ b/packages/terra-table/tests/nightwatch/TableTestRoutes.jsx
@@ -6,6 +6,7 @@ import TableTests from './TableTests';
 import DefaultTable from './components/StripedTable';
 import NoStripedTable from './components/NoStripedTable';
 import NoPaddingTable from './components/NoPaddingTable';
+import SingleRowTable from './components/SingleRowTable';
 import SingleRowSelectableTable from './components/SingleRowSelectableTable';
 import TableWithHighlightedRows from './components/TableWithHighlightedRows';
 import TableWithSortIndicator from './components/TableWithSortIndicator';
@@ -16,6 +17,7 @@ const routes = (
     <Route path="/tests/table-tests/default" component={DefaultTable} />
     <Route path="/tests/table-tests/no-striped" component={NoStripedTable} />
     <Route path="/tests/table-tests/no-padding" component={NoPaddingTable} />
+    <Route path="/tests/table-tests/single-row-table" component={SingleRowTable} />
     <Route path="/tests/table-tests/selectable-table" component={SingleRowSelectableTable} />
     <Route path="/tests/table-tests/table-highlighted-rows" component={TableWithHighlightedRows} />
     <Route path="/tests/table-tests/table-sort-indicator" component={TableWithSortIndicator} />

--- a/packages/terra-table/tests/nightwatch/TableTests.jsx
+++ b/packages/terra-table/tests/nightwatch/TableTests.jsx
@@ -9,6 +9,7 @@ const TableTests = () => (
       <li><Link to="/tests/table-tests/default">Default Table</Link></li>
       <li><Link to="/tests/table-tests/no-striped">No Striped Table</Link></li>
       <li><Link to="/tests/table-tests/no-padding">No Padding Table</Link></li>
+      <li><Link to="/tests/table-tests/single-row-table">Single Row Table</Link></li>
       <li><Link to="/tests/table-tests/selectable-table">Selectable Table</Link></li>
       <li><Link to="/tests/table-tests/table-highlighted-rows">Highlighted Rows Table</Link></li>
       <li><Link to="/tests/table-tests/table-sort-indicator">Sort Indicator Table Header</Link></li>

--- a/packages/terra-table/tests/nightwatch/components/SingleRowTable.jsx
+++ b/packages/terra-table/tests/nightwatch/components/SingleRowTable.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Table from '../../../lib/Table';
+
+const SingleRowTable = () => (
+  <Table isStriped={false}>
+    <Table.Header>
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+    </Table.Header>
+    <Table.Rows className="TableRows">
+      <Table.Row key={'PERSON_0'}>
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+    </Table.Rows>
+  </Table>
+);
+
+export default SingleRowTable;

--- a/packages/terra-table/tests/nightwatch/table-spec.js
+++ b/packages/terra-table/tests/nightwatch/table-spec.js
@@ -70,6 +70,13 @@ module.exports = {
       .assert.elementPresent('tr.terra-Table--isSelectable');
   },
 
+  'Displays a table with only one row': (browser) => {
+    browser
+      .url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/table-tests/single-row-table`);
+    browser.assert.elementPresent('.terra-Table-row:nth-child(1)');
+    browser.assert.elementNotPresent('.terra-Table-row:nth-child(2)');
+  },
+
   'Display a table highlighting rows upon clicking': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/table-tests/selectable-table`);
     browser.click('.terra-Table-row:nth-child(1)');


### PR DESCRIPTION
### Summary
Updated Rows to handle zero-many children by using React.Children.map.
Addresses #254 

@cerner/terra
