### PR TITLE
Add onRequestClose prop to Modal to ensure state is driven purely by consuming components

### DIFF
--- a/packages/terra-modal/docs/README.md
+++ b/packages/terra-modal/docs/README.md
@@ -41,6 +41,7 @@ class MyApp extends React.Component {
         <Modal
           ariaLabel="My Modal"
           isOpened={this.state.isOpened}
+          onRequestClose={this.handleCloseModal}
         >
           <div>
             <h1>My Modal</h1>

--- a/packages/terra-modal/lib/Modal.js
+++ b/packages/terra-modal/lib/Modal.js
@@ -174,8 +174,6 @@ var Modal = function (_React$Component) {
         _reactPortal2.default,
         _extends({
           isOpened: isOpened,
-          closeOnEsc: false,
-          closeOnOutsideClick: false,
           onClose: onClose,
           onOpen: onOpen,
           onUpdate: onUpdate,

--- a/packages/terra-modal/lib/Modal.js
+++ b/packages/terra-modal/lib/Modal.js
@@ -131,21 +131,17 @@ var Modal = function (_React$Component) {
   _createClass(Modal, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
-      if (this.props.closeOnEsc) {
-        document.addEventListener('keydown', this.handleKeydown);
-      }
+      document.addEventListener('keydown', this.handleKeydown);
     }
   }, {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
-      if (this.props.closeOnEsc) {
-        document.removeEventListener('keydown', this.handleKeydown);
-      }
+      document.removeEventListener('keydown', this.handleKeydown);
     }
   }, {
     key: 'handleKeydown',
     value: function handleKeydown(e) {
-      if (e.keyCode === KEYCODES.ESCAPE && this.props.isOpened) {
+      if (e.keyCode === KEYCODES.ESCAPE && this.props.isOpened && this.props.closeOnEsc) {
         this.props.onRequestClose();
       }
     }

--- a/packages/terra-modal/lib/Modal.js
+++ b/packages/terra-modal/lib/Modal.js
@@ -70,7 +70,7 @@ var propTypes = {
   /**
    * If set to true, the modal will rendered as opened
    **/
-  isOpened: _react.PropTypes.bool,
+  isOpened: _react.PropTypes.bool.isRequired,
   /**
    * If set to true, the modal dialog with have overflow-y set to scroll.
    * It is recommended not to use this prop and instead create a HOC
@@ -85,6 +85,10 @@ var propTypes = {
    * This callback is called when the modal is opened and rendered (useful for animating the DOMNode).
    **/
   onOpen: _react.PropTypes.func,
+  /**
+   * Function to set isOpened={false} and close the modal.
+   **/
+  onRequestClose: _react.PropTypes.func.isRequired,
   /**
    * This callback is called when the modal is (re)rendered.
    **/
@@ -108,7 +112,9 @@ var defaultProps = {
   role: 'document'
 };
 
-/* eslint-disable react/prefer-stateless-function */
+var KEYCODES = {
+  ESCAPE: 27
+};
 
 var Modal = function (_React$Component) {
   _inherits(Modal, _React$Component);
@@ -116,10 +122,27 @@ var Modal = function (_React$Component) {
   function Modal() {
     _classCallCheck(this, Modal);
 
-    return _possibleConstructorReturn(this, (Modal.__proto__ || Object.getPrototypeOf(Modal)).apply(this, arguments));
+    var _this = _possibleConstructorReturn(this, (Modal.__proto__ || Object.getPrototypeOf(Modal)).call(this));
+
+    _this.handleKeydown = _this.handleKeydown.bind(_this);
+    return _this;
   }
 
   _createClass(Modal, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      if (this.props.closeOnEsc) {
+        document.addEventListener('keydown', this.handleKeydown);
+      }
+    }
+  }, {
+    key: 'handleKeydown',
+    value: function handleKeydown(e) {
+      if (e.keyCode === KEYCODES.ESCAPE && this.props.isOpened) {
+        this.props.onRequestClose();
+      }
+    }
+  }, {
     key: 'render',
     value: function render() {
       var _props = this.props,
@@ -137,14 +160,15 @@ var Modal = function (_React$Component) {
           onOpen = _props.onOpen,
           onUpdate = _props.onUpdate,
           role = _props.role,
-          customProps = _objectWithoutProperties(_props, ['ariaLabel', 'beforeClose', 'children', 'classNameModal', 'classNameOverlay', 'closeOnEsc', 'closeOnOutsideClick', 'isFullscreen', 'isOpened', 'isScrollable', 'onClose', 'onOpen', 'onUpdate', 'role']);
+          onRequestClose = _props.onRequestClose,
+          customProps = _objectWithoutProperties(_props, ['ariaLabel', 'beforeClose', 'children', 'classNameModal', 'classNameOverlay', 'closeOnEsc', 'closeOnOutsideClick', 'isFullscreen', 'isOpened', 'isScrollable', 'onClose', 'onOpen', 'onUpdate', 'role', 'onRequestClose']);
 
       return _react2.default.createElement(
         _reactPortal2.default,
         _extends({
           isOpened: isOpened,
-          closeOnEsc: closeOnEsc,
-          closeOnOutsideClick: closeOnOutsideClick,
+          closeOnEsc: false,
+          closeOnOutsideClick: false,
           onClose: onClose,
           onOpen: onOpen,
           onUpdate: onUpdate,
@@ -159,7 +183,8 @@ var Modal = function (_React$Component) {
             classNameOverlay: classNameOverlay,
             role: role,
             isFullscreen: isFullscreen,
-            isScrollable: isScrollable
+            isScrollable: isScrollable,
+            onRequestClose: onRequestClose
           },
           children
         )

--- a/packages/terra-modal/lib/Modal.js
+++ b/packages/terra-modal/lib/Modal.js
@@ -136,6 +136,13 @@ var Modal = function (_React$Component) {
       }
     }
   }, {
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      if (this.props.closeOnEsc) {
+        document.removeEventListener('keydown', this.handleKeydown);
+      }
+    }
+  }, {
     key: 'handleKeydown',
     value: function handleKeydown(e) {
       if (e.keyCode === KEYCODES.ESCAPE && this.props.isOpened) {

--- a/packages/terra-modal/lib/ModalContent.js
+++ b/packages/terra-modal/lib/ModalContent.js
@@ -42,7 +42,7 @@ var propTypes = {
   classNameModal: _react.PropTypes.string,
   classNameOverlay: _react.PropTypes.string,
   closeOnOutsideClick: _react.PropTypes.bool,
-  closePortal: _react.PropTypes.func,
+  onRequestClose: _react.PropTypes.func.isRequired,
   isFullscreen: _react.PropTypes.bool,
   isScrollable: _react.PropTypes.bool,
   role: _react.PropTypes.string
@@ -79,19 +79,22 @@ var ModalContent = function (_React$Component) {
           classNameModal = _props.classNameModal,
           classNameOverlay = _props.classNameOverlay,
           closeOnOutsideClick = _props.closeOnOutsideClick,
-          closePortal = _props.closePortal,
+          onRequestClose = _props.onRequestClose,
           role = _props.role,
           isFullscreen = _props.isFullscreen,
           isScrollable = _props.isScrollable,
-          customProps = _objectWithoutProperties(_props, ['ariaLabel', 'children', 'classNameModal', 'classNameOverlay', 'closeOnOutsideClick', 'closePortal', 'role', 'isFullscreen', 'isScrollable']);
+          customProps = _objectWithoutProperties(_props, ['ariaLabel', 'children', 'classNameModal', 'classNameOverlay', 'closeOnOutsideClick', 'onRequestClose', 'role', 'isFullscreen', 'isScrollable']);
 
       var modalClassName = (0, _classnames2.default)(['terra-Modal', { 'terra-Modal--fullscreen': isFullscreen }, { 'terra-Modal--scrollable': isScrollable }, classNameModal]);
+
+      // Delete the closePortal prop that comes from react-portal.
+      delete customProps.closePortal;
 
       return _react2.default.createElement(
         _focusTrapReact2.default,
         null,
         _react2.default.createElement(_ModalOverlay2.default, {
-          onClick: closeOnOutsideClick ? closePortal : null,
+          onClick: closeOnOutsideClick ? onRequestClose : null,
           className: classNameOverlay
         }),
         _react2.default.createElement(

--- a/packages/terra-modal/src/Modal.jsx
+++ b/packages/terra-modal/src/Modal.jsx
@@ -94,19 +94,15 @@ class Modal extends React.Component {
   }
 
   componentDidMount() {
-    if (this.props.closeOnEsc) {
-      document.addEventListener('keydown', this.handleKeydown);
-    }
+    document.addEventListener('keydown', this.handleKeydown);
   }
 
   componentWillUnmount() {
-    if (this.props.closeOnEsc) {
-      document.removeEventListener('keydown', this.handleKeydown);
-    }
+    document.removeEventListener('keydown', this.handleKeydown);
   }
 
   handleKeydown(e) {
-    if (e.keyCode === KEYCODES.ESCAPE && this.props.isOpened) {
+    if (e.keyCode === KEYCODES.ESCAPE && this.props.isOpened && this.props.closeOnEsc) {
       this.props.onRequestClose();
     }
   }

--- a/packages/terra-modal/src/Modal.jsx
+++ b/packages/terra-modal/src/Modal.jsx
@@ -41,7 +41,7 @@ const propTypes = {
   /**
    * If set to true, the modal will rendered as opened
    **/
-  isOpened: PropTypes.bool,
+  isOpened: PropTypes.bool.isRequired,
   /**
    * If set to true, the modal dialog with have overflow-y set to scroll.
    * It is recommended not to use this prop and instead create a HOC
@@ -56,6 +56,10 @@ const propTypes = {
    * This callback is called when the modal is opened and rendered (useful for animating the DOMNode).
    **/
   onOpen: PropTypes.func,
+  /**
+   * Function to set isOpened={false} and close the modal.
+   **/
+  onRequestClose: PropTypes.func.isRequired,
   /**
    * This callback is called when the modal is (re)rendered.
    **/
@@ -79,8 +83,28 @@ const defaultProps = {
   role: 'document',
 };
 
-/* eslint-disable react/prefer-stateless-function */
+const KEYCODES = {
+  ESCAPE: 27,
+};
+
 class Modal extends React.Component {
+  constructor() {
+    super();
+    this.handleKeydown = this.handleKeydown.bind(this);
+  }
+
+  componentDidMount() {
+    if (this.props.closeOnEsc) {
+      document.addEventListener('keydown', this.handleKeydown);
+    }
+  }
+
+  handleKeydown(e) {
+    if (e.keyCode === KEYCODES.ESCAPE && this.props.isOpened) {
+      this.props.onRequestClose();
+    }
+  }
+
   render() {
     const {
           ariaLabel,
@@ -97,13 +121,14 @@ class Modal extends React.Component {
           onOpen,
           onUpdate,
           role,
+          onRequestClose,
            ...customProps } = this.props;
 
     return (
       <Portal
         isOpened={isOpened}
-        closeOnEsc={closeOnEsc}
-        closeOnOutsideClick={closeOnOutsideClick}
+        closeOnEsc={false}
+        closeOnOutsideClick={false}
         onClose={onClose}
         onOpen={onOpen}
         onUpdate={onUpdate}
@@ -118,6 +143,7 @@ class Modal extends React.Component {
           role={role}
           isFullscreen={isFullscreen}
           isScrollable={isScrollable}
+          onRequestClose={onRequestClose}
         >
           {children}
         </ModalContent>

--- a/packages/terra-modal/src/Modal.jsx
+++ b/packages/terra-modal/src/Modal.jsx
@@ -133,8 +133,6 @@ class Modal extends React.Component {
     return (
       <Portal
         isOpened={isOpened}
-        closeOnEsc={false}
-        closeOnOutsideClick={false}
         onClose={onClose}
         onOpen={onOpen}
         onUpdate={onUpdate}

--- a/packages/terra-modal/src/Modal.jsx
+++ b/packages/terra-modal/src/Modal.jsx
@@ -99,6 +99,12 @@ class Modal extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    if (this.props.closeOnEsc) {
+      document.removeEventListener('keydown', this.handleKeydown);
+    }
+  }
+
   handleKeydown(e) {
     if (e.keyCode === KEYCODES.ESCAPE && this.props.isOpened) {
       this.props.onRequestClose();

--- a/packages/terra-modal/src/ModalContent.jsx
+++ b/packages/terra-modal/src/ModalContent.jsx
@@ -10,7 +10,7 @@ const propTypes = {
   classNameModal: PropTypes.string,
   classNameOverlay: PropTypes.string,
   closeOnOutsideClick: PropTypes.bool,
-  closePortal: PropTypes.func,
+  onRequestClose: PropTypes.func.isRequired,
   isFullscreen: PropTypes.bool,
   isScrollable: PropTypes.bool,
   role: PropTypes.string,
@@ -36,7 +36,7 @@ class ModalContent extends React.Component {
         classNameModal,
         classNameOverlay,
         closeOnOutsideClick,
-        closePortal,
+        onRequestClose,
         role,
         isFullscreen,
         isScrollable,
@@ -48,10 +48,13 @@ class ModalContent extends React.Component {
       classNameModal,
     ]);
 
+    // Delete the closePortal prop that comes from react-portal.
+    delete customProps.closePortal;
+
     return (
       <FocusTrap>
         <ModalOverlay
-          onClick={closeOnOutsideClick ? closePortal : null}
+          onClick={closeOnOutsideClick ? onRequestClose : null}
           className={classNameOverlay}
         />
         <div

--- a/packages/terra-modal/tests/jest/ModalExample.jsx
+++ b/packages/terra-modal/tests/jest/ModalExample.jsx
@@ -28,6 +28,7 @@ class ModalExample extends React.Component {
         <Modal
           ariaLabel="Terra Modal"
           isOpened={this.state.isOpened}
+          onRequestClose={this.handleCloseModal}
         >
           <div>
             <h1>Terra Modal</h1>

--- a/packages/terra-modal/tests/jest/__snapshots__/Modal.test.jsx.snap
+++ b/packages/terra-modal/tests/jest/__snapshots__/Modal.test.jsx.snap
@@ -10,10 +10,11 @@ exports[`test should mount an open modal 1`] = `
       isFullscreen={false}
       isOpened={true}
       isScrollable={false}
+      onRequestClose={[Function]}
       role="document">
       <Portal
-        closeOnEsc={true}
-        closeOnOutsideClick={true}
+        closeOnEsc={false}
+        closeOnOutsideClick={false}
         isOpened={true}
         onClose={[Function]}
         onOpen={[Function]}
@@ -46,6 +47,7 @@ exports[`test should shallow an open modal 1`] = `
     isFullscreen={false}
     isOpened={true}
     isScrollable={false}
+    onRequestClose={[Function]}
     role="document">
     <div>
       <h1>

--- a/packages/terra-modal/tests/jest/__snapshots__/Modal.test.jsx.snap
+++ b/packages/terra-modal/tests/jest/__snapshots__/Modal.test.jsx.snap
@@ -13,8 +13,6 @@ exports[`test should mount an open modal 1`] = `
       onRequestClose={[Function]}
       role="document">
       <Portal
-        closeOnEsc={false}
-        closeOnOutsideClick={false}
         isOpened={true}
         onClose={[Function]}
         onOpen={[Function]}

--- a/packages/terra-modal/tests/nightwatch/ModalTests.jsx
+++ b/packages/terra-modal/tests/nightwatch/ModalTests.jsx
@@ -15,7 +15,6 @@ const ModalTests = () => (
       <li><Link to="/tests/modal-tests/is-fullscreen">Fullscreen</Link></li>
       <li><Link to="/tests/modal-tests/is-open">Using isOpen prop</Link></li>
       <li><Link to="/tests/modal-tests/no-focusable-content">No Focusable Content</Link></li>
-      <li><Link to="/tests/modal-tests/open-by-click-on">Using openByClickOn prop</Link></li>
       <li><Link to="/tests/modal-tests/override-role">Override Role</Link></li>
       <li><Link to="/tests/modal-tests/scrollable-true">Scrollable True</Link></li>
       <li><Link to="/tests/modal-tests/scrollable-false">Scrollable False</Link></li>

--- a/packages/terra-modal/tests/nightwatch/components/ModalAppendClass.jsx
+++ b/packages/terra-modal/tests/nightwatch/components/ModalAppendClass.jsx
@@ -31,6 +31,7 @@ class ModalAppendClass extends React.Component {
           classNameModal="modal-custom-class"
           ariaLabel="Terra Modal"
           isOpened={this.state.isOpened}
+          onRequestClose={this.handleCloseModal}
         >
           <div>
             <h1>Terra Modal</h1>

--- a/packages/terra-modal/tests/nightwatch/components/ModalContentOverflow.jsx
+++ b/packages/terra-modal/tests/nightwatch/components/ModalContentOverflow.jsx
@@ -27,6 +27,7 @@ class ModalContentOverflow extends React.Component {
         <Modal
           ariaLabel="Terra Modal"
           isOpened={this.state.isOpened}
+          onRequestClose={this.handleCloseModal}
         >
           <div>
             <h1>Terra Modal</h1>

--- a/packages/terra-modal/tests/nightwatch/components/ModalDialog.jsx
+++ b/packages/terra-modal/tests/nightwatch/components/ModalDialog.jsx
@@ -33,6 +33,7 @@ class ModalDialog extends React.Component {
         <Modal
           ariaLabel="Terra Modal"
           isOpened={this.state.isOpened}
+          onRequestClose={this.handleCloseModal}
         >
           <div>
             <ModalHeader>

--- a/packages/terra-modal/tests/nightwatch/components/ModalDisableCloseOnEsc.jsx
+++ b/packages/terra-modal/tests/nightwatch/components/ModalDisableCloseOnEsc.jsx
@@ -26,6 +26,7 @@ class ModalDisableCloseOnEsc extends React.Component {
         <Modal
           ariaLabel="Terra Modal"
           isOpened={this.state.isOpened}
+          onRequestClose={this.handleCloseModal}
           closeOnEsc={false}
         >
           <div>

--- a/packages/terra-modal/tests/nightwatch/components/ModalDisableCloseOnOutsideClick.jsx
+++ b/packages/terra-modal/tests/nightwatch/components/ModalDisableCloseOnOutsideClick.jsx
@@ -27,6 +27,7 @@ class ModalDisableCloseOnOutsideClick extends React.Component {
           ariaLabel="Terra Modal"
           isOpened={this.state.isOpened}
           closeOnOutsideClick={false}
+          onRequestClose={this.handleCloseModal}
         >
           <div>
             <h1>Terra Modal</h1>

--- a/packages/terra-modal/tests/nightwatch/components/ModalEventHooks.jsx
+++ b/packages/terra-modal/tests/nightwatch/components/ModalEventHooks.jsx
@@ -23,32 +23,38 @@ class ModalEventHooks extends React.Component {
   handleOnOpen(node) {
     const onOpenElement = document.getElementById('onOpen');
     onOpenElement.innerHTML = 'onOpen: Called';
+    console.log('onOpen');
   }
 
   handleOnClose() {
     const onOpenElement = document.getElementById('onClose');
     onOpenElement.innerHTML = 'onClose: Called';
+    console.log('onClose');
   }
 
   handleOnUpdate() {
     const onOpenElement = document.getElementById('onUpdate');
     onOpenElement.innerHTML = 'onUpdate: Called';
+    console.log('onUpdate');
   }
 
   handleBeforeClose(node, callback) {
     const onOpenElement = document.getElementById('beforeClose');
     onOpenElement.innerHTML = 'beforeClose: Called';
+    console.log('beforeClose');
     callback();
   }
-  /* eslint-enable */
 
   handleOpenModal() {
     this.setState({ isOpened: true });
+    console.log('handleOpenModal');
   }
 
   handleCloseModal() {
     this.setState({ isOpened: false });
+    console.log('handleCloseModal == onRequestClose');
   }
+  /* eslint-enable */
 
   render() {
     return (
@@ -60,6 +66,7 @@ class ModalEventHooks extends React.Component {
           onClose={this.handleOnClose}
           onUpdate={this.handleOnUpdate}
           beforeClose={this.handleBeforeClose}
+          onRequestClose={this.handleCloseModal}
         >
           <div>
             <h1>Terra Modal</h1>

--- a/packages/terra-modal/tests/nightwatch/components/ModalIsFullscreen.jsx
+++ b/packages/terra-modal/tests/nightwatch/components/ModalIsFullscreen.jsx
@@ -28,6 +28,7 @@ class ModalIsFullscreen extends React.Component {
           ariaLabel="Terra Modal"
           isOpened={this.state.isOpened}
           isFullscreen
+          onRequestClose={this.handleCloseModal}
         >
           <div>
             <h1>Terra Modal</h1>

--- a/packages/terra-modal/tests/nightwatch/components/ModalIsOpen.jsx
+++ b/packages/terra-modal/tests/nightwatch/components/ModalIsOpen.jsx
@@ -28,6 +28,7 @@ class ModalIsOpen extends React.Component {
         <Modal
           ariaLabel="Terra Modal"
           isOpened={this.state.isOpened}
+          onRequestClose={this.handleCloseModal}
         >
           <div>
             <h1>Terra Modal</h1>

--- a/packages/terra-modal/tests/nightwatch/components/ModalNoFocusableContent.jsx
+++ b/packages/terra-modal/tests/nightwatch/components/ModalNoFocusableContent.jsx
@@ -28,6 +28,7 @@ class ModalNoFocusableContent extends React.Component {
         <Modal
           ariaLabel="Terra Modal"
           isOpened={this.state.isOpened}
+          onRequestClose={this.handleCloseModal}
         >
           <div>No focusable content inside the modal.</div>
         </Modal>

--- a/packages/terra-modal/tests/nightwatch/components/ModalOverrideRole.jsx
+++ b/packages/terra-modal/tests/nightwatch/components/ModalOverrideRole.jsx
@@ -28,6 +28,7 @@ class ModalOverrideRole extends React.Component {
         <Modal
           ariaLabel="Terra Modal"
           isOpened={this.state.isOpened}
+          onRequestClose={this.handleCloseModal}
           role={newRole}
         >
           <div>

--- a/packages/terra-modal/tests/nightwatch/components/ModalScrollableFalse.jsx
+++ b/packages/terra-modal/tests/nightwatch/components/ModalScrollableFalse.jsx
@@ -27,6 +27,7 @@ class ModalScrollableFalse extends React.Component {
         <Modal
           ariaLabel="Terra Modal"
           isOpened={this.state.isOpened}
+          onRequestClose={this.handleCloseModal}
           isScrollable={false}
         >
           <div>

--- a/packages/terra-modal/tests/nightwatch/components/ModalScrollableTrue.jsx
+++ b/packages/terra-modal/tests/nightwatch/components/ModalScrollableTrue.jsx
@@ -27,6 +27,7 @@ class ModalScrollableTrue extends React.Component {
         <Modal
           ariaLabel="Terra Modal"
           isOpened={this.state.isOpened}
+          onRequestClose={this.handleCloseModal}
           isScrollable
         >
           <div>

--- a/packages/terra-site/src/examples/modal/ModalDisableCloseOnEscCloseOnOutsideClick.jsx
+++ b/packages/terra-site/src/examples/modal/ModalDisableCloseOnEscCloseOnOutsideClick.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Modal from 'terra-modal';
+import Modal from 'terra-modal/src/Modal';
 
 class ModalDisableCloseOnEscCloseOnOutsideClick extends React.Component {
   constructor() {
@@ -29,6 +29,7 @@ class ModalDisableCloseOnEscCloseOnOutsideClick extends React.Component {
           isOpened={this.state.isOpened}
           closeOnEsc={false}
           closeOnOutsideClick={false}
+          onRequestClose={this.handleCloseModal}
         >
           <div>
             <h1>Terra Modal</h1>

--- a/packages/terra-site/src/examples/modal/ModalDisableCloseOnEscCloseOnOutsideClick.jsx
+++ b/packages/terra-site/src/examples/modal/ModalDisableCloseOnEscCloseOnOutsideClick.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Modal from 'terra-modal/src/Modal';
+import Modal from 'terra-modal';
 
 class ModalDisableCloseOnEscCloseOnOutsideClick extends React.Component {
   constructor() {

--- a/packages/terra-site/src/examples/modal/ModalIsFullscreen.jsx
+++ b/packages/terra-site/src/examples/modal/ModalIsFullscreen.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Modal from 'terra-modal/src/Modal';
+import Modal from 'terra-modal';
 
 class ModalIsFullscreen extends React.Component {
   constructor() {

--- a/packages/terra-site/src/examples/modal/ModalIsFullscreen.jsx
+++ b/packages/terra-site/src/examples/modal/ModalIsFullscreen.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Modal from 'terra-modal';
+import Modal from 'terra-modal/src/Modal';
 
 class ModalIsFullscreen extends React.Component {
   constructor() {
@@ -33,6 +33,7 @@ class ModalIsFullscreen extends React.Component {
           onClose={this.onClose}
           onOpen={this.onOpen}
           onUpdate={this.onUpdate}
+          onRequestClose={this.handleCloseModal}
         >
           <div>
             <h1>Terra Modal</h1>

--- a/packages/terra-site/src/examples/modal/ModalIsOpened.jsx
+++ b/packages/terra-site/src/examples/modal/ModalIsOpened.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Modal from 'terra-modal/src/Modal';
+import Modal from 'terra-modal';
 
 class ModalIsOpened extends React.Component {
   constructor() {

--- a/packages/terra-site/src/examples/modal/ModalIsOpened.jsx
+++ b/packages/terra-site/src/examples/modal/ModalIsOpened.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Modal from 'terra-modal';
+import Modal from 'terra-modal/src/Modal';
 
 class ModalIsOpened extends React.Component {
   constructor() {
@@ -27,13 +27,14 @@ class ModalIsOpened extends React.Component {
         <Modal
           ariaLabel="Terra Modal"
           isOpened={this.state.isOpened}
+          onRequestClose={this.handleCloseModal}
         >
           <div>
             <h1>Terra Modal</h1>
-            <button onClick={this.handleCloseModal}>Close Modal</button>
+            <button onClick={this.handleCloseModal}>Close isOpen modal</button>
           </div>
         </Modal>
-        <button onClick={this.handleOpenModal}>Open Modal</button>
+        <button onClick={this.handleOpenModal}>Open isOpen modal</button>
       </div>
     );
   }


### PR DESCRIPTION
### Summary
For dismissing the modal with clicking on the overlay or pressing the esc key, we were using react-portal. This was not updating our isOpened state. This PR is correcting the value of the isOpened state.

https://github.com/cerner/terra-core/issues/293

After these changes, the isOpened state is accurate.
![isopened_state](https://cloud.githubusercontent.com/assets/8146159/25764956/02d795ca-31b0-11e7-832e-dfe33b7890db.gif)


Thanks for contributing to Terra. 
@cerner/terra
