### PR TITLE
Hard-code breakpoints for the responsive element on the motorola MC40

### DIFF
--- a/packages/terra-responsive-element/lib/breakpoints.js
+++ b/packages/terra-responsive-element/lib/breakpoints.js
@@ -1,7 +1,7 @@
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+    value: true
 });
 
 require('./breakpoints.scss');
@@ -13,24 +13,33 @@ var breakpoints = void 0;
  * @returns {Object} - Returns SASS defined breakpoints in pixels units as key value pairs
  */
 var getBreakpoints = function getBreakpoints() {
-  if (breakpoints) {
+    if (breakpoints) {
+        return breakpoints;
+    }
+
+    var data = void 0;
+    var datasource = document.createElement('div');
+    datasource.className = 'terra-Breakpoints';
+
+    document.body.appendChild(datasource);
+
+    data = window.getComputedStyle(datasource, ':before').getPropertyValue('content');
+    data = data.replace(/^['"]+|\s+|\\|(;\s?})+|['"]$/g, '');
+
+    try {
+        breakpoints = JSON.parse(data);
+    } catch (e) {
+        console.error(e);
+        console.error('JSON.parse(data) failed. data = ' + data);
+        console.info('If you have custom breakpoints, the values may be incorrect on this device');
+        // Temporary fix for the motorola MC40.
+        // See issue: https://github.com/cerner/terra-core/issues/304
+        breakpoints = { "tiny": 544, "small": 768, "medium": 992, "large": 1216, "huge": 1440 };
+    }
+
+    document.body.removeChild(datasource);
+
     return breakpoints;
-  }
-
-  var data = void 0;
-  var datasource = document.createElement('div');
-  datasource.className = 'terra-Breakpoints';
-
-  document.body.appendChild(datasource);
-
-  data = window.getComputedStyle(datasource, ':before').getPropertyValue('content');
-  data = data.replace(/^['"]+|\s+|\\|(;\s?})+|['"]$/g, '');
-
-  breakpoints = JSON.parse(data);
-
-  document.body.removeChild(datasource);
-
-  return breakpoints;
 };
 
 exports.default = getBreakpoints;

--- a/packages/terra-responsive-element/lib/breakpoints.js
+++ b/packages/terra-responsive-element/lib/breakpoints.js
@@ -1,7 +1,7 @@
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
-    value: true
+  value: true
 });
 
 require('./breakpoints.scss');
@@ -13,33 +13,36 @@ var breakpoints = void 0;
  * @returns {Object} - Returns SASS defined breakpoints in pixels units as key value pairs
  */
 var getBreakpoints = function getBreakpoints() {
-    if (breakpoints) {
-        return breakpoints;
-    }
-
-    var data = void 0;
-    var datasource = document.createElement('div');
-    datasource.className = 'terra-Breakpoints';
-
-    document.body.appendChild(datasource);
-
-    data = window.getComputedStyle(datasource, ':before').getPropertyValue('content');
-    data = data.replace(/^['"]+|\s+|\\|(;\s?})+|['"]$/g, '');
-
-    try {
-        breakpoints = JSON.parse(data);
-    } catch (e) {
-        console.error(e);
-        console.error('JSON.parse(data) failed. data = ' + data);
-        console.info('If you have custom breakpoints, the values may be incorrect on this device');
-        // Temporary fix for the motorola MC40.
-        // See issue: https://github.com/cerner/terra-core/issues/304
-        breakpoints = { "tiny": 544, "small": 768, "medium": 992, "large": 1216, "huge": 1440 };
-    }
-
-    document.body.removeChild(datasource);
-
+  if (breakpoints) {
     return breakpoints;
+  }
+
+  var data = void 0;
+  var datasource = document.createElement('div');
+  datasource.className = 'terra-Breakpoints';
+
+  document.body.appendChild(datasource);
+
+  data = window.getComputedStyle(datasource, ':before').getPropertyValue('content');
+  data = data.replace(/^['"]+|\s+|\\|(;\s?})+|['"]$/g, '');
+
+  try {
+    breakpoints = JSON.parse(data);
+  } catch (e) {
+    /* eslint-disable no-console */
+    console.error(e);
+    console.error('JSON.parse(data) failed. data = ' + data);
+    console.info('If you have custom breakpoints, the values may be incorrect on this device');
+    /* eslint-enable no-console */
+
+    // Temporary fix for the motorola MC40.
+    // See issue: https://github.com/cerner/terra-core/issues/304
+    breakpoints = { tiny: 544, small: 768, medium: 992, large: 1216, huge: 1440 };
+  }
+
+  document.body.removeChild(datasource);
+
+  return breakpoints;
 };
 
 exports.default = getBreakpoints;

--- a/packages/terra-responsive-element/src/breakpoints.js
+++ b/packages/terra-responsive-element/src/breakpoints.js
@@ -20,7 +20,16 @@ const getBreakpoints = () => {
   data = window.getComputedStyle(datasource, ':before').getPropertyValue('content');
   data = data.replace(/^['"]+|\s+|\\|(;\s?})+|['"]$/g, '');
 
-  breakpoints = JSON.parse(data);
+  try {
+      breakpoints = JSON.parse(data);
+  } catch(e) {
+      console.error(e);
+      console.error(`JSON.parse(data) failed. data = ${data}`);
+      console.info(`If you have custom breakpoints, the values may be incorrect on this device`);
+      // Temporary fix for the motorola MC40.
+      // See issue: https://github.com/cerner/terra-core/issues/304
+      breakpoints = {"tiny":544,"small":768,"medium":992,"large":1216,"huge":1440};
+  }
 
   document.body.removeChild(datasource);
 

--- a/packages/terra-responsive-element/src/breakpoints.js
+++ b/packages/terra-responsive-element/src/breakpoints.js
@@ -21,14 +21,17 @@ const getBreakpoints = () => {
   data = data.replace(/^['"]+|\s+|\\|(;\s?})+|['"]$/g, '');
 
   try {
-      breakpoints = JSON.parse(data);
-  } catch(e) {
-      console.error(e);
-      console.error(`JSON.parse(data) failed. data = ${data}`);
-      console.info(`If you have custom breakpoints, the values may be incorrect on this device`);
-      // Temporary fix for the motorola MC40.
-      // See issue: https://github.com/cerner/terra-core/issues/304
-      breakpoints = {"tiny":544,"small":768,"medium":992,"large":1216,"huge":1440};
+    breakpoints = JSON.parse(data);
+  } catch (e) {
+    /* eslint-disable no-console */
+    console.error(e);
+    console.error(`JSON.parse(data) failed. data = ${data}`);
+    console.info('If you have custom breakpoints, the values may be incorrect on this device');
+    /* eslint-enable no-console */
+
+    // Temporary fix for the motorola MC40.
+    // See issue: https://github.com/cerner/terra-core/issues/304
+    breakpoints = { tiny: 544, small: 768, medium: 992, large: 1216, huge: 1440 };
   }
 
   document.body.removeChild(datasource);


### PR DESCRIPTION
### Summary
- The breakpoints fail to be added to the terra-Breakpoints div content on the motorola MC40.

Now if the breakpoints do not exist, it falls back to hard-coded values:
```
breakpoints = {"tiny":544,"small":768,"medium":992,"large":1216,"huge":1440};
```

This change would only affect consumers using the MC40 with themeable breakpoints.  I think this is only a tempory solution. If we move to css-in-js, that would solve our issue.

Investigation on this issue can be found here: https://github.com/cerner/terra-core/issues/304

After this change, the demographics banner and the date picker both work on the MC40.

Thanks for contributing to Terra. 
@cerner/terra
