### PR TITLE
Nightwatch logging: quiet -> noInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,3 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
 &nbsp;&nbsp;&nbsp;&nbsp;http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-

--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
 &nbsp;&nbsp;&nbsp;&nbsp;http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+

--- a/packages/terra-toolkit/lib/server-launcher.js
+++ b/packages/terra-toolkit/lib/server-launcher.js
@@ -43,7 +43,7 @@ exports.launchServer = function () {
     compiler.plugin('done', resolve);
 
     module.server = new _webpackDevServer2.default(compiler, {
-      quiet: true
+      noInfo: true
     });
 
     module.server.listen(8080, '0.0.0.0');

--- a/packages/terra-toolkit/src/server-launcher.js
+++ b/packages/terra-toolkit/src/server-launcher.js
@@ -27,7 +27,7 @@ exports.launchServer = () => new Promise((resolve) => {
   compiler.plugin('done', resolve);
 
   module.server = new WebpackDevServer(compiler, {
-    quiet: true,
+    noInfo: true,
   });
 
   module.server.listen(8080, '0.0.0.0');


### PR DESCRIPTION
### Summary
Updating the webpack config for nightwatch testing. 

Updating
[quiet](https://webpack.js.org/configuration/dev-server/#devserver-quiet-)
to
[noInfo](https://webpack.js.org/configuration/dev-server/#devserver-noinfo-)

Now when webpack fails before nightwatch tests, the information will be available in the travis-ci log

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
