### PR TITLE
Update lerna to v2.0.0-rc.4

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.36",
+  "lerna": "2.0.0-rc.4",
   "packages": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "compile": "lerna run compile",
     "compile:heroku": "cd packages/terra-site && npm run compile:heroku",
     "deploy": "lerna run --scope terra-site deploy",
-    "heroku-prebuild": "npm install -g lerna@2.0.0-beta.36",
+    "heroku-prebuild": "npm install -g lerna@2.0.0-rc.4",
     "heroku-postbuild": "npm install --only=dev && npm run compile:heroku",
     "jest": "jest",
     "jest:coverage": "jest --coverage",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "compile": "lerna run compile",
     "compile:heroku": "cd packages/terra-site && npm run compile:heroku",
     "deploy": "lerna run --scope terra-site deploy",
-    "heroku-prebuild": "npm install -g lerna@2.0.0-rc.4",
+    "heroku-prebuild": "npm install -g lerna@2.0.0-rc.4 && lerna init",
     "heroku-postbuild": "npm install --only=dev && npm run compile:heroku",
     "jest": "jest",
     "jest:coverage": "jest --coverage",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "husky": "^0.13.3",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^18.0.0",
-    "lerna": "2.0.0-beta.36",
+    "lerna": "^2.0.0-rc.4",
     "load-json-file": "^2.0.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "husky": "^0.13.3",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^18.0.0",
-    "lerna": "^2.0.0-rc.4",
+    "lerna": "2.0.0-rc.4",
     "load-json-file": "^2.0.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",


### PR DESCRIPTION
### Summary
This change bumps lerna to [v2.0.0-rc.4](https://github.com/lerna/lerna/releases).

@cerner/terra 