### PR TITLE
Update lerna.json to ignore private npm packages

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,17 @@
   "packages": [
     "packages/*"
   ],
+  "command": {
+    "publish": {
+      "ignore": [
+        "terra-content-container",
+        "terra-content",
+        "terra-modal",
+        "terra-site",
+        "terra-standout",
+        "terra-content"
+      ]
+    }
+  },
   "version": "independent"
 }


### PR DESCRIPTION
### Summary
This addition allows us the ability to run `lerna publish` in the root directory to release packages without modifying the packages in the master branch that we have marked as private.

### Additional Details
Running `lerna publish` will only publish packages that don't have `"private": true` in their package.json file, but it will bump version numbers in the private packages. 

This addition ensures version numbers do not change in the packages we've marked as private when running `lerna publish`.

@cerner/terra
