### PR TITLE
Remove terra-site reference from toolkit

### DIFF
--- a/packages/terra-site/webpack.config.js
+++ b/packages/terra-site/webpack.config.js
@@ -109,4 +109,7 @@ module.exports = {
       errors: true,
     },
   },
+  resolveLoader: {
+    modules: [path.resolve(path.join(__dirname, 'node_modules'))],
+  },
 };

--- a/packages/terra-toolkit/lib/server-launcher.js
+++ b/packages/terra-toolkit/lib/server-launcher.js
@@ -22,14 +22,6 @@ exports.launchServer = function () {
   return new Promise(function (resolve) {
     var compiler = void 0;
 
-    // After migrating from webpack 1 to webpack 2
-    // webpack can't find correct devDependencies modules directory
-    // A quick solution is to switch working directory to terra-site
-    // and make all modules available.
-    // Switch to terra site directory
-    var curDir = _path2.default.resolve(process.cwd());
-    _shelljs2.default.cd(_path2.default.resolve(__dirname, '../../terra-site'));
-
     if (process.env.WEBPACK_CONFIG_PATH) {
       /* eslint-disable global-require, import/no-dynamic-require */
       compiler = (0, _webpack2.default)(require(process.env.WEBPACK_CONFIG_PATH));
@@ -47,8 +39,6 @@ exports.launchServer = function () {
     });
 
     module.server.listen(8080, '0.0.0.0');
-    // Switch back to previous directory
-    _shelljs2.default.cd(curDir);
   });
 };
 

--- a/packages/terra-toolkit/lib/server-launcher.js
+++ b/packages/terra-toolkit/lib/server-launcher.js
@@ -8,14 +8,6 @@ var _webpackDevServer = require('webpack-dev-server');
 
 var _webpackDevServer2 = _interopRequireDefault(_webpackDevServer);
 
-var _shelljs = require('shelljs');
-
-var _shelljs2 = _interopRequireDefault(_shelljs);
-
-var _path = require('path');
-
-var _path2 = _interopRequireDefault(_path);
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 exports.launchServer = function () {

--- a/packages/terra-toolkit/src/server-launcher.js
+++ b/packages/terra-toolkit/src/server-launcher.js
@@ -1,7 +1,5 @@
 import webpack from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
-import shell from 'shelljs';
-import path from 'path';
 
 exports.launchServer = () => new Promise((resolve) => {
   let compiler;

--- a/packages/terra-toolkit/src/server-launcher.js
+++ b/packages/terra-toolkit/src/server-launcher.js
@@ -6,14 +6,6 @@ import path from 'path';
 exports.launchServer = () => new Promise((resolve) => {
   let compiler;
 
-  // After migrating from webpack 1 to webpack 2
-  // webpack can't find correct devDependencies modules directory
-  // A quick solution is to switch working directory to terra-site
-  // and make all modules available.
-  // Switch to terra site directory
-  const curDir = path.resolve(process.cwd());
-  shell.cd(path.resolve(__dirname, '../../terra-site'));
-
   if (process.env.WEBPACK_CONFIG_PATH) {
     /* eslint-disable global-require, import/no-dynamic-require */
     compiler = webpack(require(process.env.WEBPACK_CONFIG_PATH));
@@ -31,8 +23,6 @@ exports.launchServer = () => new Promise((resolve) => {
   });
 
   module.server.listen(8080, '0.0.0.0');
-  // Switch back to previous directory
-  shell.cd(curDir);
 });
 
 exports.closeServer = () => new Promise((resolve) => {


### PR DESCRIPTION
### Summary
https://github.com/cerner/terra-core/issues/349


https://github.com/cerner/terra-core/pull/270/files#diff-9999c132bd53c2a36d76ea10d837dd57L14
Adding back in the resolve-loader.  root has been updated to modules for webpack 2.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
