### PR TITLE
Update import from react-docgen

### DIFF
--- a/packages/terra-props-table/lib/PropsTable.js
+++ b/packages/terra-props-table/lib/PropsTable.js
@@ -14,7 +14,9 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _reactDocgen = require('react-docgen');
+var _parse = require('react-docgen/dist/parse');
+
+var _parse2 = _interopRequireDefault(_parse);
 
 var _terraMarkdown = require('terra-markdown');
 
@@ -40,7 +42,7 @@ var PropsTable = function PropsTable(_ref) {
    * Runs component source code through react-docgen
    * @type {Object}
    */
-  var componentMetaData = (0, _reactDocgen.parse)(src);
+  var componentMetaData = (0, _parse2.default)(src);
 
   /**
    * Alias for props object from componentMetaData

--- a/packages/terra-props-table/src/PropsTable.jsx
+++ b/packages/terra-props-table/src/PropsTable.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { parse } from 'react-docgen';
+import parse from 'react-docgen/dist/parse';
 import Markdown from 'terra-markdown';
 
 const propTypes = {


### PR DESCRIPTION
### Summary
Small change in the way we import parse from react-docgen. This takes our bundle from 5.59 MB -> 5.32 MB. 

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
