### PR TITLE
Lock webpack version to 2.5.1 in terra-toolkit and terra-site

### DIFF
--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -76,7 +76,7 @@
     "sass-loader": "^6.0.3",
     "style-loader": "^0.16.1",
     "terra-i18n-plugin": "^0.x",
-    "webpack": "^2.4.1",
+    "webpack": "2.5.1",
     "webpack-dev-server": "^2.4.5"
   }
 }

--- a/packages/terra-toolkit/package.json
+++ b/packages/terra-toolkit/package.json
@@ -37,7 +37,7 @@
     "sauce-connect-launcher": "^1.2.0",
     "selenium-server-standalone-jar": "3.2.0",
     "shelljs": "^0.7.6",
-    "webpack": "^2.4.1",
+    "webpack": "2.5.1",
     "webpack-dev-server": "^2.4.5"
   }
 }


### PR DESCRIPTION
### Summary
Lock webpack version to 2.5.1, avoid missing Promise error.
Lock version in terra-toolkit and terra-site to keep this config consistent in these two packages.