### PR TITLE
Selection styles without responsive

### DIFF
--- a/packages/terra-list/lib/List.scss
+++ b/packages/terra-list/lib/List.scss
@@ -7,7 +7,7 @@
   padding: 0;
 }
 
-.terra-List-divided > li {
+.terra-List-divided > li.terra-ListItem {
   border-top: solid 1px $terra-list-divider-color;
-  &:last-child {border-bottom: solid 1px $terra-list-divider-color;}
+  &:last-of-type { border-bottom: solid 1px $terra-list-divider-color; }
 }

--- a/packages/terra-list/lib/ListItem.scss
+++ b/packages/terra-list/lib/ListItem.scss
@@ -24,38 +24,23 @@
     text-decoration: inherit;
     top: 50%;
     transform: translate(0, -50%);
-  }
-
-  .terra-ListItem-chevron {
     color: $terra-list-chevron-color;
   }
-
 }
 
-.terra-ListItem--selected {
-  background-color: $terra-list-item-selected-background-color;
-  border-bottom-color: $terra-list-item-selected-divider-color;
-  box-shadow: $terra-list-item-selected-box-shadow;
+.terra-ListItem--selected { background-color: $terra-list-item-selected-background-color; }
+
+.terra-List-divided .terra-ListItem--selected {
+  &.terra-ListItem{ border-color: $terra-list-item-selected-divider-color; }
+  + .terra-ListItem{ border-top-color: $terra-list-item-selected-divider-color; }
 }
 
 .terra-ListItem-isSelectable {
   cursor: pointer;
 
-  &.terra-ListItem:hover {
-    background-color: $terra-list-item-hover-background-color !important;
-    box-shadow: $terra-list-item-hover-box-shadow;
-  }
+  &.terra-ListItem:hover,
+  &.terra-ListItem:focus { background-color: $terra-list-item-hover-background-color !important; }
 
-  &.terra-ListItem:focus {
-    background-color: $terra-list-item-hover-background-color !important;
-  }
-
-  &.terra-ListItem--selected:hover {
-    background-color: $terra-list-item-selected-hover-background-color !important;
-  }
-
-  &.terra-ListItem--selected:focus {
-    background-color: $terra-list-item-selected-hover-background-color !important;
-  }
-
+  &.terra-ListItem--selected:hover,
+  &.terra-ListItem--selected:focus { background-color: $terra-list-item-selected-hover-background-color !important; }
 }

--- a/packages/terra-list/lib/_variables.scss
+++ b/packages/terra-list/lib/_variables.scss
@@ -1,11 +1,12 @@
 // Variables
 // ==========================
 
+// Basic List Element Colors
 $terra-list-chevron-color: $terra-grey-30 !default;
 $terra-list-divider-color: $terra-grey-15 !default;
-$terra-list-item-hover-background-color: $terra-grey-10 !default;
-$terra-list-item-hover-box-shadow: 0 3px 2px -1px rgba(0, 0, 0, 0.08), 0 -2px 2px 0 rgba(0, 0, 0, 0.1) !default;
+
+// Selection Styles
+$terra-list-item-hover-background-color: $terra-blue-10 !default;
 $terra-list-item-selected-background-color: $terra-blue-10 !default;
-$terra-list-item-selected-box-shadow: 0 3px 3px -2px rgba(0, 0, 0, 0.3) !default;
-$terra-list-item-selected-divider-color: $terra-grey-25 !default;
-$terra-list-item-selected-hover-background-color: $terra-blue-20 !default;
+$terra-list-item-selected-hover-background-color: darken( $terra-blue-10, 5% ) !default;
+$terra-list-item-selected-divider-color: $terra-blue-70 !default;

--- a/packages/terra-list/src/List.scss
+++ b/packages/terra-list/src/List.scss
@@ -7,7 +7,7 @@
   padding: 0;
 }
 
-.terra-List-divided > li {
+.terra-List-divided > li.terra-ListItem {
   border-top: solid 1px $terra-list-divider-color;
-  &:last-child {border-bottom: solid 1px $terra-list-divider-color;}
+  &:last-of-type { border-bottom: solid 1px $terra-list-divider-color; }
 }

--- a/packages/terra-list/src/ListItem.scss
+++ b/packages/terra-list/src/ListItem.scss
@@ -24,38 +24,23 @@
     text-decoration: inherit;
     top: 50%;
     transform: translate(0, -50%);
-  }
-
-  .terra-ListItem-chevron {
     color: $terra-list-chevron-color;
   }
-
 }
 
-.terra-ListItem--selected {
-  background-color: $terra-list-item-selected-background-color;
-  border-bottom-color: $terra-list-item-selected-divider-color;
-  box-shadow: $terra-list-item-selected-box-shadow;
+.terra-ListItem--selected { background-color: $terra-list-item-selected-background-color; }
+
+.terra-List-divided .terra-ListItem--selected {
+  &.terra-ListItem{ border-color: $terra-list-item-selected-divider-color; }
+  + .terra-ListItem{ border-top-color: $terra-list-item-selected-divider-color; }
 }
 
 .terra-ListItem-isSelectable {
   cursor: pointer;
 
-  &.terra-ListItem:hover {
-    background-color: $terra-list-item-hover-background-color !important;
-    box-shadow: $terra-list-item-hover-box-shadow;
-  }
+  &.terra-ListItem:hover,
+  &.terra-ListItem:focus { background-color: $terra-list-item-hover-background-color !important; }
 
-  &.terra-ListItem:focus {
-    background-color: $terra-list-item-hover-background-color !important;
-  }
-
-  &.terra-ListItem--selected:hover {
-    background-color: $terra-list-item-selected-hover-background-color !important;
-  }
-
-  &.terra-ListItem--selected:focus {
-    background-color: $terra-list-item-selected-hover-background-color !important;
-  }
-
+  &.terra-ListItem--selected:hover,
+  &.terra-ListItem--selected:focus { background-color: $terra-list-item-selected-hover-background-color !important; }
 }

--- a/packages/terra-list/src/_variables.scss
+++ b/packages/terra-list/src/_variables.scss
@@ -1,11 +1,12 @@
 // Variables
 // ==========================
 
+// Basic List Element Colors
 $terra-list-chevron-color: $terra-grey-30 !default;
 $terra-list-divider-color: $terra-grey-15 !default;
-$terra-list-item-hover-background-color: $terra-grey-10 !default;
-$terra-list-item-hover-box-shadow: 0 3px 2px -1px rgba(0, 0, 0, 0.08), 0 -2px 2px 0 rgba(0, 0, 0, 0.1) !default;
+
+// Selection Styles
+$terra-list-item-hover-background-color: $terra-blue-10 !default;
 $terra-list-item-selected-background-color: $terra-blue-10 !default;
-$terra-list-item-selected-box-shadow: 0 3px 3px -2px rgba(0, 0, 0, 0.3) !default;
-$terra-list-item-selected-divider-color: $terra-grey-25 !default;
-$terra-list-item-selected-hover-background-color: $terra-blue-20 !default;
+$terra-list-item-selected-hover-background-color: darken( $terra-blue-10, 5% ) !default;
+$terra-list-item-selected-divider-color: $terra-blue-70 !default;

--- a/packages/terra-table/lib/Table.scss
+++ b/packages/terra-table/lib/Table.scss
@@ -49,10 +49,6 @@
       border-top: $terra-table-row-border-topbottom;
       &:last-of-type { border-bottom: $terra-table-row-border-topbottom; }
     }
-    th {
-      @include terra-text-align-start;
-      background-color: $terra-table-row-th-background-color;
-    }
   }
 
   tfoot {
@@ -62,6 +58,14 @@
       border-bottom: $terra-table-tfoot-tr-border-bottom;
     }
   }
+}
+
+.terra-Table-subheader {
+  @include terra-text-align-start;
+  background-color: $terra-table-subheader-background-color;
+  font-size: $terra-table-subheader-font-size;
+  font-weight: $terra-table-subheader-font-weight;
+  color: $terra-table-subheader-color;
 }
 
 .terra-Table-sort-indicator {

--- a/packages/terra-table/lib/Table.scss
+++ b/packages/terra-table/lib/Table.scss
@@ -1,7 +1,7 @@
 @import '~terra-mixins';
 @import './variables';
 
-.terra-Table {
+terra-Table {
   background-color: $terra-table-background-color;
   border-collapse: collapse;
   border-spacing: 0;
@@ -93,22 +93,27 @@
 }
 
 .terra-Table--striped {
-  tbody tr:nth-of-type(even) {
-    background-color: $terra-table-row-striped-background-color;
-
-    &.terra-Table-row:hover {
-      background-color: $terra-table-row-striped-hover-background-color !important;
+  tbody tr {
+    &:nth-of-type(even) {
+      background-color: $terra-table-row-striped-background-color;
     }
-  }
 
-  .terra-Table--isSelected {
-    background-color: $terra-table-row-striped-selected-background-color !important;
+    &.terra-Table--isSelected {
+      background-color: $terra-table-row-striped-selected-background-color !important;
+    }
 
-    &.terra-Table-row:hover {
-      background-color: $terra-table-row-striped-selected-hover-background-color !important;
+    &.terra-Table--isSelectable {
+      &:hover {
+        background-color: $terra-table-row-striped-hover-background-color !important;
+
+        &.terra-Table--isSelected {
+          background-color: $terra-table-row-striped-selected-hover-background-color !important;
+        }
+      }
     }
   }
 }
+
 
 .terra-Table--isSelected {
   background-color: $terra-table-row-selected-background-color;

--- a/packages/terra-table/lib/Table.scss
+++ b/packages/terra-table/lib/Table.scss
@@ -70,7 +70,7 @@
 }
 
 
-// Reccommend changing these to .terra-Table-column-min-width--{size}
+// Reccommend changing these to .terra-Table-cell-min-width--{size}
 .terra-Table-min-width--tiny { min-width: $terra-table-cell-min-width-tiny; }
 
 .terra-Table-min-width--small { min-width: $terra-table-cell-min-width-small; }
@@ -80,7 +80,7 @@
 .terra-Table-min-width--large { min-width: $terra-table-cell-min-width-large; }
 
 .terra-Table-min-width--huge { min-width: $terra-table-cell-min-width-huge; }
-// end: Reccommend changing these to .terra-Table-column-min-width--{size}
+// end: Reccommend changing these to .terra-Table-cell-min-width--{size}
 
 
 .terra-Table--padded {
@@ -113,7 +113,6 @@
     }
   }
 }
-
 
 .terra-Table--isSelected {
   background-color: $terra-table-row-selected-background-color;

--- a/packages/terra-table/lib/Table.scss
+++ b/packages/terra-table/lib/Table.scss
@@ -5,6 +5,7 @@
   background-color: $terra-table-background-color;
   border-collapse: collapse;
   border-spacing: 0;
+  border: $terra-table-border;
   max-width: 100%;
   width: 100%;
 
@@ -13,137 +14,119 @@
   }
 
   tr {
-    display: block;
+    display: table-row;
+    margin-bottom: 0;
   }
 
   th,
   td {
     @include terra-text-align-start;
+    border: 0;
+    border-left: $terra-table-cell-column-border-left;
+    display: table-cell;
+    vertical-align: top;
+    &:first-of-type { border-left: $terra-table-row-border-leftright; }
+    &:last-of-type { border-right: $terra-table-row-border-leftright; }
+  }
 
-    border: $terra-table-border-width solid $terra-table-border-color;
-    border-bottom: 0;
-    display: block;
-
-    &::before {
-      content: attr(data-heading);
-      display: block;
-      font-weight: bold;
+  thead {
+    background-color: $terra-table-thead-background-color;
+    display: table-header-group;
+    tr {
+      border-top: $terra-table-thead-tr-border-top;
+      border-bottom: $terra-table-thead-tr-border-bottom;
     }
-
-    // Clears floated :before
-    &::after {
-      @include terra-clear-both;
-
-      content: ' ';
-      display: table;
-    }
-
-    &:last-child {
-      border-bottom: $terra-table-border-width solid $terra-table-border-color;
-      margin-bottom: 1em;
+    th {
+      vertical-align: bottom;
+      font-size: $terra-table-thead-th-font-size;
+      font-weight: $terra-table-thead-th-font-weight;
+      color: $terra-table-thead-th-color;
     }
   }
 
-  // Full behavior
-  @media screen and (min-width: $terra-small-breakpoint) {
-    border: $terra-table-border-width solid $terra-table-border-color;
-
+  tbody {
     tr {
-      border-bottom: $terra-table-border-width solid $terra-table-border-color;
-      display: table-row;
-      margin-bottom: 0;
+      border-top: $terra-table-row-border-topbottom;
+      &:last-of-type { border-bottom: $terra-table-row-border-topbottom; }
     }
-
-    th,
-    td {
+    th {
       @include terra-text-align-start;
-
-      border: 0; // Remove border from compact "card" view
-      display: table-cell;
-      vertical-align: top;
-    }
-
-    th::before,
-    td::before,
-    th::after,
-    td::after {
-      display: none;
-    }
-
-    th:last-child,
-    td:last-child {
-      border: 0; // Remove border from compact "card" view
-    }
-
-    thead {
-      background-color: $terra-table-thead-background-color;
-      border-bottom: $terra-table-border-width solid $terra-table-border-color;
-      display: table-header-group;
-    }
-
-    thead th {
-      vertical-align: bottom;
-    }
-
-    tbody th {
-      @include terra-text-align-end;
-
       background-color: $terra-table-row-th-background-color;
     }
+  }
 
-    tfoot tr {
+  tfoot {
+    tr {
       @include terra-text-align-start;
-
-      border-top: $terra-table-border-width solid $terra-table-border-color;
+      border-top: $terra-table-tfoot-tr-border-top;
+      border-bottom: $terra-table-tfoot-tr-border-bottom;
     }
   }
 }
+
+.terra-Table-sort-indicator {
+  @include terra-float-end();
+  color: $terra-table-sort-indicator-color;
+}
+
+
+// Reccommend changing these to .terra-Table-column-min-width--{size}
+.terra-Table-min-width--tiny { min-width: $terra-table-cell-min-width-tiny; }
+
+.terra-Table-min-width--small { min-width: $terra-table-cell-min-width-small; }
+
+.terra-Table-min-width--medium { min-width: $terra-table-cell-min-width-medium; }
+
+.terra-Table-min-width--large { min-width: $terra-table-cell-min-width-large; }
+
+.terra-Table-min-width--huge { min-width: $terra-table-cell-min-width-huge; }
+// end: Reccommend changing these to .terra-Table-column-min-width--{size}
+
 
 .terra-Table--padded {
   th,
   td {
     @include terra-padding-horizontal($terra-table-cell-padding-left, $terra-table-cell-padding-right);
-
     padding-bottom: $terra-table-cell-padding-bottom;
     padding-top: $terra-table-cell-padding-top;
   }
 }
 
 .terra-Table--striped {
-  .terra-Table--isSelected:hover {
-    background-color: $terra-table-row-selected-hover-background-color !important;
-  }
-
-  tbody td:nth-of-type(even) {
+  tbody tr:nth-of-type(even) {
     background-color: $terra-table-row-striped-background-color;
 
-    @media screen and (min-width: $terra-small-breakpoint) {
-      background-color: transparent;
+    &.terra-Table-row:hover {
+      background-color: $terra-table-row-striped-hover-background-color !important;
     }
   }
 
-  @media screen and (min-width: $terra-small-breakpoint) {
-    tbody tr:nth-of-type(even) {
-      background-color: $terra-table-row-striped-background-color;
+  .terra-Table--isSelected {
+    background-color: $terra-table-row-striped-selected-background-color !important;
 
-      /* stylelint-disable-next-line selector-max-compound-selectors */
-      .terra-Table--isSelected {
-        background-color: $terra-table-row-selected-background-color;
-      }
-
+    &.terra-Table-row:hover {
+      background-color: $terra-table-row-striped-selected-hover-background-color !important;
     }
+  }
+}
 
-    /* Compound selector depth required for specificity */
-    /* stylelint-disable-next-line selector-max-compound-selectors */
-    tbody tr:nth-of-type(even) th {
-      background-color: $terra-table-row-striped-th-background-color;
+.terra-Table--isSelected {
+  background-color: $terra-table-row-selected-background-color;
 
-      /* stylelint-disable-next-line selector-max-compound-selectors */
-      .terra-Table--isSelected {
-        background-color: $terra-table-row-selected-background-color;
-      }
+  &.terra-Table-row{ border-color: $terra-table-row-selected-border-color; }
+  + .terra-Table-row { border-top-color: $terra-table-row-selected-border-color; }
+}
 
-    }
+.terra-Table--isSelectable {
+  cursor: pointer;
+
+  &.terra-Table-row:hover,
+  &.terra-Table-row:focus {
+    background-color: $terra-table-row-hover-background-color !important;
+  }
+  &.terra-Table--isSelected:hover,
+  &.terra-Table--isSelected:focus {
+    background-color: $terra-table-row-selected-hover-background-color !important;
   }
 }
 
@@ -156,55 +139,4 @@
   .terra-Table tr {
     page-break-inside: avoid;
   }
-}
-
-.terra-Table-min-width--tiny {
-  min-width: $terra-table-cell-min-width-tiny;
-}
-
-.terra-Table-min-width--small {
-  min-width: $terra-table-cell-min-width-small;
-}
-
-.terra-Table-min-width--medium {
-  min-width: $terra-table-cell-min-width-medium;
-}
-
-.terra-Table-min-width--large {
-  min-width: $terra-table-cell-min-width-large;
-}
-
-.terra-Table-min-width--huge {
-  min-width: $terra-table-cell-min-width-huge;
-}
-
-.terra-Table--isSelected {
-  background-color: $terra-table-row-selected-background-color;
-  box-shadow: $terra-table-row-selected-box-shadow;
-}
-
-.terra-Table--isSelectable {
-  cursor: pointer;
-
-  &.terra-Table-row:hover {
-    background-color: $terra-table-row-hover-background-color !important;
-    box-shadow: $terra-table-row-hover-box-shadow;
-  }
-
-  &.terra-Table-row:focus {
-    background-color: $terra-table-row-hover-background-color !important;
-  }
-
-  &.terra-Table--isSelected:hover {
-    background-color: $terra-table-row-selected-hover-background-color !important;
-  }
-
-  &.terra-Table--isSelected:focus {
-    background-color: $terra-table-row-selected-hover-background-color !important;
-  }
-
-}
-
-.terra-Table-sort-indicator {
-  @include terra-float-end();
 }

--- a/packages/terra-table/lib/Table.scss
+++ b/packages/terra-table/lib/Table.scss
@@ -1,7 +1,7 @@
 @import '~terra-mixins';
 @import './variables';
 
-terra-Table {
+.terra-Table {
   background-color: $terra-table-background-color;
   border-collapse: collapse;
   border-spacing: 0;

--- a/packages/terra-table/lib/_variables.scss
+++ b/packages/terra-table/lib/_variables.scss
@@ -3,20 +3,37 @@
 
 // Background Colors
 $terra-table-background-color: $terra-white !default;
+$terra-table-thead-background-color: $terra-grey-15 !default;
+$terra-table-row-th-background-color: $terra-grey-25 !default;
 $terra-table-cell-background-color: $terra-white !default;
-$terra-table-row-hover-background-color: $terra-grey-10 !default;
-$terra-table-row-selected-background-color: $terra-blue-10 !default;
-$terra-table-row-selected-hover-background-color: $terra-blue-20 !default;
 $terra-table-row-striped-background-color: $terra-grey-5 !default;
 $terra-table-row-striped-th-background-color: $terra-grey-25 !default;
 $terra-table-row-th-background-color: $terra-grey-25 !default;
-$terra-table-thead-background-color: $terra-grey-20 !default;
 
-// Border and Box Shadows
-$terra-table-border-color: $terra-grey-25 !default;
-$terra-table-border-width: 1px !default;
-$terra-table-row-hover-box-shadow: 0 3px 2px -1px rgba(0, 0, 0, 0.08), 0 -2px 2px 0 rgba(0, 0, 0, 0.1) !default;
-$terra-table-row-selected-box-shadow: 0 3px 3px -2px rgba(0, 0, 0, 0.3) !default;
+// Base Border Styles
+$terra-table-base-border-color: $terra-grey-25 !default;
+$terra-table-base-border-width: 1px !default;
+
+// Borders
+$terra-table-border: 0 !default;
+$terra-table-thead-tr-border-top: $terra-table-base-border-width solid $terra-table-base-border-color !default;
+$terra-table-thead-tr-border-bottom: 0 !default;
+$terra-table-tfoot-tr-border-top: 0 !default;
+$terra-table-tfoot-tr-border-bottom: $terra-table-base-border-width solid $terra-table-base-border-color !default;
+$terra-table-row-border-leftright: $terra-table-base-border-width solid $terra-table-base-border-color !default;
+$terra-table-row-border-topbottom: $terra-table-base-border-width solid $terra-table-base-border-color !default;
+$terra-table-cell-column-border-left: 0 !default;
+
+// Table Header Font Styles
+$terra-table-thead-th-font-size:1rem !default;
+$terra-table-thead-th-font-weight: bold !default;
+$terra-table-thead-th-color: $terra-dark !default;
+$terra-table-sort-indicator-color: $terra-dark !default;
+
+// Table Subheader Font Styles
+$terra-table-row-th-font-size:1rem !default;
+$terra-table-row-th-font-weight: bold !default;
+$terra-table-row-th-color: $terra-dark !default;
 
 // Cell Padding
 $terra-table-cell-padding-bottom: 0.5em !default;
@@ -44,3 +61,12 @@ $terra-table-cell-min-width-small: 4.25rem;
 $terra-table-cell-min-width-medium: 5.75rem;
 $terra-table-cell-min-width-large: 8.5rem;
 $terra-table-cell-min-width-huge: 10.5rem;
+
+// Selection Styles
+$terra-table-row-hover-background-color: $terra-blue-10 !default;
+$terra-table-row-selected-background-color: $terra-blue-10 !default;
+$terra-table-row-selected-hover-background-color: darken( $terra-blue-10, 5% ) !default;
+$terra-table-row-selected-border-color: $terra-blue-70 !default;
+$terra-table-row-striped-hover-background-color: darken( $terra-blue-10, 2% ) !default;
+$terra-table-row-striped-selected-background-color: darken( $terra-blue-10, 5% ) !default;
+$terra-table-row-striped-selected-hover-background-color: darken( $terra-blue-10, 10% ) !default;

--- a/packages/terra-table/lib/_variables.scss
+++ b/packages/terra-table/lib/_variables.scss
@@ -4,7 +4,7 @@
 // Background Colors
 $terra-table-background-color: $terra-white !default;
 $terra-table-thead-background-color: $terra-grey-15 !default;
-$terra-table-row-th-background-color: $terra-grey-25 !default;
+$terra-table-subheader-background-color: $terra-grey-25 !default;
 $terra-table-cell-background-color: $terra-white !default;
 $terra-table-row-striped-background-color: $terra-grey-5 !default;
 $terra-table-row-striped-th-background-color: $terra-grey-25 !default;
@@ -31,9 +31,9 @@ $terra-table-thead-th-color: $terra-dark !default;
 $terra-table-sort-indicator-color: $terra-dark !default;
 
 // Table Subheader Font Styles
-$terra-table-row-th-font-size:1rem !default;
-$terra-table-row-th-font-weight: bold !default;
-$terra-table-row-th-color: $terra-dark !default;
+$terra-table-subheader-font-size:1rem !default;
+$terra-table-subheader-font-weight: bold !default;
+$terra-table-subheader-color: $terra-dark !default;
 
 // Cell Padding
 $terra-table-cell-padding-bottom: 0.5em !default;

--- a/packages/terra-table/src/Table.scss
+++ b/packages/terra-table/src/Table.scss
@@ -49,10 +49,6 @@
       border-top: $terra-table-row-border-topbottom;
       &:last-of-type { border-bottom: $terra-table-row-border-topbottom; }
     }
-    th {
-      @include terra-text-align-start;
-      background-color: $terra-table-row-th-background-color;
-    }
   }
 
   tfoot {
@@ -62,6 +58,14 @@
       border-bottom: $terra-table-tfoot-tr-border-bottom;
     }
   }
+}
+
+.terra-Table-subheader {
+  @include terra-text-align-start;
+  background-color: $terra-table-subheader-background-color;
+  font-size: $terra-table-subheader-font-size;
+  font-weight: $terra-table-subheader-font-weight;
+  color: $terra-table-subheader-color;
 }
 
 .terra-Table-sort-indicator {

--- a/packages/terra-table/src/Table.scss
+++ b/packages/terra-table/src/Table.scss
@@ -1,7 +1,7 @@
 @import '~terra-mixins';
 @import './variables';
 
-.terra-Table {
+terra-Table {
   background-color: $terra-table-background-color;
   border-collapse: collapse;
   border-spacing: 0;
@@ -93,22 +93,27 @@
 }
 
 .terra-Table--striped {
-  tbody tr:nth-of-type(even) {
-    background-color: $terra-table-row-striped-background-color;
-
-    &.terra-Table-row:hover {
-      background-color: $terra-table-row-striped-hover-background-color !important;
+  tbody tr {
+    &:nth-of-type(even) {
+      background-color: $terra-table-row-striped-background-color;
     }
-  }
 
-  .terra-Table--isSelected {
-    background-color: $terra-table-row-striped-selected-background-color !important;
+    &.terra-Table--isSelected {
+      background-color: $terra-table-row-striped-selected-background-color !important;
+    }
 
-    &.terra-Table-row:hover {
-      background-color: $terra-table-row-striped-selected-hover-background-color !important;
+    &.terra-Table--isSelectable {
+      &:hover {
+        background-color: $terra-table-row-striped-hover-background-color !important;
+
+        &.terra-Table--isSelected {
+          background-color: $terra-table-row-striped-selected-hover-background-color !important;
+        }
+      }
     }
   }
 }
+
 
 .terra-Table--isSelected {
   background-color: $terra-table-row-selected-background-color;

--- a/packages/terra-table/src/Table.scss
+++ b/packages/terra-table/src/Table.scss
@@ -70,7 +70,7 @@
 }
 
 
-// Reccommend changing these to .terra-Table-column-min-width--{size}
+// Reccommend changing these to .terra-Table-cell-min-width--{size}
 .terra-Table-min-width--tiny { min-width: $terra-table-cell-min-width-tiny; }
 
 .terra-Table-min-width--small { min-width: $terra-table-cell-min-width-small; }
@@ -80,7 +80,7 @@
 .terra-Table-min-width--large { min-width: $terra-table-cell-min-width-large; }
 
 .terra-Table-min-width--huge { min-width: $terra-table-cell-min-width-huge; }
-// end: Reccommend changing these to .terra-Table-column-min-width--{size}
+// end: Reccommend changing these to .terra-Table-cell-min-width--{size}
 
 
 .terra-Table--padded {
@@ -113,7 +113,6 @@
     }
   }
 }
-
 
 .terra-Table--isSelected {
   background-color: $terra-table-row-selected-background-color;

--- a/packages/terra-table/src/Table.scss
+++ b/packages/terra-table/src/Table.scss
@@ -5,6 +5,7 @@
   background-color: $terra-table-background-color;
   border-collapse: collapse;
   border-spacing: 0;
+  border: $terra-table-border;
   max-width: 100%;
   width: 100%;
 
@@ -13,137 +14,119 @@
   }
 
   tr {
-    display: block;
+    display: table-row;
+    margin-bottom: 0;
   }
 
   th,
   td {
     @include terra-text-align-start;
+    border: 0;
+    border-left: $terra-table-cell-column-border-left;
+    display: table-cell;
+    vertical-align: top;
+    &:first-of-type { border-left: $terra-table-row-border-leftright; }
+    &:last-of-type { border-right: $terra-table-row-border-leftright; }
+  }
 
-    border: $terra-table-border-width solid $terra-table-border-color;
-    border-bottom: 0;
-    display: block;
-
-    &::before {
-      content: attr(data-heading);
-      display: block;
-      font-weight: bold;
+  thead {
+    background-color: $terra-table-thead-background-color;
+    display: table-header-group;
+    tr {
+      border-top: $terra-table-thead-tr-border-top;
+      border-bottom: $terra-table-thead-tr-border-bottom;
     }
-
-    // Clears floated :before
-    &::after {
-      @include terra-clear-both;
-
-      content: ' ';
-      display: table;
-    }
-
-    &:last-child {
-      border-bottom: $terra-table-border-width solid $terra-table-border-color;
-      margin-bottom: 1em;
+    th {
+      vertical-align: bottom;
+      font-size: $terra-table-thead-th-font-size;
+      font-weight: $terra-table-thead-th-font-weight;
+      color: $terra-table-thead-th-color;
     }
   }
 
-  // Full behavior
-  @media screen and (min-width: $terra-small-breakpoint) {
-    border: $terra-table-border-width solid $terra-table-border-color;
-
+  tbody {
     tr {
-      border-bottom: $terra-table-border-width solid $terra-table-border-color;
-      display: table-row;
-      margin-bottom: 0;
+      border-top: $terra-table-row-border-topbottom;
+      &:last-of-type { border-bottom: $terra-table-row-border-topbottom; }
     }
-
-    th,
-    td {
+    th {
       @include terra-text-align-start;
-
-      border: 0; // Remove border from compact "card" view
-      display: table-cell;
-      vertical-align: top;
-    }
-
-    th::before,
-    td::before,
-    th::after,
-    td::after {
-      display: none;
-    }
-
-    th:last-child,
-    td:last-child {
-      border: 0; // Remove border from compact "card" view
-    }
-
-    thead {
-      background-color: $terra-table-thead-background-color;
-      border-bottom: $terra-table-border-width solid $terra-table-border-color;
-      display: table-header-group;
-    }
-
-    thead th {
-      vertical-align: bottom;
-    }
-
-    tbody th {
-      @include terra-text-align-end;
-
       background-color: $terra-table-row-th-background-color;
     }
+  }
 
-    tfoot tr {
+  tfoot {
+    tr {
       @include terra-text-align-start;
-
-      border-top: $terra-table-border-width solid $terra-table-border-color;
+      border-top: $terra-table-tfoot-tr-border-top;
+      border-bottom: $terra-table-tfoot-tr-border-bottom;
     }
   }
 }
+
+.terra-Table-sort-indicator {
+  @include terra-float-end();
+  color: $terra-table-sort-indicator-color;
+}
+
+
+// Reccommend changing these to .terra-Table-column-min-width--{size}
+.terra-Table-min-width--tiny { min-width: $terra-table-cell-min-width-tiny; }
+
+.terra-Table-min-width--small { min-width: $terra-table-cell-min-width-small; }
+
+.terra-Table-min-width--medium { min-width: $terra-table-cell-min-width-medium; }
+
+.terra-Table-min-width--large { min-width: $terra-table-cell-min-width-large; }
+
+.terra-Table-min-width--huge { min-width: $terra-table-cell-min-width-huge; }
+// end: Reccommend changing these to .terra-Table-column-min-width--{size}
+
 
 .terra-Table--padded {
   th,
   td {
     @include terra-padding-horizontal($terra-table-cell-padding-left, $terra-table-cell-padding-right);
-
     padding-bottom: $terra-table-cell-padding-bottom;
     padding-top: $terra-table-cell-padding-top;
   }
 }
 
 .terra-Table--striped {
-  .terra-Table--isSelected:hover {
-    background-color: $terra-table-row-selected-hover-background-color !important;
-  }
-
-  tbody td:nth-of-type(even) {
+  tbody tr:nth-of-type(even) {
     background-color: $terra-table-row-striped-background-color;
 
-    @media screen and (min-width: $terra-small-breakpoint) {
-      background-color: transparent;
+    &.terra-Table-row:hover {
+      background-color: $terra-table-row-striped-hover-background-color !important;
     }
   }
 
-  @media screen and (min-width: $terra-small-breakpoint) {
-    tbody tr:nth-of-type(even) {
-      background-color: $terra-table-row-striped-background-color;
+  .terra-Table--isSelected {
+    background-color: $terra-table-row-striped-selected-background-color !important;
 
-      /* stylelint-disable-next-line selector-max-compound-selectors */
-      .terra-Table--isSelected {
-        background-color: $terra-table-row-selected-background-color;
-      }
-
+    &.terra-Table-row:hover {
+      background-color: $terra-table-row-striped-selected-hover-background-color !important;
     }
+  }
+}
 
-    /* Compound selector depth required for specificity */
-    /* stylelint-disable-next-line selector-max-compound-selectors */
-    tbody tr:nth-of-type(even) th {
-      background-color: $terra-table-row-striped-th-background-color;
+.terra-Table--isSelected {
+  background-color: $terra-table-row-selected-background-color;
 
-      /* stylelint-disable-next-line selector-max-compound-selectors */
-      .terra-Table--isSelected {
-        background-color: $terra-table-row-selected-background-color;
-      }
+  &.terra-Table-row{ border-color: $terra-table-row-selected-border-color; }
+  + .terra-Table-row { border-top-color: $terra-table-row-selected-border-color; }
+}
 
-    }
+.terra-Table--isSelectable {
+  cursor: pointer;
+
+  &.terra-Table-row:hover,
+  &.terra-Table-row:focus {
+    background-color: $terra-table-row-hover-background-color !important;
+  }
+  &.terra-Table--isSelected:hover,
+  &.terra-Table--isSelected:focus {
+    background-color: $terra-table-row-selected-hover-background-color !important;
   }
 }
 
@@ -156,55 +139,4 @@
   .terra-Table tr {
     page-break-inside: avoid;
   }
-}
-
-.terra-Table-min-width--tiny {
-  min-width: $terra-table-cell-min-width-tiny;
-}
-
-.terra-Table-min-width--small {
-  min-width: $terra-table-cell-min-width-small;
-}
-
-.terra-Table-min-width--medium {
-  min-width: $terra-table-cell-min-width-medium;
-}
-
-.terra-Table-min-width--large {
-  min-width: $terra-table-cell-min-width-large;
-}
-
-.terra-Table-min-width--huge {
-  min-width: $terra-table-cell-min-width-huge;
-}
-
-.terra-Table--isSelected {
-  background-color: $terra-table-row-selected-background-color;
-  box-shadow: $terra-table-row-selected-box-shadow;
-}
-
-.terra-Table--isSelectable {
-  cursor: pointer;
-
-  &.terra-Table-row:hover {
-    background-color: $terra-table-row-hover-background-color !important;
-    box-shadow: $terra-table-row-hover-box-shadow;
-  }
-
-  &.terra-Table-row:focus {
-    background-color: $terra-table-row-hover-background-color !important;
-  }
-
-  &.terra-Table--isSelected:hover {
-    background-color: $terra-table-row-selected-hover-background-color !important;
-  }
-
-  &.terra-Table--isSelected:focus {
-    background-color: $terra-table-row-selected-hover-background-color !important;
-  }
-
-}
-
-.terra-Table-sort-indicator {
-  @include terra-float-end();
 }

--- a/packages/terra-table/src/Table.scss
+++ b/packages/terra-table/src/Table.scss
@@ -1,7 +1,7 @@
 @import '~terra-mixins';
 @import './variables';
 
-terra-Table {
+.terra-Table {
   background-color: $terra-table-background-color;
   border-collapse: collapse;
   border-spacing: 0;

--- a/packages/terra-table/src/_variables.scss
+++ b/packages/terra-table/src/_variables.scss
@@ -3,20 +3,37 @@
 
 // Background Colors
 $terra-table-background-color: $terra-white !default;
+$terra-table-thead-background-color: $terra-grey-15 !default;
+$terra-table-row-th-background-color: $terra-grey-25 !default;
 $terra-table-cell-background-color: $terra-white !default;
-$terra-table-row-hover-background-color: $terra-grey-10 !default;
-$terra-table-row-selected-background-color: $terra-blue-10 !default;
-$terra-table-row-selected-hover-background-color: $terra-blue-20 !default;
 $terra-table-row-striped-background-color: $terra-grey-5 !default;
 $terra-table-row-striped-th-background-color: $terra-grey-25 !default;
 $terra-table-row-th-background-color: $terra-grey-25 !default;
-$terra-table-thead-background-color: $terra-grey-20 !default;
 
-// Border and Box Shadows
-$terra-table-border-color: $terra-grey-25 !default;
-$terra-table-border-width: 1px !default;
-$terra-table-row-hover-box-shadow: 0 3px 2px -1px rgba(0, 0, 0, 0.08), 0 -2px 2px 0 rgba(0, 0, 0, 0.1) !default;
-$terra-table-row-selected-box-shadow: 0 3px 3px -2px rgba(0, 0, 0, 0.3) !default;
+// Base Border Styles
+$terra-table-base-border-color: $terra-grey-25 !default;
+$terra-table-base-border-width: 1px !default;
+
+// Borders
+$terra-table-border: 0 !default;
+$terra-table-thead-tr-border-top: $terra-table-base-border-width solid $terra-table-base-border-color !default;
+$terra-table-thead-tr-border-bottom: 0 !default;
+$terra-table-tfoot-tr-border-top: 0 !default;
+$terra-table-tfoot-tr-border-bottom: $terra-table-base-border-width solid $terra-table-base-border-color !default;
+$terra-table-row-border-leftright: $terra-table-base-border-width solid $terra-table-base-border-color !default;
+$terra-table-row-border-topbottom: $terra-table-base-border-width solid $terra-table-base-border-color !default;
+$terra-table-cell-column-border-left: 0 !default;
+
+// Table Header Font Styles
+$terra-table-thead-th-font-size:1rem !default;
+$terra-table-thead-th-font-weight: bold !default;
+$terra-table-thead-th-color: $terra-dark !default;
+$terra-table-sort-indicator-color: $terra-dark !default;
+
+// Table Subheader Font Styles
+$terra-table-row-th-font-size:1rem !default;
+$terra-table-row-th-font-weight: bold !default;
+$terra-table-row-th-color: $terra-dark !default;
 
 // Cell Padding
 $terra-table-cell-padding-bottom: 0.5em !default;
@@ -44,3 +61,12 @@ $terra-table-cell-min-width-small: 4.25rem;
 $terra-table-cell-min-width-medium: 5.75rem;
 $terra-table-cell-min-width-large: 8.5rem;
 $terra-table-cell-min-width-huge: 10.5rem;
+
+// Selection Styles
+$terra-table-row-hover-background-color: $terra-blue-10 !default;
+$terra-table-row-selected-background-color: $terra-blue-10 !default;
+$terra-table-row-selected-hover-background-color: darken( $terra-blue-10, 5% ) !default;
+$terra-table-row-selected-border-color: $terra-blue-70 !default;
+$terra-table-row-striped-hover-background-color: darken( $terra-blue-10, 2% ) !default;
+$terra-table-row-striped-selected-background-color: darken( $terra-blue-10, 5% ) !default;
+$terra-table-row-striped-selected-hover-background-color: darken( $terra-blue-10, 10% ) !default;

--- a/packages/terra-table/src/_variables.scss
+++ b/packages/terra-table/src/_variables.scss
@@ -4,7 +4,7 @@
 // Background Colors
 $terra-table-background-color: $terra-white !default;
 $terra-table-thead-background-color: $terra-grey-15 !default;
-$terra-table-row-th-background-color: $terra-grey-25 !default;
+$terra-table-subheader-background-color: $terra-grey-25 !default;
 $terra-table-cell-background-color: $terra-white !default;
 $terra-table-row-striped-background-color: $terra-grey-5 !default;
 $terra-table-row-striped-th-background-color: $terra-grey-25 !default;
@@ -31,9 +31,9 @@ $terra-table-thead-th-color: $terra-dark !default;
 $terra-table-sort-indicator-color: $terra-dark !default;
 
 // Table Subheader Font Styles
-$terra-table-row-th-font-size:1rem !default;
-$terra-table-row-th-font-weight: bold !default;
-$terra-table-row-th-color: $terra-dark !default;
+$terra-table-subheader-font-size:1rem !default;
+$terra-table-subheader-font-weight: bold !default;
+$terra-table-subheader-color: $terra-dark !default;
 
 // Cell Padding
 $terra-table-cell-padding-bottom: 0.5em !default;


### PR DESCRIPTION
Updated the finalized selection styles for terra-list and terra-table. Updated the header, subheader, border, and striped row colors for terra-table. Removed the responsive behavior from terra-table.

Also updated table subheader css class names to work with updates in PR#341.