### PR TITLE
fix: Add type to datepicker button to prevent unexpected form submits

### DIFF
--- a/packages/terra-date-picker/lib/DateInput.js
+++ b/packages/terra-date-picker/lib/DateInput.js
@@ -91,7 +91,8 @@ var DatePickerInput = function (_React$Component) {
           className: 'terra-DatePicker-button',
           onClick: this.props.onClick,
           onKeyDown: this.props.onKeyDown,
-          icon: Icon
+          icon: Icon,
+          type: 'button'
         })
       );
     }

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -51,6 +51,7 @@ class DatePickerInput extends React.Component {
           onClick={this.props.onClick}
           onKeyDown={this.props.onKeyDown}
           icon={Icon}
+          type="button"
         />
       </div>)
     );


### PR DESCRIPTION
### Summary
Users have reported that the small calendar icon that is present on the datepicker is a button which has a type submit on it which causes my form to submit when they try to open the calendar.

This fix is to explicitly set the button to type `button` to prevent unexpected form submissions.

@cerner/terra
