### PR TITLE
Update terra-border bidi mixin to take border shorthand strings

### DIFF
--- a/packages/terra-mixins/lib/Mixins.scss
+++ b/packages/terra-mixins/lib/Mixins.scss
@@ -104,31 +104,31 @@
   }
 }
 
-@mixin terra-border-start ($width, $style, $color) {
+@mixin terra-border-start ($border) {
   @if $terra-bidi {
     [dir='ltr'] & {
-      border-left: $width $style $color;
+      border-left: $border;
     }
 
     [dir='rtl'] & {
-      border-right: $width $style $color;
+      border-right: $border;
     }
   } @else {
-    border-left: $width $style $color;
+    border-left: $border;
   }
 }
 
-@mixin terra-border-end ($width, $style, $color) {
+@mixin terra-border-end ($border) {
   @if $terra-bidi {
     [dir='ltr'] & {
-      border-right: $width $style $color;
+      border-right: $border;
     }
 
     [dir='rtl'] & {
-      border-left: $width $style $color;
+      border-left: $border;
     }
   } @else {
-    border-right: $width $style $color;
+    border-right: $border;
   }
 }
 

--- a/packages/terra-mixins/src/Mixins.scss
+++ b/packages/terra-mixins/src/Mixins.scss
@@ -104,31 +104,31 @@
   }
 }
 
-@mixin terra-border-start ($width, $style, $color) {
+@mixin terra-border-start ($border) {
   @if $terra-bidi {
     [dir='ltr'] & {
-      border-left: $width $style $color;
+      border-left: $border;
     }
 
     [dir='rtl'] & {
-      border-right: $width $style $color;
+      border-right: $border;
     }
   } @else {
-    border-left: $width $style $color;
+    border-left: $border;
   }
 }
 
-@mixin terra-border-end ($width, $style, $color) {
+@mixin terra-border-end ($border) {
   @if $terra-bidi {
     [dir='ltr'] & {
-      border-right: $width $style $color;
+      border-right: $border;
     }
 
     [dir='rtl'] & {
-      border-left: $width $style $color;
+      border-left: $border;
     }
   } @else {
-    border-right: $width $style $color;
+    border-right: $border;
   }
 }
 

--- a/packages/terra-progress-bar/lib/ProgressBar.scss
+++ b/packages/terra-progress-bar/lib/ProgressBar.scss
@@ -26,13 +26,13 @@
 
     &::-webkit-progress-value {
       background-color: currentColor;
-      @include terra-border-end(1px, solid, #FFF);
+      @include terra-border-end(1px solid #FFF);
       @include terra-border-radius-start(0);
     }
 
     &::-ms-fill {
       background-color: currentColor;
-      @include terra-border-end(1px, solid, #FFF);
+      @include terra-border-end(1px solid #FFF);
     }
   }
 
@@ -40,11 +40,11 @@
   &[value='0'] {
     &::-webkit-progress-value {
       @include terra-border-radius-end(0);
-      @include terra-border-end(0, solid, #FFF);
+      @include terra-border-end(0 solid #FFF);
     }
 
     &::-ms-fill {
-      @include terra-border-end(0, solid, #FFF);
+      @include terra-border-end(0 solid #FFF);
     }
   }
 }
@@ -66,17 +66,17 @@
     &[value]::-moz-progress-bar {
       @include terra-border-radius-start(0);
       background-color: currentColor;
-      @include terra-border-end(1px, solid, #FFF);
+      @include terra-border-end(1px solid #FFF);
     }
 
     &[value='100'] {
-      @include terra-border-end(0, solid, #FFF);
+      @include terra-border-end(0 solid #FFF);
     }
 
     &[value='0']::-moz-progress-bar,
     &[value='100']::-moz-progress-bar {
       @include terra-border-radius-end(0);
-      @include terra-border-end(0, solid, #FFF);
+      @include terra-border-end(0 solid #FFF);
     }
   }
 }

--- a/packages/terra-progress-bar/src/ProgressBar.scss
+++ b/packages/terra-progress-bar/src/ProgressBar.scss
@@ -26,13 +26,13 @@
 
     &::-webkit-progress-value {
       background-color: currentColor;
-      @include terra-border-end(1px, solid, #FFF);
+      @include terra-border-end(1px solid #FFF);
       @include terra-border-radius-start(0);
     }
 
     &::-ms-fill {
       background-color: currentColor;
-      @include terra-border-end(1px, solid, #FFF);
+      @include terra-border-end(1px solid #FFF);
     }
   }
 
@@ -40,11 +40,11 @@
   &[value='0'] {
     &::-webkit-progress-value {
       @include terra-border-radius-end(0);
-      @include terra-border-end(0, solid, #FFF);
+      @include terra-border-end(0 solid #FFF);
     }
 
     &::-ms-fill {
-      @include terra-border-end(0, solid, #FFF);
+      @include terra-border-end(0 solid #FFF);
     }
   }
 }
@@ -66,17 +66,17 @@
     &[value]::-moz-progress-bar {
       @include terra-border-radius-start(0);
       background-color: currentColor;
-      @include terra-border-end(1px, solid, #FFF);
+      @include terra-border-end(1px solid #FFF);
     }
 
     &[value='100'] {
-      @include terra-border-end(0, solid, #FFF);
+      @include terra-border-end(0 solid #FFF);
     }
 
     &[value='0']::-moz-progress-bar,
     &[value='100']::-moz-progress-bar {
       @include terra-border-radius-end(0);
-      @include terra-border-end(0, solid, #FFF);
+      @include terra-border-end(0 solid #FFF);
     }
   }
 }

--- a/packages/terra-slide-panel/lib/SlidePanel.scss
+++ b/packages/terra-slide-panel/lib/SlidePanel.scss
@@ -100,11 +100,11 @@
     }
 
     &[data-slide-panel-panel-position='start'] > .terra-SlidePanel-panel {
-      @include terra-border-end(1px, solid, $terra-slide-panel-panel-border-color);
+      @include terra-border-end(1px solid $terra-slide-panel-panel-border-color);
     }
 
     &[data-slide-panel-panel-position='end'] > .terra-SlidePanel-panel {
-      @include terra-border-start(1px, solid, $terra-slide-panel-panel-border-color);
+      @include terra-border-start(1px solid $terra-slide-panel-panel-border-color);
     }
   }
 }

--- a/packages/terra-slide-panel/src/SlidePanel.scss
+++ b/packages/terra-slide-panel/src/SlidePanel.scss
@@ -100,11 +100,11 @@
     }
 
     &[data-slide-panel-panel-position='start'] > .terra-SlidePanel-panel {
-      @include terra-border-end(1px, solid, $terra-slide-panel-panel-border-color);
+      @include terra-border-end(1px solid $terra-slide-panel-panel-border-color);
     }
 
     &[data-slide-panel-panel-position='end'] > .terra-SlidePanel-panel {
-      @include terra-border-start(1px, solid, $terra-slide-panel-panel-border-color);
+      @include terra-border-start(1px solid $terra-slide-panel-panel-border-color);
     }
   }
 }


### PR DESCRIPTION
### Summary
Currently the `terra-border-start` and `terra-border-end` mixins expect 3 individual string values, one for width, one for style, and one for color.

`@mixin terra-border-start ($width, $style, $color)`.

This code changes the format that terra-border-start/end mixins accept input to a single string.

`@mixin terra-border-start ($border)`.

This allows users to pass in border shorthand values.

The following would all be valid values to pass to the terra-border-start/end mixin
```scss
$border1: 1px;
$border2: 3em solid;
$border3: 2rem dotted #f00;

@include terra-border-start ($border1);
@include terra-border-start ($border2);
@include terra-border-end ($border3);
```

This code change also updates all the instances we used the border-start/end mixin in terra-core to use the new format.

### Additional Details
This pull requests is to resolve an issue here: https://github.com/cerner/terra-core/pull/392#discussion_r118625718

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
