### PR TITLE
Update webpack version to 2.6.1

### DIFF
--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -77,7 +77,7 @@
     "sass-loader": "^6.0.3",
     "style-loader": "^0.16.1",
     "terra-i18n-plugin": "^0.x",
-    "webpack": "2.5.1",
+    "webpack": "^2.6.1",
     "webpack-dev-server": "^2.4.5"
   }
 }

--- a/packages/terra-toolkit/package.json
+++ b/packages/terra-toolkit/package.json
@@ -37,7 +37,7 @@
     "sauce-connect-launcher": "^1.2.0",
     "selenium-server-standalone-jar": "3.2.0",
     "shelljs": "^0.7.6",
-    "webpack": "2.5.1",
+    "webpack": "^2.6.1",
     "webpack-dev-server": "^2.4.5"
   }
 }


### PR DESCRIPTION
### Summary
Fix #385 . Webpack new 2.6.1 [link](https://github.com/webpack/webpack/commits/v2.6.1) fixed the promise issue by 4923 PR.

Consume new webpack 2.6.1 version. 