### PR TITLE
Add version number to example pages

### DIFF
--- a/packages/terra-site/src/examples/content-container/Index.jsx
+++ b/packages/terra-site/src/examples/content-container/Index.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import PropsTable from 'terra-props-table';
 import Markdown from 'terra-markdown';
 import ReadMe from 'terra-content-container/docs/README.md';
+import { version } from 'terra-content-container/package.json';
+
 // Component Source
 // eslint-disable-next-line import/no-webpack-loader-syntax, import/first, import/no-unresolved, import/extensions
 import ContentContainerSrc from '!raw-loader!terra-content-container/src/ContentContainer.jsx';
@@ -12,6 +14,7 @@ import ContentContainerFill from './ContentContainerFill';
 
 const ContentContainerExamples = () => (
   <div>
+    <div id="version">Version: {version}</div>
     <Markdown id="readme" src={ReadMe} />
     <PropsTable id="props" src={ContentContainerSrc} />
     <h2 id="standard">Standard Container</h2>

--- a/packages/terra-site/src/examples/demographics-banner/Index.jsx
+++ b/packages/terra-site/src/examples/demographics-banner/Index.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import PropsTable from 'terra-props-table';
 import Markdown from 'terra-markdown';
 import ReadMe from 'terra-demographics-banner/docs/README.md';
+import { version } from 'terra-demographics-banner/package.json';
 import DemographicsBanner from 'terra-demographics-banner';
 
 
@@ -17,6 +18,7 @@ import DemographicsBannerSrc from '!raw-loader!terra-demographics-banner/src/Dem
 
 const DemographicsBannerExamples = () => (
   <div>
+    <div id="version">Version: {version}</div>
     <Markdown id="readme" src={ReadMe} />
     <PropsTable id="props" src={DemographicsBannerSrc} />
     <h1>Basic Demographics Banner</h1>


### PR DESCRIPTION
### Summary
Currently the index files for content-container and demo-banner, do not include an entry to display their version numbers, unlike the rest of the components.

This resolves #332

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE

### Deployment Link
https://terra-core-deployed-pr-434.herokuapp.com/