### PR TITLE
Fix unexpected horizontal scrollbar addition on grids

### DIFF
--- a/packages/terra-grid/src/Grid.scss
+++ b/packages/terra-grid/src/Grid.scss
@@ -6,8 +6,7 @@
 // ========================================================
 
 .terra-Grid {
-  @include terra-margin-start(- $terra-grid-gutter-width * 0.5);
-  @include terra-margin-end(- $terra-grid-gutter-width * 0.5);
+  @include terra-margin-start(- $terra-grid-gutter-width * 1);
 
   box-sizing: border-box;
   display: flex;
@@ -19,8 +18,7 @@
 }
 
 .terra-Grid-col {
-  @include terra-padding-start($terra-grid-gutter-width * 0.5);
-  @include terra-padding-end($terra-grid-gutter-width * 0.5);
+  @include terra-padding-start($terra-grid-gutter-width * 1);
 
   box-sizing: border-box;
   flex-basis: 100%;


### PR DESCRIPTION
### Summary
Reverting to adding grid gutter spacing to match how we added it in legacy terra. Resolves #4 

#### Before
<img width="1318" alt="screen shot 2017-06-05 at 11 18 42 am" src="https://cloud.githubusercontent.com/assets/633148/26792840/5bd01456-49e1-11e7-990f-b2f1de12a1f9.png">

#### After
<img width="1314" alt="screen shot 2017-06-05 at 11 18 16 am" src="https://cloud.githubusercontent.com/assets/633148/26792853/653f0cae-49e1-11e7-8b37-cd92059399cf.png">

Thanks for contributing to Terra. 
@cerner/terra
