### PR TITLE
Add Types to Buttons

### DIFF
--- a/packages/terra-button-group/tests/jest/__snapshots__/ButtonGroupButton.test.jsx.snap
+++ b/packages/terra-button-group/tests/jest/__snapshots__/ButtonGroupButton.test.jsx.snap
@@ -6,6 +6,7 @@ exports[`test should render a default component 1`] = `
   isCompact={false}
   isDisabled={false}
   isReversed={false}
+  type="button"
   variant="default" />
 `;
 
@@ -17,6 +18,7 @@ exports[`test should render as selected 1`] = `
   isCompact={false}
   isDisabled={false}
   isReversed={false}
+  type="button"
   variant="default" />
 `;
 
@@ -33,6 +35,7 @@ exports[`test should render with icon and text 1`] = `
   isDisabled={false}
   isReversed={false}
   text="text"
+  type="button"
   variant="default" />
 `;
 
@@ -49,6 +52,7 @@ exports[`test should render with icon and text reversed 1`] = `
   isDisabled={false}
   isReversed={true}
   text="text"
+  type="button"
   variant="default" />
 `;
 
@@ -64,6 +68,7 @@ exports[`test should render with icon only 1`] = `
   isCompact={false}
   isDisabled={false}
   isReversed={false}
+  type="button"
   variant="default" />
 `;
 
@@ -76,5 +81,6 @@ exports[`test should render with text 1`] = `
   isDisabled={false}
   isReversed={false}
   text="text"
+  type="button"
   variant="default" />
 `;

--- a/packages/terra-button/src/Button.jsx
+++ b/packages/terra-button/src/Button.jsx
@@ -46,6 +46,10 @@ const propTypes = {
    */
   text: PropTypes.string,
   /**
+   * Sets the button type. One of button, submit, or reset
+   */
+  type: PropTypes.oneOf(['button', 'submit', 'reset']),
+  /**
    * Sets the button variant. One of primary, secondary, or link
    */
   variant: PropTypes.oneOf(['default', 'link', 'primary', 'secondary']),
@@ -56,6 +60,7 @@ const defaultProps = {
   isCompact: false,
   isDisabled: false,
   isReversed: false,
+  type: 'button',
   variant: 'default',
 };
 
@@ -68,6 +73,7 @@ const Button = ({
   isReversed,
   size,
   text,
+  type,
   variant,
   ...customProps
   }) => {
@@ -84,6 +90,7 @@ const Button = ({
     attributes.className,
   ]);
 
+  attributes.type = type;
   attributes.disabled = isDisabled;
   attributes.tabIndex = isDisabled ? '-1' : undefined;
   attributes['aria-disabled'] = isDisabled;

--- a/packages/terra-button/tests/jest/Button.test.jsx
+++ b/packages/terra-button/tests/jest/Button.test.jsx
@@ -22,6 +22,21 @@ it('should render a secondary button', () => {
   expect(button).toMatchSnapshot();
 });
 
+it('should render a button with type equal to button', () => {
+  const button = shallow(<Button type="button" />);
+  expect(button).toMatchSnapshot();
+});
+
+it('should render a button with type equal to reset', () => {
+  const button = shallow(<Button type="reset" />);
+  expect(button).toMatchSnapshot();
+});
+
+it('should render a button with type equal to submit', () => {
+  const button = shallow(<Button type="submit" />);
+  expect(button).toMatchSnapshot();
+});
+
 it('should render an icon', () => {
   const testElement = <img alt="icon" />;
   const button = shallow(<Button icon={testElement} size="tiny" />);

--- a/packages/terra-button/tests/jest/__snapshots__/Button.test.jsx.snap
+++ b/packages/terra-button/tests/jest/__snapshots__/Button.test.jsx.snap
@@ -8,42 +8,72 @@ exports[`test should render a Button with merged attributes 1`] = `
     Object {
       "height": "100px",
     }
-  } />
+  }
+  type="button" />
+`;
+
+exports[`test should render a button with type equal to button 1`] = `
+<button
+  aria-disabled={false}
+  className="terra-Button terra-Button--default"
+  disabled={false}
+  type="button" />
+`;
+
+exports[`test should render a button with type equal to reset 1`] = `
+<button
+  aria-disabled={false}
+  className="terra-Button terra-Button--default"
+  disabled={false}
+  type="reset" />
+`;
+
+exports[`test should render a button with type equal to submit 1`] = `
+<button
+  aria-disabled={false}
+  className="terra-Button terra-Button--default"
+  disabled={false}
+  type="submit" />
 `;
 
 exports[`test should render a default button 1`] = `
 <button
   aria-disabled={false}
   className="terra-Button terra-Button--default"
-  disabled={false} />
+  disabled={false}
+  type="button" />
 `;
 
 exports[`test should render a link button 1`] = `
 <button
   aria-disabled={false}
   className="terra-Button terra-Button--link"
-  disabled={false} />
+  disabled={false}
+  type="button" />
 `;
 
 exports[`test should render a primary button 1`] = `
 <button
   aria-disabled={false}
   className="terra-Button terra-Button--primary"
-  disabled={false} />
+  disabled={false}
+  type="button" />
 `;
 
 exports[`test should render a secondary button 1`] = `
 <button
   aria-disabled={false}
   className="terra-Button terra-Button--secondary"
-  disabled={false} />
+  disabled={false}
+  type="button" />
 `;
 
 exports[`test should render an icon 1`] = `
 <button
   aria-disabled={false}
   className="terra-Button terra-Button--default terra-Button--tiny"
-  disabled={false}>
+  disabled={false}
+  type="button">
   <img
     alt="icon" />
 </button>
@@ -53,7 +83,8 @@ exports[`test should render an icon and a text 1`] = `
 <button
   aria-disabled={false}
   className="terra-Button terra-Button--default terra-Button--tiny"
-  disabled={false}>
+  disabled={false}
+  type="button">
   <img
     alt="icon" />
   <span
@@ -68,7 +99,8 @@ exports[`test should render as an anchor when provided an href 1`] = `
   aria-disabled={false}
   className="terra-Button terra-Button--default"
   disabled={false}
-  href="MockHref">
+  href="MockHref"
+  type="button">
   <span
     className="terra-Button-text">
     href
@@ -81,7 +113,8 @@ exports[`test should render as disabled when set 1`] = `
   aria-disabled={true}
   className="terra-Button terra-Button--default is-disabled"
   disabled={true}
-  tabIndex="-1">
+  tabIndex="-1"
+  type="button">
   <span
     className="terra-Button-text">
     Disabled

--- a/packages/terra-button/tests/nightwatch/ButtonTestRoutes.jsx
+++ b/packages/terra-button/tests/nightwatch/ButtonTestRoutes.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Route } from 'react-router';
 import ButtonTests from './ButtonTests';
 import { TinyButton, SmallButton, MediumButton, LargeButton, HugeButton } from './SizeButton';
+import { ButtonWithTypeButton, ButtonWithTypeReset, ButtonWithTypeSubmit } from './ButtonTypes';
 import { DefaultButton, PrimaryButton, SecondaryButton, LinkButton } from './VariantButton';
 import { DisabledButton, DisabledLink } from './Disabled';
 import { IconDefaultButton, IconOnlyButton, IconReversedButton } from './IconButton';
@@ -28,6 +29,9 @@ const routes = (
     <Route path="/tests/button-tests/small" component={SmallButton} />
     <Route path="/tests/button-tests/tiny" component={TinyButton} />
     <Route path="/tests/button-tests/link" component={LinkButton} />
+    <Route path="/tests/button-tests/with-type-button" component={ButtonWithTypeButton} />
+    <Route path="/tests/button-tests/with-type-reset" component={ButtonWithTypeReset} />
+    <Route path="/tests/button-tests/with-type-submit" component={ButtonWithTypeSubmit} />
     <Route path="/tests/button-tests/compact" component={CompactButton} />
   </div>
 );

--- a/packages/terra-button/tests/nightwatch/ButtonTests.jsx
+++ b/packages/terra-button/tests/nightwatch/ButtonTests.jsx
@@ -20,6 +20,9 @@ const ButtonTests = () => (
       <li><Link to="/tests/button-tests/medium">Medium Button</Link></li>
       <li><Link to="/tests/button-tests/small">Small Button</Link></li>
       <li><Link to="/tests/button-tests/tiny">Tiny Button</Link></li>
+      <li><Link to="/tests/button-tests/with-type-button">Button with Type Button</Link></li>
+      <li><Link to="/tests/button-tests/with-type-reset">Button with Type Reset</Link></li>
+      <li><Link to="/tests/button-tests/with-type-submit">Button with Type Submit</Link></li>
       <li><Link to="/tests/button-tests/link">Link</Link></li>
       <li><Link to="/tests/button-tests/compact">Compact</Link></li>
     </ul>

--- a/packages/terra-button/tests/nightwatch/ButtonTypes.jsx
+++ b/packages/terra-button/tests/nightwatch/ButtonTypes.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import Button from '../../lib/Button';
+
+const ButtonWithTypeButton = () => <Button text="Button Type is Default" type="button" />;
+const ButtonWithTypeReset = () => <Button text="Button Type is Reset" type="reset" />;
+const ButtonWithTypeSubmit = () => <Button text="Button Type is Submit" type="submit" />;
+
+export {
+  ButtonWithTypeButton,
+  ButtonWithTypeReset,
+  ButtonWithTypeSubmit,
+};

--- a/packages/terra-button/tests/nightwatch/button-spec.js
+++ b/packages/terra-button/tests/nightwatch/button-spec.js
@@ -83,6 +83,24 @@ module.exports = {
       .assert.containsText('.terra-Button.terra-Button--huge', 'Huge');
   },
 
+  'Displays as a button with the type set to button and with the provided text': (browser) => {
+    browser
+      .url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/button-tests/with-type-button`)
+      .assert.containsText('.terra-Button[type="button"]', 'Button Type is Default');
+  },
+
+  'Displays as a button with the type set to reset and with the provided text': (browser) => {
+    browser
+      .url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/button-tests/with-type-reset`)
+      .assert.containsText('.terra-Button[type="reset"]', 'Button Type is Reset');
+  },
+
+  'Displays as a button with the type set to submit and with the provided text': (browser) => {
+    browser
+      .url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/button-tests/with-type-submit`)
+      .assert.containsText('.terra-Button[type="submit"]', 'Button Type is Submit');
+  },
+
   'Displays an icon inline with the provided text': (browser) => {
     browser
       .url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/button-tests/icon-default`)

--- a/packages/terra-search-field/tests/jest/__snapshots__/SearchField.test.jsx.snap
+++ b/packages/terra-search-field/tests/jest/__snapshots__/SearchField.test.jsx.snap
@@ -14,6 +14,7 @@ exports[`Snapshots renders a basic search field 1`] = `
     isDisabled={false}
     isReversed={false}
     onClick={[Function]}
+    type="button"
     variant="default">
     <IconSearch
       data-name="Layer 1"
@@ -39,6 +40,7 @@ exports[`Snapshots renders a search field with a placeholder 1`] = `
     isDisabled={false}
     isReversed={false}
     onClick={[Function]}
+    type="button"
     variant="default">
     <IconSearch
       data-name="Layer 1"
@@ -64,6 +66,7 @@ exports[`Snapshots renders a search field with a value 1`] = `
     isDisabled={false}
     isReversed={false}
     onClick={[Function]}
+    type="button"
     variant="default">
     <IconSearch
       data-name="Layer 1"


### PR DESCRIPTION
### Summary
This adds the ability to add the type attribute to any terra buttons. This allows for more consistent and better browser performance when working with buttons.
