### PR TITLE
Fix Docs and First Class Props of Control

### DIFF
--- a/packages/terra-form/docs/Control.md
+++ b/packages/terra-form/docs/Control.md
@@ -14,8 +14,7 @@ import Control from 'terra-form/lib/Control';
   labelAttrs={{ className: 'healtheintent-application' }}
   name="children_present"
   value="children_present"
-  error="This field is required"
-  help="Families are eligible for family package"
+  onChange={() => {}}
   required={true}
   textAttrs={{ className: 'healtheintent-control-label' }}
   isInline={false}

--- a/packages/terra-form/docs/Control.md
+++ b/packages/terra-form/docs/Control.md
@@ -10,13 +10,14 @@ import Control from 'terra-form/lib/Control';
 
 <Control
   type="checkbox"
+  defaultChecked={false}
+  id="form-checkbox"
+  inputAttrs={{ className: 'healtheintent-checkbox' }}
   labelText="Do you have any Children?"
-  labelAttrs={{ className: 'healtheintent-application' }}
+  labelTextAttrs={{ className: 'healtheintent-control-label-text' }}
   name="children_present"
-  value="children_present"
   onChange={() => {}}
-  required={true}
-  textAttrs={{ className: 'healtheintent-control-label' }}
-  isInline={false}
+  value="children_present"
+  isInline
  />
 ```

--- a/packages/terra-form/src/Control.jsx
+++ b/packages/terra-form/src/Control.jsx
@@ -45,6 +45,10 @@ const propTypes = {
    */
   name: PropTypes.string,
   /**
+   * Function to trigger when user clicks on the input. Provide a function to create a controlled input.
+   */
+  onChange: PropTypes.func,
+  /**
    * The Value of the input element
    */
   value: PropTypes.string,
@@ -60,10 +64,24 @@ const defaultProps = {
   labelText: null,
   labelTextAttrs: {},
   name: null,
+  onChange: undefined,
   value: undefined,
 };
 
-const Control = ({ type, checked, defaultChecked, inputAttrs, id, isInline, labelText, labelTextAttrs, name, value, ...customProps }) => {
+const Control = ({
+  type,
+  checked,
+  defaultChecked,
+  inputAttrs,
+  id,
+  isInline,
+  labelText,
+  labelTextAttrs,
+  name,
+  onChange,
+  value,
+  ...customProps
+}) => {
   const labelClassNames = classNames(
     'terra-Form-control',
     { 'terra-Form-control--inline': isInline },
@@ -90,6 +108,7 @@ const Control = ({ type, checked, defaultChecked, inputAttrs, id, isInline, labe
         name={name}
         value={value}
         type={type}
+        onChange={onChange}
         {...controlInputAttrs}
       />
       <span {...labelTextAttrs} className={labelTextClasses}>{labelText}</span>

--- a/packages/terra-form/tests/jest/__snapshots__/Control.test.jsx.snap
+++ b/packages/terra-form/tests/jest/__snapshots__/Control.test.jsx.snap
@@ -58,11 +58,11 @@ exports[`test should render a default checkbox when type is "radio" 1`] = `
 
 exports[`test should render as an controlled checkbox when a checked value and onChange function are passed into the Control 1`] = `
 <label
-  className="terra-Form-control"
-  onChange={[Function]}>
+  className="terra-Form-control">
   <Input
     checked={true}
     name={null}
+    onChange={[Function]}
     required={false}
     type="checkbox" />
   <span
@@ -72,11 +72,11 @@ exports[`test should render as an controlled checkbox when a checked value and o
 
 exports[`test should render as an controlled radio when a checked value and onChange function are passed into the Control 1`] = `
 <label
-  className="terra-Form-control"
-  onChange={[Function]}>
+  className="terra-Form-control">
   <Input
     checked={true}
     name={null}
+    onChange={[Function]}
     required={false}
     type="radio" />
   <span


### PR DESCRIPTION
### Summary
Control Inputs have a few small issues with them

- The docs have incorrect props on them. They provide error and help examples, even though Control does not support those values.
- onChange should be a first class attribute that is passed into the input.