### PR TITLE
Add changelog for terra-grid

### DIFF
--- a/packages/terra-grid/CHANGELOG.md
+++ b/packages/terra-grid/CHANGELOG.md
@@ -1,71 +1,71 @@
 Terra Grid Changelog
 ====================
 
-3.1.0 - 2017-06-20
+3.1.0 (June 20, 2017)
 ------------------
-### Enhancements
+### Dependency Updates
 * Bump dependency on terra-base to `^0.7.0`
 
-3.0.0 - 2017-06-13
+3.0.0 (June 13, 2017)
 ------------------
 ### Breaking Changes
 * Remove theming capability in grid component
 
-### Enhancements
+### Dependency Updates
 * Bump dependency on terra-base to `^0.6.0`
 * Bump dependency on terra-mixins to `^1.3.0`
 
-2.4.1 - 2017-06-07
+2.4.1 (June 7, 2017)
 ------------------
 ### Bug Fix
 * Fix unexpected horizontal scrollbar addition on grids
 
-2.4.0 - 2017-06-01
+2.4.0 (June 1, 2017)
 ------------------
 ### Removals
 * Remove lib directory from npm package
 
-### Enhancements
+### Dependency Updates
 * Bump dependency on terra-base to `^0.5.0`
 * Bump dependency on terra-mixins to `^1.2.0`
 * Bump devDependency on terra-toolkit to `^0.4.0`
 
-2.3.2 - 2017-05-25
+2.3.2 (May 25, 2017)
 ------------------
-### Enhancements
+### Dependency Updates
 * Bump dependency on terra-base to `^0.4.2`
 * Bump devDependency on terra-toolkit to `^0.3.2`
 
-2.3.1 - 2017-05-16
+2.3.1 (May 16, 2017)
 ------------------
-### Enhancements
+### Dependency Updates
 * Bump dependency on terra-base to `^0.4.1`
 * Bump dependency on terra-mixins to `^1.1.0`
 * Bump devDependency on terra-toolkit to `^0.3.1`
 
-2.3.0 - 2017-05-16
+2.3.0 (May 16, 2017)
 ------------------
-### Enhancements
+### Dependency Updates
 * Bump dependency on terra-base to `^0.4.0`
 * Add prop-types `^15.5.8` as a dependency
 
-2.2.0 - 2017-04-26
+2.2.0 (April 26, 2017)
 ------------------
-### Enhancements
+### Dependency Updates
 * Add terra-base `^0.x` as a dependency
 
-2.1.0 - 2017-04-12
+2.1.0 (April 12, 2017)
 ------------------
-### Enhancements
+### Dependency Updates
 * Add terra-base `^0.x` as a peerDependency
 
-2.0.0 - 2017-03-30
+2.0.0 (March 30, 2017)
 ------------------
 ### Breaking Changes
 * Convert component to ReactJS
 * Remove grid alignment and justify modifiers
 * Remove grid flex-direction and flex-basis modifiers
 
-1.0.0 - 2016-10-14
+1.0.0 - (October 14, 2016)
 ------------------
 Initial stable release

--- a/packages/terra-grid/CHANGELOG.md
+++ b/packages/terra-grid/CHANGELOG.md
@@ -1,0 +1,71 @@
+Terra Grid Changelog
+====================
+
+3.1.0 - 2017-06-20
+------------------
+### Enhancements
+* Bump dependency on terra-base to `^0.7.0`
+
+3.0.0 - 2017-06-13
+------------------
+### Breaking Changes
+* Remove theming capability in grid component
+
+### Enhancements
+* Bump dependency on terra-base to `^0.6.0`
+* Bump dependency on terra-mixins to `^1.3.0`
+
+2.4.1 - 2017-06-07
+------------------
+### Bug Fix
+* Fix unexpected horizontal scrollbar addition on grids
+
+2.4.0 - 2017-06-01
+------------------
+### Removals
+* Remove lib directory from npm package
+
+### Enhancements
+* Bump dependency on terra-base to `^0.5.0`
+* Bump dependency on terra-mixins to `^1.2.0`
+* Bump devDependency on terra-toolkit to `^0.4.0`
+
+2.3.2 - 2017-05-25
+------------------
+### Enhancements
+* Bump dependency on terra-base to `^0.4.2`
+* Bump devDependency on terra-toolkit to `^0.3.2`
+
+2.3.1 - 2017-05-16
+------------------
+### Enhancements
+* Bump dependency on terra-base to `^0.4.1`
+* Bump dependency on terra-mixins to `^1.1.0`
+* Bump devDependency on terra-toolkit to `^0.3.1`
+
+2.3.0 - 2017-05-16
+------------------
+### Enhancements
+* Bump dependency on terra-base to `^0.4.0`
+* Add prop-types `^15.5.8` as a dependency
+
+2.2.0 - 2017-04-26
+------------------
+### Enhancements
+* Add terra-base `^0.x` as a dependency
+
+2.1.0 - 2017-04-12
+------------------
+### Enhancements
+* Add terra-base `^0.x` as a peerDependency
+
+2.0.0 - 2017-03-30
+------------------
+### Breaking Changes
+* Convert component to ReactJS
+* Remove grid alignment and justify modifiers
+* Remove grid flex-direction and flex-basis modifiers
+
+1.0.0 - 2016-10-14
+------------------
+Initial stable release

--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-site",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Documentation Site for Functional Verification",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Summary
Adding changelog for grid since its v1.0.0 release to now.

### Additional Details
We can use this review to decide what format we like for the CHANGELOG file. Based on this review, I'll add a change log to terra-mixins for v1.0.0+ releases and all the other components when we release them as v1.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
