### PR TITLE
Issue-493 Fix onChange not updating with correct index

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,6 +23,7 @@ Cerner Corporation
 - David Schoonover [@dkschoonover]
 - Christian Alten [@cwalten]
 - Viren Sawant [@viren140290]
+- Madeline Gilbert [@madelineisabelle]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -48,3 +49,4 @@ Cerner Corporation
 [@dkschoonover]: https://github.com/dkschoonover
 [@cwalten]: https://github.com/cwalten
 [@viren140290]: https://github.com/viren140290
+[@madelineisabelle]: https://github.com/madelineisabelle

--- a/packages/terra-button-group/src/ButtonGroup.jsx
+++ b/packages/terra-button-group/src/ButtonGroup.jsx
@@ -85,7 +85,7 @@ class ButtonGroup extends React.Component {
       this.setState({ selectedIndex: index });
 
       if (this.props.onChange) {
-        this.props.onChange(this.state.selectedIndex);
+        this.props.onChange(index);
       }
     }
   }

--- a/packages/terra-button-group/tests/jest/ButtonGroup.test.jsx
+++ b/packages/terra-button-group/tests/jest/ButtonGroup.test.jsx
@@ -64,3 +64,15 @@ it('should render a button group with children', () => {
   ));
   expect(buttonGroup).toMatchSnapshot();
 });
+
+it('should send correct index when onChange is triggered', () => {
+  const onChange = jest.fn();
+  const isSelectable = true;
+  const buttonGroup = shallow(<ButtonGroup onChange={onChange} isSelectable={isSelectable} buttons={[<ButtonGroup.Button key="1" />, <ButtonGroup.Button key="2" />]} />);
+
+  buttonGroup.childAt(1).simulate('click');
+  expect(onChange).toBeCalledWith(1);
+
+  buttonGroup.childAt(0).simulate('click');
+  expect(onChange).toBeCalledWith(0);
+});


### PR DESCRIPTION
### Summary
#493 Fixing onChange receiving incorrect index because setState is not synchronous