### PR TITLE
Update Arrange.scss to fix weight model data source wrap issue

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,6 +27,7 @@ Cerner Corporation
 - Matt Schile [@mschile]
 - Madeline Gilbert [@madelineisabelle]
 - Michael Hemesath [@mhemesath]
+- Umesh Shimpi [@us044466]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -56,3 +57,4 @@ Cerner Corporation
 [@mschile]: https://github.com/mschile
 [@madelineisabelle]: https://github.com/madelineisabelle
 [@mhemesath]: https://github.com/mhemesath
+[@us044466]: https://github.com/us044466

--- a/packages/terra-arrange/src/Arrange.scss
+++ b/packages/terra-arrange/src/Arrange.scss
@@ -19,6 +19,7 @@
   display: block;
   flex: 1;
   min-width: 0;
+  flex-basis: auto;
 }
 
 // Styles specific to align items independently of each other

--- a/packages/terra-arrange/src/Arrange.scss
+++ b/packages/terra-arrange/src/Arrange.scss
@@ -17,8 +17,8 @@
 // Display set to ensure correct appreance if applied to inline elements like span
 .terra-Arrange-fill {
   display: block;
+  flex-basis: auto;
   flex: 1;
-  flex-basis: auto;  
   min-width: 0;
 }
 

--- a/packages/terra-arrange/src/Arrange.scss
+++ b/packages/terra-arrange/src/Arrange.scss
@@ -18,8 +18,8 @@
 .terra-Arrange-fill {
   display: block;
   flex: 1;
+  flex-basis: auto;  
   min-width: 0;
-  flex-basis: auto;
 }
 
 // Styles specific to align items independently of each other

--- a/packages/terra-arrange/src/Arrange.scss
+++ b/packages/terra-arrange/src/Arrange.scss
@@ -17,8 +17,8 @@
 // Display set to ensure correct appreance if applied to inline elements like span
 .terra-Arrange-fill {
   display: block;
-  flex-basis: auto;
   flex: 1;
+  flex-basis: auto;
   min-width: 0;
 }
 


### PR DESCRIPTION
Issue: Datasource in weight model does not wrap in IE
![ie_issue_datasource](https://user-images.githubusercontent.com/29923454/27878293-bc901b8a-618b-11e7-9a88-2e468d301dbb.gif)

Solution: flex-basis: auto fixes this issue with IE and edge. Also tested in other browsers
![datasource_ie_fix](https://user-images.githubusercontent.com/29923454/27878327-d9370316-618b-11e7-90c1-ab1563b05394.gif)

Note: There's another r_wellness PR to fix other issues
https://github.cerner.com/HealtheLife/r_wellness/pull/466

### Deployment Link:
https://terra-core-deployed-pr-576.herokuapp.com/
