### PR TITLE
Add custom-property-no-outside-root stylelint rule

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,8 +1,12 @@
 {
   "extends": "stylelint-config-sass-guidelines",
+  "plugins": [
+     "stylelint-suitcss"
+  ],
   "rules": {
     "max-nesting-depth": 3,
     "scss/at-mixin-pattern": "^(terra-)[a-z]+([a-z0-9-]+[a-z0-9]+)?$",
+    "suitcss/custom-property-no-outside-root": true,
     "custom-property-pattern": [
       "^terra-(?:[A-Z][a-zA-Z0-9]+)*(?:-[a-z0-9][a-zA-Z0-9]+)*?(?:--[a-z0-9][a-zA-Z0-9-]+)*?$",
       {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "rimraf": "^2.6.1",
     "shelljs": "^0.7.7",
     "stylelint": "^7.10.1",
-    "stylelint-config-sass-guidelines": "^2.1.0"
+    "stylelint-config-sass-guidelines": "^2.1.0",
+    "stylelint-suitcss": "^1.0.0"
   }
 }


### PR DESCRIPTION
### Summary
Adding [stylelint rule](https://github.com/suitcss/stylelint-suitcss/blob/master/rules/custom-property-no-outside-root/README.md) that disallows setting the value of a CSS custom properties outside of :root selectors. This enforces the limitation set by [postcss-custom-properties](https://github.com/postcss/postcss-custom-properties):

> It currently just aims to provide a future-proof way of using a limited subset (to :root selector) of the features provided by native CSS custom properties.

**The following patterns are considered errors:**

```css
a { --terra-Badge-borderRadius: 5px; }
:root, a { --terra-Badge-borderRadius: 5px; }
```

**The following patterns are not considered errors:**

```css
:root { --terra-Badge-borderRadius: 5px; }
```
Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
