### PR TITLE
Migrated time-input to CSS modules

### DIFF
--- a/packages/terra-time-input/CHANGELOG.md
+++ b/packages/terra-time-input/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Converted component to use CSS modules
 
 1.0.0 - (June 28, 2017)
 ------------------

--- a/packages/terra-time-input/src/TimeInput.jsx
+++ b/packages/terra-time-input/src/TimeInput.jsx
@@ -268,7 +268,7 @@ class TimeInput extends React.Component {
         <Input
           {...inputAttributes}
           ref={(inputRef) => { this.hourInput = inputRef; }}
-          className={styles['time-input-hour']}
+          className={cx('time-input-hour')}
           type="text"
           value={this.state.hour}
           name={'terra-time-hour-'.concat(name)}
@@ -284,7 +284,7 @@ class TimeInput extends React.Component {
         <Input
           {...inputAttributes}
           ref={(inputRef) => { this.minuteInput = inputRef; }}
-          className={styles['time-input-minute']}
+          className={cx('time-input-minute')}
           type="text"
           value={this.state.minute}
           name={'terra-time-minute-'.concat(name)}

--- a/packages/terra-time-input/src/TimeInput.jsx
+++ b/packages/terra-time-input/src/TimeInput.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import classNames from 'classnames/bind';
 import 'terra-base/lib/baseStyles';
 import Input from 'terra-form/lib/Input';
 import TimeUtil from './TimeUtil';
-import './TimeInput.scss';
+import styles from './TimeInput.scss';
+
+const cx = classNames.bind(styles);
 
 const propTypes = {
   /**
@@ -242,8 +244,8 @@ class TimeInput extends React.Component {
       ...customProps
     } = this.props;
 
-    const timeInputClassNames = classNames([
-      'terra-TimeInput',
+    const timeInputClassNames = cx([
+      'time-input',
       { 'is-focused': this.state.isFocused },
       customProps.className,
     ]);
@@ -259,7 +261,6 @@ class TimeInput extends React.Component {
         <input
           // Create a hidden input for storing the name and value attributes to use when submitting the form.
           // The data stored in the value attribute will be the visible date in the date input but in ISO 8601 format.
-          className="terra-hidden-time-input"
           type="hidden"
           name={name}
           value={timeValue}
@@ -267,7 +268,7 @@ class TimeInput extends React.Component {
         <Input
           {...inputAttributes}
           ref={(inputRef) => { this.hourInput = inputRef; }}
-          className="terra-TimeInput-hour"
+          className={styles['time-input-hour']}
           type="text"
           value={this.state.hour}
           name={'terra-time-hour-'.concat(name)}
@@ -283,7 +284,7 @@ class TimeInput extends React.Component {
         <Input
           {...inputAttributes}
           ref={(inputRef) => { this.minuteInput = inputRef; }}
-          className="terra-TimeInput-minute"
+          className={styles['time-input-minute']}
           type="text"
           value={this.state.minute}
           name={'terra-time-minute-'.concat(name)}

--- a/packages/terra-time-input/src/TimeInput.scss
+++ b/packages/terra-time-input/src/TimeInput.scss
@@ -1,32 +1,36 @@
-@import '~terra-mixins';
-
 // stylelint-disable declaration-property-value-blacklist
-.terra-TimeInput {
-  @include terra-border-radius-start(0.25em);
-  @include terra-border-radius-end(0.25em);
-  background-color: transparent;
-  border: #dedfe0 solid 1px;
-  display: inline-block;
-  margin: 0;
+/* stylelint-disable selector-class-pattern  */
+:local {
+  .time-input {
+    background-color: transparent;
+    border: #dedfe0 solid 1px;
+    border-bottom-left-radius: 0.25em;
+    border-bottom-right-radius: 0.25em;
+    border-top-left-radius: 0.25em;
+    border-top-right-radius: 0.25em;
+    display: inline-block;
+    margin: 0;
 
-  &.is-focused {
-    border-color: #26a2e5;
-    outline: none;
+    &.is-focused {
+      border-color: #26a2e5;
+      outline: none;
+    }
+  }
+
+  .time-input-hour,
+  .time-input-minute {
+    border: none;
+    display: inline-block;
+    margin: 0;
+    min-width: 2.1em;
+    padding: 0.179em 0;
+    text-align: center;
+    width: 2.1em;
+
+    &:focus {
+      border-color: none;
+      outline: none;
+    }
   }
 }
-
-.terra-TimeInput-hour,
-.terra-TimeInput-minute {
-  border: none;
-  display: inline-block;
-  margin: 0;
-  min-width: 2.1em;
-  padding: 0.179em 0;
-  text-align: center;
-  width: 2.1em;
-
-  &:focus {
-    border-color: none;
-    outline: none;
-  }
-}
+/* stylelint-enable */

--- a/packages/terra-time-input/tests/jest/__snapshots__/TimeInput.test.jsx.snap
+++ b/packages/terra-time-input/tests/jest/__snapshots__/TimeInput.test.jsx.snap
@@ -1,13 +1,12 @@
 exports[`test should render a default time input 1`] = `
 <div
-  className="terra-TimeInput">
+  className="time-input">
   <input
-    className="terra-hidden-time-input"
     name="time-input"
     type="hidden"
     value="" />
   <Input
-    className="terra-TimeInput-hour"
+    className="time-input-hour"
     maxLength="2"
     name="terra-time-hour-time-input"
     onBlur={[Function]}
@@ -23,7 +22,7 @@ exports[`test should render a default time input 1`] = `
     :
   </span>
   <Input
-    className="terra-TimeInput-minute"
+    className="time-input-minute"
     maxLength="2"
     name="terra-time-minute-time-input"
     onBlur={[Function]}
@@ -40,14 +39,13 @@ exports[`test should render a default time input 1`] = `
 
 exports[`test should render a time input with a default time 1`] = `
 <div
-  className="terra-TimeInput">
+  className="time-input">
   <input
-    className="terra-hidden-time-input"
     name="time-input"
     type="hidden"
     value="T10:45" />
   <Input
-    className="terra-TimeInput-hour"
+    className="time-input-hour"
     maxLength="2"
     name="terra-time-hour-time-input"
     onBlur={[Function]}
@@ -63,7 +61,7 @@ exports[`test should render a time input with a default time 1`] = `
     :
   </span>
   <Input
-    className="terra-TimeInput-minute"
+    className="time-input-minute"
     maxLength="2"
     name="terra-time-minute-time-input"
     onBlur={[Function]}
@@ -80,14 +78,13 @@ exports[`test should render a time input with a default time 1`] = `
 
 exports[`test should render a time input with custom attributes 1`] = `
 <div
-  className="terra-TimeInput">
+  className="time-input">
   <input
-    className="terra-hidden-time-input"
     name="time-input"
     type="hidden"
     value="" />
   <Input
-    className="terra-TimeInput-hour"
+    className="time-input-hour"
     id="terra-time-input"
     maxLength="2"
     name="terra-time-hour-time-input"
@@ -104,7 +101,7 @@ exports[`test should render a time input with custom attributes 1`] = `
     :
   </span>
   <Input
-    className="terra-TimeInput-minute"
+    className="time-input-minute"
     id="terra-time-input"
     maxLength="2"
     name="terra-time-minute-time-input"
@@ -122,14 +119,13 @@ exports[`test should render a time input with custom attributes 1`] = `
 
 exports[`test should render a time input with onChange 1`] = `
 <div
-  className="terra-TimeInput">
+  className="time-input">
   <input
-    className="terra-hidden-time-input"
     name="time-input"
     type="hidden"
     value="" />
   <Input
-    className="terra-TimeInput-hour"
+    className="time-input-hour"
     maxLength="2"
     name="terra-time-hour-time-input"
     onBlur={[Function]}
@@ -145,7 +141,7 @@ exports[`test should render a time input with onChange 1`] = `
     :
   </span>
   <Input
-    className="terra-TimeInput-minute"
+    className="time-input-minute"
     maxLength="2"
     name="terra-time-minute-time-input"
     onBlur={[Function]}

--- a/packages/terra-time-input/tests/nightwatch/component/TimeInputDefault.jsx
+++ b/packages/terra-time-input/tests/nightwatch/component/TimeInputDefault.jsx
@@ -3,6 +3,7 @@ import TimeInput from '../../../lib/TimeInput';
 
 const TimeInputDefault = () => (
   <TimeInput
+    id="timeInput"
     name="time-input"
   />
 );

--- a/packages/terra-time-input/tests/nightwatch/component/TimeInputDefaultTime.jsx
+++ b/packages/terra-time-input/tests/nightwatch/component/TimeInputDefaultTime.jsx
@@ -7,6 +7,7 @@ const handleOnChange = (event, time) => {
 
 const TimeInputDefault = () => (
   <TimeInput
+    id="timeInput"
     name="time-input"
     value={'12:00'}
     onChange={handleOnChange}

--- a/packages/terra-time-input/tests/nightwatch/time-input-spec.js
+++ b/packages/terra-time-input/tests/nightwatch/time-input-spec.js
@@ -15,209 +15,208 @@ module.exports = {
   'Displays the time input with default props': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.expect.element('.terra-TimeInput').to.be.present;
-    browser.expect.element('.terra-TimeInput-hour').to.be.present;
-    browser.expect.element('.terra-TimeInput-minute').to.be.present;
-    browser.expect.element('.terra-TimeInput-hour').to.have.attribute('placeholder').equals('hh');
-    browser.expect.element('.terra-TimeInput-minute').to.have.attribute('placeholder').equals('mm');
+    browser.expect.element('#timeInput').to.be.present;
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.be.present;
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.be.present;
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('placeholder').equals('hh');
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('placeholder').equals('mm');
   },
 
   'Displays the time input with a default time': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default-time`);
 
-    browser.expect.element('.terra-TimeInput-hour').to.be.present;
-    browser.expect.element('.terra-TimeInput-hour').to.have.attribute('value').equals('12');
-    browser.expect.element('.terra-TimeInput-minute').to.be.present;
-    browser.expect.element('.terra-TimeInput-minute').to.have.attribute('value').equals('00');
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.be.present;
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('value').equals('12');
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.be.present;
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('00');
   },
 
   'Time input accepts valid time entry and jumps to the minute input when the hour input has a valid entry': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-hour');
+    browser.click('#timeInput input[name="terra-time-hour-time-input"]');
 
     browser.keys('1234');
-    browser.expect.element('.terra-TimeInput-hour').to.have.attribute('value').equals('12');
-    browser.expect.element('.terra-TimeInput-minute').to.have.attribute('value').equals('34');
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('value').equals('12');
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('34');
   },
 
   'Prepends 0 on deblur when the value in the hour input is a single digit': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-hour');
+    browser.click('#timeInput input[name="terra-time-hour-time-input"]');
     browser.keys('2');
-    browser.click('.terra-TimeInput-minute');
-    browser.expect.element('.terra-TimeInput-hour').to.have.attribute('value').equals('02');
+    browser.click('#timeInput input[name="terra-time-minute-time-input"]');
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('value').equals('02');
   },
 
   'Prepends 0 on deblur when the value in the minute input is a single digit': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-minute');
+    browser.click('#timeInput input[name="terra-time-minute-time-input"]');
     browser.keys('2');
-    browser.click('.terra-TimeInput-hour');
-    browser.expect.element('.terra-TimeInput-minute').to.have.attribute('value').equals('02');
+    browser.click('#timeInput input[name="terra-time-hour-time-input"]');
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('02');
   },
 
   'Hour input prepends 0 to the hour if the entered hour is >= 3': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-hour');
+    browser.click('#timeInput input[name="terra-time-hour-time-input"]');
 
     browser.keys('3');
-    browser.expect.element('.terra-TimeInput-hour').to.have.attribute('value').equals('03');
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('value').equals('03');
   },
 
   'Hour input does not prepends 0 to the hour if the entered hour is < 3': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-hour');
+    browser.click('#timeInput input[name="terra-time-hour-time-input"]');
 
     browser.keys('2');
-    browser.expect.element('.terra-TimeInput-hour').to.have.attribute('value').equals('2');
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('value').equals('2');
   },
 
   'Hour input does not accept entered hour is > 23': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-hour');
+    browser.click('#timeInput input[name="terra-time-hour-time-input"]');
 
     browser.keys('24');
-    browser.expect.element('.terra-TimeInput-hour').to.have.attribute('value').equals('2');
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('value').equals('2');
   },
 
   'Minute input prepends 0 to the minute if the entered minute is >= 6': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-minute');
+    browser.click('#timeInput input[name="terra-time-minute-time-input"]');
 
     browser.keys('6');
-    browser.expect.element('.terra-TimeInput-minute').to.have.attribute('value').equals('06');
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('06');
   },
 
   'Minute input does not prepends 0 to the minute if the entered minute is < 6': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-minute');
+    browser.click('#timeInput input[name="terra-time-minute-time-input"]');
 
     browser.keys('5');
-    browser.expect.element('.terra-TimeInput-minute').to.have.attribute('value').equals('5');
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('5');
   },
 
   'Minute input does not accept entered minute is > 59': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-minute');
+    browser.click('#timeInput input[name="terra-time-minute-time-input"]');
 
     browser.keys('66');
-    browser.expect.element('.terra-TimeInput-minute').to.have.attribute('value').equals('06');
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('06');
   },
 
   'Pressing the DOWN_ARROW key decrements the hour by 1 hour': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default-time`);
 
-    browser.click('.terra-TimeInput-hour');
+    browser.click('#timeInput input[name="terra-time-hour-time-input"]');
 
-    browser.expect.element('.terra-TimeInput-hour').to.have.attribute('value').equals('12');
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('value').equals('12');
     browser.keys(browser.Keys.DOWN_ARROW);
-    browser.expect.element('.terra-TimeInput-hour').to.have.attribute('value').equals('11');
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('value').equals('11');
   },
 
   'Pressing the UP_ARROW key increments the hour by 1 hour': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default-time`);
 
-    browser.click('.terra-TimeInput-hour');
+    browser.click('#timeInput input[name="terra-time-hour-time-input"]');
 
-    browser.expect.element('.terra-TimeInput-hour').to.have.attribute('value').equals('12');
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('value').equals('12');
     browser.keys(browser.Keys.UP_ARROW);
-    browser.expect.element('.terra-TimeInput-hour').to.have.attribute('value').equals('13');
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('value').equals('13');
   },
 
   'Pressing the UP_ARROW key is ignored when the hour has reached 23': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-hour');
+    browser.click('#timeInput input[name="terra-time-hour-time-input"]');
 
     browser.keys('23');
     browser.keys(browser.Keys.UP_ARROW);
     browser.keys(browser.Keys.UP_ARROW);
-    browser.expect.element('.terra-TimeInput-hour').to.have.attribute('value').equals('23');
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('value').equals('23');
   },
 
   'Pressing the DOWN_ARROW key is ignored when the hour is 00': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-hour');
+    browser.click('#timeInput input[name="terra-time-hour-time-input"]');
 
     browser.keys(browser.Keys.DOWN_ARROW);
     browser.keys(browser.Keys.DOWN_ARROW);
-    browser.expect.element('.terra-TimeInput-hour').to.have.attribute('value').equals('00');
+    browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('value').equals('00');
   },
 
   'Pressing the DOWN_ARROW key decrements the minute by 1 minute': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-minute');
+    browser.click('#timeInput input[name="terra-time-minute-time-input"]');
     browser.keys('30');
 
-    browser.expect.element('.terra-TimeInput-minute').to.have.attribute('value').equals('30');
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('30');
     browser.keys(browser.Keys.DOWN_ARROW);
-    browser.expect.element('.terra-TimeInput-minute').to.have.attribute('value').equals('29');
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('29');
   },
 
   'Pressing the UP_ARROW key increments the minute by 1 minute': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-minute');
+    browser.click('#timeInput input[name="terra-time-minute-time-input"]');
     browser.keys('30');
 
-    browser.expect.element('.terra-TimeInput-minute').to.have.attribute('value').equals('30');
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('30');
     browser.keys(browser.Keys.UP_ARROW);
-    browser.expect.element('.terra-TimeInput-minute').to.have.attribute('value').equals('31');
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('31');
   },
 
   'Pressing the UP_ARROW key is ignored when the minute has reached 59': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-minute');
+    browser.click('#timeInput input[name="terra-time-minute-time-input"]');
 
     browser.keys('59');
     browser.keys(browser.Keys.UP_ARROW);
     browser.keys(browser.Keys.UP_ARROW);
-    browser.expect.element('.terra-TimeInput-minute').to.have.attribute('value').equals('59');
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('59');
   },
 
   'Pressing the DOWN_ARROW key is ignored when the minute is 00': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.click('.terra-TimeInput-minute');
+    browser.click('#timeInput input[name="terra-time-minute-time-input"]');
 
     browser.keys(browser.Keys.DOWN_ARROW);
     browser.keys(browser.Keys.DOWN_ARROW);
-    browser.expect.element('.terra-TimeInput-minute').to.have.attribute('value').equals('00');
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('00');
   },
 
   'Pressing the DELETE key in the minute input when there is no value will move focus to the hour input': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default-time`);
 
-    browser.click('.terra-TimeInput-minute');
+    browser.click('#timeInput input[name="terra-time-minute-time-input"]');
 
     browser.keys(browser.Keys.DELETE);
-    browser.expect.element('.terra-TimeInput-minute').to.have.attribute('value').equals('00');
+    browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('00');
   },
 
   'Creates a hidden input with a name atribute of "time-input" and an empty value attribute when no time is entered': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default`);
 
-    browser.expect.element('.terra-hidden-time-input').to.have.attribute('name').which.equals('time-input');
-    browser.expect.element('.terra-hidden-time-input').to.have.attribute('value').which.equals('');
+    browser.expect.element('#timeInput input[type="hidden"]').to.have.attribute('name').which.equals('time-input');
+    browser.expect.element('#timeInput input[type="hidden"]').to.have.attribute('value').which.equals('');
   },
 
   'Creates a hidden input with a name atribute of "time-input" and sets the time in the value attribute.': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/time-input-tests/default-time`);
 
-    browser.expect.element('.terra-hidden-time-input').to.have.attribute('name').which.equals('time-input');
-    browser.expect.element('.terra-hidden-time-input').to.have.attribute('value').which.equals('T12:00');
+    browser.expect.element('#timeInput input[type="hidden"]').to.have.attribute('name').which.equals('time-input');
+    browser.expect.element('#timeInput input[type="hidden"]').to.have.attribute('value').which.equals('T12:00');
   },
 };
-


### PR DESCRIPTION
### Summary
Migrated time-input to CSS modules

Resolves #569 

@cerner/terra

### Deployment Link:
https://terra-core-deployed-pr-590.herokuapp.com/static/#/site/time-input