### PR TITLE
Update stylelint dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,8 @@
     "react-test-renderer": "^15.5.4",
     "rimraf": "^2.6.1",
     "shelljs": "^0.7.7",
-    "stylelint": "^7.10.1",
-    "stylelint-config-sass-guidelines": "^2.1.0",
+    "stylelint": "^7.12.0",
+    "stylelint-config-sass-guidelines": "^2.2.0",
     "stylelint-suitcss": "^1.0.0"
   }
 }


### PR DESCRIPTION
### Summary
This _should_ help reduce the deprecation warnings we see in travis CI when running stylelint.

@cerner/terra
