### PR TITLE
terra-date-picker - Check for null date when date entry is cleared.

### DIFF
--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Check null date when date entry is cleared
 
 1.0.0 - (June 28, 2017)
 ------------------

--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 Unreleased
 ----------
-### Changed
+### Fixed
 * Check null date when date entry is cleared
 
 1.0.0 - (June 28, 2017)

--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 Unreleased
 ----------
-### Added
+### Changed
 * Check null date when date entry is cleared
 
 1.0.0 - (June 28, 2017)

--- a/packages/terra-date-picker/src/DatePicker.jsx
+++ b/packages/terra-date-picker/src/DatePicker.jsx
@@ -77,7 +77,7 @@ class DatePicker extends React.Component {
     });
 
     if (this.props.onChange) {
-      this.props.onChange(event, date.format());
+      this.props.onChange(event, date ? date.format() : '');
     }
   }
 

--- a/packages/terra-date-picker/tests/nightwatch/components/DatePickerOnChange.jsx
+++ b/packages/terra-date-picker/tests/nightwatch/components/DatePickerOnChange.jsx
@@ -1,15 +1,28 @@
 import React from 'react';
 import DatePicker from '../../../lib/DatePicker';
 
-const handleOnChange = (selectedDate) => {
-  window.console.log('**handleOnChange** The selected date is: ', selectedDate);
-};
+class DatePickerOnChange extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { date: '' };
+    this.handleDateChange = this.handleDateChange.bind(this);
+  }
 
-const DatePickerOnChange = () => (
-  <DatePicker
-    name="date-input"
-    onChange={handleOnChange}
-  />
-);
+  handleDateChange(event, date) {
+    this.setState({ date });
+  }
+
+  render() {
+    return (
+      <div>
+        <h3>Selected Date: {this.state.date}</h3>
+        <DatePicker
+          name="date-input-onchange"
+          onChange={this.handleDateChange}
+        />
+      </div>
+    );
+  }
+}
 
 export default DatePickerOnChange;

--- a/packages/terra-date-picker/tests/nightwatch/date-picker-spec.js
+++ b/packages/terra-date-picker/tests/nightwatch/date-picker-spec.js
@@ -91,4 +91,14 @@ module.exports = {
       });
     });
   },
+
+  'Triggers onChange when a date value is cleared': (browser) => {
+    browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/date-picker-tests/on-change`);
+
+    browser.setValue('input[name="terra-date-date-input-onchange"]', '07/12/2017');
+    browser.expect.element('h3').text.to.contain('2017-07-12');
+
+    browser.clearValue('input[name="terra-date-date-input-onchange"]');
+    browser.expect.element('h3').text.to.not.contain('2017-07-12');
+  },
 };


### PR DESCRIPTION
Fix console error by checking for a null date in onChange when the date entry is cleared.

Resolves #542 

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
