### PR TITLE
#608 - terra-i18n-plugin now uses synchronous mkdirp

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -58,3 +58,4 @@ Cerner Corporation
 [@madelineisabelle]: https://github.com/madelineisabelle
 [@mhemesath]: https://github.com/mhemesath
 [@us044466]: https://github.com/us044466
+[@brhoades]: https://github.com/brhoades

--- a/packages/terra-i18n-plugin/CHANGELOG.md
+++ b/packages/terra-i18n-plugin/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 Unreleased
 ----------
+* Updated to synchronous mkdirp
 
 1.1.0 - (July 13, 2017)
 ------------------

--- a/packages/terra-i18n-plugin/src/I18nAggregatorPlugin.js
+++ b/packages/terra-i18n-plugin/src/I18nAggregatorPlugin.js
@@ -42,7 +42,7 @@ function aggregateTranslations(options) {
 
     // Aggregate messages for language in one file
     if (currentLanguageMessages !== {}) {
-      mkdirp(path.resolve(options.baseDirectory, 'aggregated-translations'));
+      mkdirp.sync(path.resolve(options.baseDirectory, 'aggregated-translations'));
       fs.writeFileSync(path.resolve(options.baseDirectory, 'aggregated-translations', `${language}.js`),
         generateTranslationFile(language, currentLanguageMessages));
     } else {


### PR DESCRIPTION
See #608 

terra-i18n-plugin runs mkdirp asynchronously before doing a synchronous write. This switches mkdirp to the synchronous variant.
