### PR TITLE
Fix i18n plugin race condition by using mkdirp.sync instead of mkdirp

### DIFF
--- a/packages/terra-i18n-plugin/CHANGELOG.md
+++ b/packages/terra-i18n-plugin/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Fixed a race condition with creating the aggregation-translations directory by using mkdirp.sync instead of mkdirp.
 
 1.1.0 - (July 13, 2017)
 ------------------

--- a/packages/terra-i18n-plugin/src/I18nAggregatorPlugin.js
+++ b/packages/terra-i18n-plugin/src/I18nAggregatorPlugin.js
@@ -42,7 +42,7 @@ function aggregateTranslations(options) {
 
     // Aggregate messages for language in one file
     if (currentLanguageMessages !== {}) {
-      mkdirp(path.resolve(options.baseDirectory, 'aggregated-translations'));
+      mkdirp.sync(path.resolve(options.baseDirectory, 'aggregated-translations'));
       fs.writeFileSync(path.resolve(options.baseDirectory, 'aggregated-translations', `${language}.js`),
         generateTranslationFile(language, currentLanguageMessages));
     } else {


### PR DESCRIPTION
### Summary
Update i18n plugin to fix a race condition by using mkdirp.sync instead of mkdirp.  Fixes #608.  

