### PR TITLE
Issue-615 - Updated package.json in terra-time-input to use rimraf

### DIFF
--- a/packages/terra-time-input/CHANGELOG.md
+++ b/packages/terra-time-input/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased
 ### Changed
 * Converted component to use CSS modules
 
+### Fixed
+* Updated package.json to use rimraf
+
 1.0.0 - (June 28, 2017)
 ------------------
 Initial stable release

--- a/packages/terra-time-input/package.json
+++ b/packages/terra-time-input/package.json
@@ -41,7 +41,7 @@
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",
-    "compile:clean": "rm -rf lib",
+    "compile:clean": "$(cd ..; npm bin)/rimraf lib",
     "compile:build": "$(cd ..; npm bin)/babel src --out-dir lib --copy-files",
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
@@ -53,6 +53,8 @@
     "test:nightwatch-default": "SPECTRE_TEST_SUITE=terra-time-input node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js",
     "test:nightwatch-chrome": "SPECTRE_TEST_SUITE=terra-time-input node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js chrome",
     "test:nightwatch-firefox": "SPECTRE_TEST_SUITE=terra-time-input node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js firefox",
-    "test:nightwatch-safari": "SPECTRE_TEST_SUITE=terra-time-input node ./node_modules/terra-toolkit/lib/scripts/nightwatch-non-parallel.js safari"
+    "test:nightwatch-safari": "SPECTRE_TEST_SUITE=terra-time-input node ./node_modules/terra-toolkit/lib/scripts/nightwatch-non-parallel.js safari",
+    "test:remote": "SPECTRE_TEST_SUITE=terra-time-input REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js",
+    "test:remote:all": "SPECTRE_TEST_SUITE=terra-time-input REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js --env chrome-tiny,chrome-small,chrome-medium,chrome-large,chrome-huge,chrome-enormous,firefox-tiny,firefox-small,firefox-medium,firefox-large,firefox-huge,firefox-enormous,ie10-tiny,ie10-small,ie10-medium,ie10-large,ie10-huge,ie10-enormous,ie11-tiny,ie11-small,ie11-medium,ie11-large,ie11-huge,ie11-enormous,edge-tiny,edge-small,edge-medium,edge-large,edge-huge,edge-enormous,safari-tiny,safari-small,safari-medium,safari-large,safari-huge,safari-enormous"
   }
 }

--- a/packages/terra-time-input/package.json
+++ b/packages/terra-time-input/package.json
@@ -53,8 +53,6 @@
     "test:nightwatch-default": "SPECTRE_TEST_SUITE=terra-time-input node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js",
     "test:nightwatch-chrome": "SPECTRE_TEST_SUITE=terra-time-input node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js chrome",
     "test:nightwatch-firefox": "SPECTRE_TEST_SUITE=terra-time-input node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js firefox",
-    "test:nightwatch-safari": "SPECTRE_TEST_SUITE=terra-time-input node ./node_modules/terra-toolkit/lib/scripts/nightwatch-non-parallel.js safari",
-    "test:remote": "SPECTRE_TEST_SUITE=terra-time-input REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js",
-    "test:remote:all": "SPECTRE_TEST_SUITE=terra-time-input REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js --env chrome-tiny,chrome-small,chrome-medium,chrome-large,chrome-huge,chrome-enormous,firefox-tiny,firefox-small,firefox-medium,firefox-large,firefox-huge,firefox-enormous,ie10-tiny,ie10-small,ie10-medium,ie10-large,ie10-huge,ie10-enormous,ie11-tiny,ie11-small,ie11-medium,ie11-large,ie11-huge,ie11-enormous,edge-tiny,edge-small,edge-medium,edge-large,edge-huge,edge-enormous,safari-tiny,safari-small,safari-medium,safari-large,safari-huge,safari-enormous"
+    "test:nightwatch-safari": "SPECTRE_TEST_SUITE=terra-time-input node ./node_modules/terra-toolkit/lib/scripts/nightwatch-non-parallel.js safari"
   }
 }


### PR DESCRIPTION
TimeInput package.json file has rm -rf command which doesn't run in Windows. Should use rimraf.

Resolves #615

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
