### PR TITLE
Normalize css custom props

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -8,9 +8,9 @@
     "scss/at-mixin-pattern": "^(terra-)[a-z]+([a-z0-9-]+[a-z0-9]+)?$",
     "suitcss/custom-property-no-outside-root": true,
     "custom-property-pattern": [
-      "^terra-(?:[A-Z][a-zA-Z0-9]+)*(?:-[a-z0-9][a-zA-Z0-9]+)*?(?:--[a-z0-9][a-zA-Z0-9-]+)*?$",
+      "terra-[a-z]+([a-z0-9-]+[a-z0-9]+)?$",
       {
-        "message": "Custom property names should match the SUIT CSS naming convention"
+        "message": "Custom property names should be written in lowercase with hyphens"
       }
     ],
     "selector-class-pattern": [

--- a/packages/terra-badge/CHANGELOG.md
+++ b/packages/terra-badge/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
 ### Changed
 * Converted component to use CSS modules
 * Converted SCSS variables to CSS custom properties for theming
+* Normalized CSS custom properties naming
 * Updated nightwatch test scripts
 * Removed nightwatch.config file
 

--- a/packages/terra-badge/src/Badge.scss
+++ b/packages/terra-badge/src/Badge.scss
@@ -4,49 +4,49 @@
 :local {
   /* stylelint-disable selector-class-pattern  */
   .badge {
-    border-radius: var(--terra-Badge-borderRadius);
-    display: var(--terra-Badge-display);
-    font-size: var(--terra-Badge-fontSize--small);
-    font-weight: var(--terra-Badge-fontWeight);
-    line-height: var(--terra-Badge-lineHeight);
-    min-width: var(--terra-Badge-minWidth);
-    padding-bottom: var(--terra-Badge-paddingBottom);
-    padding-left: var(--terra-Badge-paddingLeft);
-    padding-right: var(--terra-Badge-paddingRight);
-    padding-top: var(--terra-Badge-paddingTop);
+    border-radius: var(--terra-badge-border-radius);
+    display: var(--terra-badge-display);
+    font-size: var(--terra-badge-font-size-small);
+    font-weight: var(--terra-badge-font-weight);
+    line-height: var(--terra-badge-line-height);
+    min-width: var(--terra-badge-min-width);
+    padding-bottom: var(--terra-badge-padding-bottom);
+    padding-left: var(--terra-badge-padding-left);
+    padding-right: var(--terra-badge-padding-right);
+    padding-top: var(--terra-badge-padding-top);
     position: relative;
     text-align: center;
     text-decoration: none;
-    text-transform: var(--terra-Badge-textTransform);
+    text-transform: var(--terra-badge-text-transform);
     white-space: nowrap;
   }
 
   .text:first-child:not(:last-child) {
-    margin-right: var(--terra-Badge-child--margin);
+    margin-right: var(--terra-badge-child-margin);
   }
 
   .text:nth-child(2) {
-    margin-left: var(--terra-Badge-child--margin);
+    margin-left: var(--terra-badge-child-margin);
   }
 
   .tiny {
-    font-size: var(--terra-Badge-fontSize--tiny);
+    font-size: var(--terra-badge-fontSize-tiny);
   }
 
   .small {
-    font-size: var(--terra-Badge-fontSize--small);
+    font-size: var(--terra-badge-fontSize-small);
   }
 
   .medium {
-    font-size: var(--terra-Badge-fontSize--medium);
+    font-size: var(--terra-badge-fontSize-medium);
   }
 
   .large {
-    font-size: var(--terra-Badge-fontSize--large);
+    font-size: var(--terra-badge-fontSize-large);
   }
 
   .huge {
-    font-size: var(--terra-Badge-fontSize--huge);
+    font-size: var(--terra-badge-fontSize-huge);
   }
 
   .default {

--- a/packages/terra-badge/src/_variables.scss
+++ b/packages/terra-badge/src/_variables.scss
@@ -1,80 +1,80 @@
 :root {
-  --terra-Badge-fontSize--tiny: 0.5rem;
-  --terra-Badge-fontSize--small: 0.8rem;
-  --terra-Badge-fontSize--medium: 1rem;
-  --terra-Badge-fontSize--large: 1.4rem;
-  --terra-Badge-fontSize--huge: 1.7rem;
-  --terra-Badge-minWidth: 1.65em;
+  --terra-badge-font-size-tiny: 0.5rem;
+  --terra-badge-font-size-small: 0.8rem;
+  --terra-badge-font-size-medium: 1rem;
+  --terra-badge-font-size-large: 1.4rem;
+  --terra-badge-font-size-huge: 1.7rem;
+  --terra-badge-min-width: 1.65em;
 
-  --terra-Badge-child--margin: 0.357em;
+  --terra-badge-child-margin: 0.357em;
 
-  --terra-Badge-borderRadius: 0.25em;
-  --terra-Badge-display: inline-block;
+  --terra-badge-border-radius: 0.25em;
+  --terra-badge-display: inline-block;
 
-  --terra-Badge-fontWeight: 700;
-  --terra-Badge-lineHeight: 1;
+  --terra-badge-font-weight: 700;
+  --terra-badge-line-height: 1;
 
-  --terra-Badge-paddingBottom: 0.5rem;
-  --terra-Badge-paddingLeft: 0.36rem;
-  --terra-Badge-paddingRight: 0.36rem;
-  --terra-Badge-paddingTop: 0.5rem;
+  --terra-badge-padding-bottom: 0.5rem;
+  --terra-badge-padding-left: 0.36rem;
+  --terra-badge-padding-right: 0.36rem;
+  --terra-badge-padding-top: 0.5rem;
 
-  --terra-Badge-textTransform: none;
+  --terra-badge-text-transform: none;
 
   // Color variants
-  --terra-Badge-backgroundColor--default: #bcbfc0;
-  --terra-Badge-color--default: #383f42;
+  --terra-badge-background-color-default: #bcbfc0;
+  --terra-badge-color-default: #383f42;
 
-  --terra-Badge-backgroundColor--primary: #004c76;
-  --terra-Badge-color--primary: #fff;
+  --terra-badge-background-color-primary: #004c76;
+  --terra-badge-color-primary: #fff;
 
-  --terra-Badge-backgroundColor--secondary: #4e832b;
-  --terra-Badge-color--secondary: #fff;
+  --terra-badge-background-color-secondary: #4e832b;
+  --terra-badge-color-secondary: #fff;
 
-  --terra-Badge-backgroundColor--positive: #4e832b;
-  --terra-Badge-color--positive: #fff;
+  --terra-badge-background-color-positive: #4e832b;
+  --terra-badge-color-positive: #fff;
 
-  --terra-Badge-backgroundColor--negative: #bc0203;
-  --terra-Badge-color--negative: #fff;
+  --terra-badge-background-color-negative: #bc0203;
+  --terra-badge-color-negative: #fff;
 
-  --terra-Badge-backgroundColor--warning: #da3b03;
-  --terra-Badge-color--warning: #fff;
+  --terra-badge-background-color-warning: #da3b03;
+  --terra-badge-color-warning: #fff;
 
-  --terra-Badge-backgroundColor--info: #004c76;
-  --terra-Badge-color--info: #fff;
+  --terra-badge-background-color-info: #004c76;
+  --terra-badge-color-info: #fff;
 }
 
 $terra-badge-default-color-scheme: (
-  background-color: var(--terra-Badge-backgroundColor--default),
-  color: var(--terra-Badge-color--default)
+  background-color: var(--terra-badge-background-color-default),
+  color: var(--terra-badge-color-default)
 );
 
 $terra-badge-primary-color-scheme: (
-  background-color: var(--terra-Badge-backgroundColor--primary),
-  color: var(--terra-Badge-color--primary)
+  background-color: var(--terra-badge-background-color-primary),
+  color: var(--terra-badge-color-primary)
 );
 
 $terra-badge-secondary-color-scheme: (
-  background-color: var(--terra-Badge-backgroundColor--secondary),
-  color: var(--terra-Badge-color--secondary)
+  background-color: var(--terra-badge-background-color-secondary),
+  color: var(--terra-badge-color-secondary)
 );
 
 $terra-badge-positive-color-scheme: (
-  background-color: var(--terra-Badge-backgroundColor--positive),
-  color: var(--terra-Badge-color--positive)
+  background-color: var(--terra-badge-background-color-positive),
+  color: var(--terra-badge-color-positive)
 );
 
 $terra-badge-negative-color-scheme: (
-  background-color: var(--terra-Badge-backgroundColor--negative),
-  color: var(--terra-Badge-color--negative)
+  background-color: var(--terra-badge-background-color-negative),
+  color: var(--terra-badge-color-negative)
 );
 
 $terra-badge-warning-color-scheme: (
-  background-color: var(--terra-Badge-backgroundColor--warning),
-  color: var(--terra-Badge-color--warning)
+  background-color: var(--terra-badge-background-color-warning),
+  color: var(--terra-badge-color-warning)
 );
 
 $terra-badge-info-color-scheme: (
-  background-color: var(--terra-Badge-backgroundColor--info),
-  color: var(--terra-Badge-color--info)
+  background-color: var(--terra-badge-background-color-info),
+  color: var(--terra-badge-color-info)
 );

--- a/packages/terra-base/CHANGELOG.md
+++ b/packages/terra-base/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
 ### Changed
 * Converted component to use CSS modules
 * Converted SCSS variables to CSS custom properties for theming
+* Normalized CSS custom properties naming
 * Updated nightwatch test scripts
 * Removed nightwatch.config file
 

--- a/packages/terra-base/src/Base.scss
+++ b/packages/terra-base/src/Base.scss
@@ -4,16 +4,16 @@
 // More info: https://css-tricks.com/box-sizing/#article-header-id-6
 html {
   box-sizing: border-box;
-  font-family: var(--terra-Base-fontFamily);
-  font-size: var(--terra-Base-fontSize);
+  font-family: var(--terra-base-font-family);
+  font-size: var(--terra-base-font-size);
   height: 100%;
   margin: 0;
   text-size-adjust: 100%;
 }
 
 body {
-  background-color: var(--terra-Base-backgroundColor);
-  color: var(--terra-Base-color);
+  background-color: var(--terra-base-background-color);
+  color: var(--terra-base-color);
   font-size: 1rem;
   line-height: 1;
   margin: 0;

--- a/packages/terra-base/src/_variables.scss
+++ b/packages/terra-base/src/_variables.scss
@@ -1,6 +1,6 @@
 :root {
-  --terra-Base-backgroundColor: #fff;
-  --terra-Base-color: #1c1f21;
-  --terra-Base-fontSize: 87.5%; // scales with browser settings, equivalent to 14px
-  --terra-Base-fontFamily: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --terra-base-background-color: #fff;
+  --terra-base-color: #1c1f21;
+  --terra-base-font-size: 87.5%; // scales with browser settings, equivalent to 14px
+  --terra-base-font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }

--- a/packages/terra-button/CHANGELOG.md
+++ b/packages/terra-button/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased
 ### Changed
 * Converted component to use CSS modules
 * Converted SCSS variables to CSS custom properties for theming
+* Normalized CSS custom properties naming
 * Updated nightwatch test scripts
 * Removed nightwatch.config file
 

--- a/packages/terra-button/src/Button.scss
+++ b/packages/terra-button/src/Button.scss
@@ -32,21 +32,21 @@
   .button {
     @include terra-text-align-center;
 
-    border-radius: var(--terra-Button-borderRadius);
+    border-radius: var(--terra-button-border-radius);
     border-style: solid;
-    border-width: var(--terra-Button-borderWidth);
+    border-width: var(--terra-button-border-width);
     cursor: pointer;
     display: inline-block;
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     font-size: map-get($terra-button-font-sizes, medium);
-    font-weight: var(--terra-Button-fontWeight);
+    font-weight: var(--terra-button-font-weight);
     line-height: 1.429; // 20px when html font size is computed to 14px
-    padding-bottom: var(--terra-Button-paddingBottom);
-    padding-left: var(--terra-Button-paddingLeft);
-    padding-right: var(--terra-Button-paddingRight);
-    padding-top: var(--terra-Button-paddingTop);
+    padding-bottom: var(--terra-button-padding-bottom);
+    padding-left: var(--terra-button-padding-left);
+    padding-right: var(--terra-button-padding-right);
+    padding-top: var(--terra-button-padding-top);
     text-decoration: none;
-    text-transform: var(--terra-Button-textTransform);
+    text-transform: var(--terra-button-text-transform);
     touch-action: manipulation; // Enable fast tap interactiion in webkit browsers; see https://webkit.org/blog/5610/more-responsive-tapping-on-ios/
     user-select: none; // Prevent text selection on buttons on mobile devices
     vertical-align: middle;
@@ -117,7 +117,7 @@
   }
 
   .compact {
-    padding-bottom: var(--terra-Button-paddingTop--compact);
-    padding-top: var(--terra-Button-paddingTop--bottom);
+    padding-bottom: var(--terra-button-padding-bottom-compact);
+    padding-top: var(--terra-button-padding-top-compact);
   }
 }

--- a/packages/terra-button/src/_variables.scss
+++ b/packages/terra-button/src/_variables.scss
@@ -3,113 +3,113 @@
 :root {
   --terra-button-child-margin: 0.357em;
 
-  --terra-button-borderRadius: 0.25em;
-  --terra-button-borderWidth: 1px;
-  --terra-button-fontWeight: 400;
-  --terra-button-paddingTop: 0.286em;
-  --terra-button-paddingRight: 0.714em;
-  --terra-button-paddingBottom: 0.286em;
-  --terra-button-paddingLeft: 0.714em;
+  --terra-button-border-radius: 0.25em;
+  --terra-button-border-width: 1px;
+  --terra-button-font-weight: 400;
+  --terra-button-padding-top: 0.286em;
+  --terra-button-padding-right: 0.714em;
+  --terra-button-padding-bottom: 0.286em;
+  --terra-button-padding-left: 0.714em;
 
-  --terra-button-paddingTop--compact: 0;
-  --terra-button-paddingBottom--compact: 0;
+  --terra-button-padding-top-compact: 0;
+  --terra-button-padding-bottom-compact: 0;
 
-  --terra-button-textTransform: none;
+  --terra-button-text-transform: none;
 
   // Font Sizes
-  --terra-button-fontSize--tiny: 0.5rem;
-  --terra-button-fontSize--small: 0.8rem;
-  --terra-button-fontSize--medium: 1rem;
-  --terra-button-fontSize--large: 1.4rem;
-  --terra-button-fontSize--huge: 1.7rem;
+  --terra-button-font-size-tiny: 0.5rem;
+  --terra-button-font-size-small: 0.8rem;
+  --terra-button-font-size-medium: 1rem;
+  --terra-button-font-size-large: 1.4rem;
+  --terra-button-font-size-huge: 1.7rem;
 
   // Default Color Scheme
-  --terra-button-activeBackgroundColor--default: #4e5558;
-  --terra-button-activeBorderColor--default: #4e5558;
-  --terra-button-activeColor--default: #fff;
-  --terra-button-backgroundColor--default: #d3d4d5;
-  --terra-button-borderColor--default: #bcbfc0;
+  --terra-button-active-background-color-default: #4e5558;
+  --terra-button-active-border-color-default: #4e5558;
+  --terra-button-active-color-default: #fff;
+  --terra-button-background-color-default: #d3d4d5;
+  --terra-button-border-color-default: #bcbfc0;
   --terra-button-color--default: #383f42;
-  --terra-button-disabledBackgroundColor--default: #e8e9ea;
-  --terra-button-disabledBorderColor--default: #d3d4d5;
-  --terra-button-disabledColor--default: #909496;
-  --terra-button-hoverBackgroundColor--default: #bcbfc0;
-  --terra-button-hoverColor--default: #222a2e;
+  --terra-button-disabled-background-color-default: #e8e9ea;
+  --terra-button-disabled-border-color-default: #d3d4d5;
+  --terra-button-disabled-color-default: #909496;
+  --terra-button-hover-background-color-default: #bcbfc0;
+  --terra-button-hover-color-default: #222a2e;
 
   // Primary Color Scheme
-  --terra-button-activeBackgroundColor--primary: #004c76;
-  --terra-button-activeBorderColor--primary: #383f42;
-  --terra-button-activeColor--primary: #fff;
-  --terra-button-backgroundColor--primary: #007cc3;
-  --terra-button-borderColor--primary: #0065a3;
+  --terra-button-active-background-color-primary: #004c76;
+  --terra-button-active-border-color-primary: #383f42;
+  --terra-button-active-color-primary: #fff;
+  --terra-button-background-color-primary: #007cc3;
+  --terra-button-border-color-primary: #0065a3;
   --terra-button-color--primary: #fff;
-  --terra-button-disabledBackgroundColor--primary: #cce9f9;
-  --terra-button-disabledBorderColor--primary: #a6d9f4;
-  --terra-button-disabledColor--primary: #909496;
-  --terra-button-hoverBackgroundColor--primary: #0065a3;
-  --terra-button-hoverColor--primary: #fff;
+  --terra-button-disabled-background-color-primary: #cce9f9;
+  --terra-button-disabled-border-color-primary: #a6d9f4;
+  --terra-button-disabled-color-primary: #909496;
+  --terra-button-hover-background-color-primary: #0065a3;
+  --terra-button-hover-color-primary: #fff;
 
   // Secondary Color Scheme
-  --terra-button-activeBackgroundColor--secondary: #4e5558;
-  --terra-button-activeBorderColor--secondary: #4e5558;
-  --terra-button-activeColor--secondary: #fff;
-  --terra-button-borderColor--secondary: #bcbfc0;
+  --terra-button-active-background-color-secondary: #4e5558;
+  --terra-button-active-border-color-secondary: #4e5558;
+  --terra-button-active-color-secondary: #fff;
+  --terra-button-border-color-secondary: #bcbfc0;
   --terra-button-color--secondary: #4e5558;
-  --terra-button-disabledBorderColor--secondary: #d3d4d5;
-  --terra-button-disabledColor--secondary: #909496;
-  --terra-button-hoverBackgroundColor--secondary: #bcbfc0;
-  --terra-button-hoverColor--secondary: #222a2e;
+  --terra-button-disabled-border-color-secondary: #d3d4d5;
+  --terra-button-disabled-color-secondary: #909496;
+  --terra-button-hover-background-color-secondary: #bcbfc0;
+  --terra-button-hover-color-secondary: #222a2e;
 
   // link
   --terra-button-color--link: #0065a3;
-  --terra-button-activeColor--link: darken(#0065a3, 10%);
-  --terra-button-disabledColor--link: #909496;
+  --terra-button-active-color-link: darken(#0065a3, 10%);
+  --terra-button-disabled-color-link: #909496;
 }
 
 $terra-button-default-color-scheme: (
-  active-background-color: var(--terra-button-activeBackgroundColor--default),
-  active-border-color: var(--terra-button-activeBorderColor--default),
-  active-color: var(--terra-button-activeColor--default),
-  background-color: var(--terra-button-backgroundColor--default),
-  border-color: var(--terra-button-borderColor--default),
+  active-background-color: var(--terra-button-active-background-color-default),
+  active-border-color: var(--terra-button-active-border-color-default),
+  active-color: var(--terra-button-active-color-default),
+  background-color: var(--terra-button-background-color-default),
+  border-color: var(--terra-button-border-color-default),
   color: var(--terra-button-color--default),
-  disabled-background-color: var(--terra-button-disabledBackgroundColor--default),
-  disabled-border-color: var(--terra-button-disabledBorderColor--default),
-  disabled-color: var(--terra-button-disabledColor--default),
-  hover-background-color: var(--terra-button-hoverBackgroundColor--default),
-  hover-color: var(--terra-button-hoverColor--default)
+  disabled-background-color: var(--terra-button-disabled-background-color-default),
+  disabled-border-color: var(--terra-button-disabled-border-color-default),
+  disabled-color: var(--terra-button-disabled-color-default),
+  hover-background-color: var(--terra-button-hover-background-color-default),
+  hover-color: var(--terra-button-hover-color-default)
 );
 
 $terra-button-primary-color-scheme: (
-  active-background-color: var(--terra-button-activeBackgroundColor--primary),
-  active-border-color: var(--terra-button-activeBorderColor--primary),
-  active-color: var(--terra-button-activeColor--primary),
-  background-color: var(--terra-button-backgroundColor--primary),
-  border-color: var(--terra-button-borderColor--primary),
+  active-background-color: var(--terra-button-active-background-color-primary),
+  active-border-color: var(--terra-button-active-border-color-primary),
+  active-color: var(--terra-button-active-color-primary),
+  background-color: var(--terra-button-background-color-primary),
+  border-color: var(--terra-button-border-color-primary),
   color: var(--terra-button-color--primary),
-  disabled-background-color: var(--terra-button-disabledBackgroundColor--primary),
-  disabled-border-color: var(--terra-button-disabledBorderColor--primary),
-  disabled-color: var(--terra-button-disabledColor--primary),
-  hover-background-color: var(--terra-button-hoverBackgroundColor--primary),
-  hover-color: var(--terra-button-hoverColor--primary)
+  disabled-background-color: var(--terra-button-disabled-background-color-primary),
+  disabled-border-color: var(--terra-button-disabled-border-color-primary),
+  disabled-color: var(--terra-button-disabled-color-primary),
+  hover-background-color: var(--terra-button-hover-background-color-primary),
+  hover-color: var(--terra-button-hover-color-primary)
 );
 
 $terra-button-secondary-color-scheme: (
-  active-background-color: var(--terra-button-activeBackgroundColor--secondary),
-  active-border-color: var(--terra-button-activeBorderColor--secondary),
-  active-color: var(--terra-button-activeColor--secondary),
-  border-color: var(--terra-button-borderColor--secondary),
+  active-background-color: var(--terra-button-active-background-color-secondary),
+  active-border-color: var(--terra-button-active-border-color-secondary),
+  active-color: var(--terra-button-active-color-secondary),
+  border-color: var(--terra-button-border-color-secondary),
   color: var(--terra-button-color--secondary),
-  disabled-border-color: var(--terra-button-disabledBorderColor--secondary),
-  disabled-color: var(--terra-button-disabledColor--secondary),
-  hover-background-color: var(--terra-button-hoverBackgroundColor--secondary),
-  hover-color: var(--terra-button-hoverColor--secondary)
+  disabled-border-color: var(--terra-button-disabled-border-color-secondary),
+  disabled-color: var(--terra-button-disabled-color-secondary),
+  hover-background-color: var(--terra-button-hover-background-color-secondary),
+  hover-color: var(--terra-button-hover-color-secondary)
 );
 
 $terra-button-link-color-scheme: (
   color: var(--terra-button-color--link),
-  active-color: var(--terra-button-activeColor--link),
-  disabled-color: var(--terra-button-disabledColor--link),
+  active-color: var(--terra-button-active-color-link),
+  disabled-color: var(--terra-button-disabled-color-link),
 );
 
 $terra-button-font-sizes: (

--- a/packages/terra-button/src/_variables.scss
+++ b/packages/terra-button/src/_variables.scss
@@ -1,121 +1,121 @@
 // Variables
 // ==========================
 :root {
-  --terra-Button-childMargin: 0.357em;
+  --terra-button-child-margin: 0.357em;
 
-  --terra-Button-borderRadius: 0.25em;
-  --terra-Button-borderWidth: 1px;
-  --terra-Button-fontWeight: 400;
-  --terra-Button-paddingTop: 0.286em;
-  --terra-Button-paddingRight: 0.714em;
-  --terra-Button-paddingBottom: 0.286em;
-  --terra-Button-paddingLeft: 0.714em;
+  --terra-button-borderRadius: 0.25em;
+  --terra-button-borderWidth: 1px;
+  --terra-button-fontWeight: 400;
+  --terra-button-paddingTop: 0.286em;
+  --terra-button-paddingRight: 0.714em;
+  --terra-button-paddingBottom: 0.286em;
+  --terra-button-paddingLeft: 0.714em;
 
-  --terra-Button-paddingTop--compact: 0;
-  --terra-Button-paddingBottom--compact: 0;
+  --terra-button-paddingTop--compact: 0;
+  --terra-button-paddingBottom--compact: 0;
 
-  --terra-Button-textTransform: none;
+  --terra-button-textTransform: none;
 
   // Font Sizes
-  --terra-Button-fontSize--tiny: 0.5rem;
-  --terra-Button-fontSize--small: 0.8rem;
-  --terra-Button-fontSize--medium: 1rem;
-  --terra-Button-fontSize--large: 1.4rem;
-  --terra-Button-fontSize--huge: 1.7rem;
+  --terra-button-fontSize--tiny: 0.5rem;
+  --terra-button-fontSize--small: 0.8rem;
+  --terra-button-fontSize--medium: 1rem;
+  --terra-button-fontSize--large: 1.4rem;
+  --terra-button-fontSize--huge: 1.7rem;
 
   // Default Color Scheme
-  --terra-Button-activeBackgroundColor--default: #4e5558;
-  --terra-Button-activeBorderColor--default: #4e5558;
-  --terra-Button-activeColor--default: #fff;
-  --terra-Button-backgroundColor--default: #d3d4d5;
-  --terra-Button-borderColor--default: #bcbfc0;
-  --terra-Button-color--default: #383f42;
-  --terra-Button-disabledBackgroundColor--default: #e8e9ea;
-  --terra-Button-disabledBorderColor--default: #d3d4d5;
-  --terra-Button-disabledColor--default: #909496;
-  --terra-Button-hoverBackgroundColor--default: #bcbfc0;
-  --terra-Button-hoverColor--default: #222a2e;
+  --terra-button-activeBackgroundColor--default: #4e5558;
+  --terra-button-activeBorderColor--default: #4e5558;
+  --terra-button-activeColor--default: #fff;
+  --terra-button-backgroundColor--default: #d3d4d5;
+  --terra-button-borderColor--default: #bcbfc0;
+  --terra-button-color--default: #383f42;
+  --terra-button-disabledBackgroundColor--default: #e8e9ea;
+  --terra-button-disabledBorderColor--default: #d3d4d5;
+  --terra-button-disabledColor--default: #909496;
+  --terra-button-hoverBackgroundColor--default: #bcbfc0;
+  --terra-button-hoverColor--default: #222a2e;
 
   // Primary Color Scheme
-  --terra-Button-activeBackgroundColor--primary: #004c76;
-  --terra-Button-activeBorderColor--primary: #383f42;
-  --terra-Button-activeColor--primary: #fff;
-  --terra-Button-backgroundColor--primary: #007cc3;
-  --terra-Button-borderColor--primary: #0065a3;
-  --terra-Button-color--primary: #fff;
-  --terra-Button-disabledBackgroundColor--primary: #cce9f9;
-  --terra-Button-disabledBorderColor--primary: #a6d9f4;
-  --terra-Button-disabledColor--primary: #909496;
-  --terra-Button-hoverBackgroundColor--primary: #0065a3;
-  --terra-Button-hoverColor--primary: #fff;
+  --terra-button-activeBackgroundColor--primary: #004c76;
+  --terra-button-activeBorderColor--primary: #383f42;
+  --terra-button-activeColor--primary: #fff;
+  --terra-button-backgroundColor--primary: #007cc3;
+  --terra-button-borderColor--primary: #0065a3;
+  --terra-button-color--primary: #fff;
+  --terra-button-disabledBackgroundColor--primary: #cce9f9;
+  --terra-button-disabledBorderColor--primary: #a6d9f4;
+  --terra-button-disabledColor--primary: #909496;
+  --terra-button-hoverBackgroundColor--primary: #0065a3;
+  --terra-button-hoverColor--primary: #fff;
 
   // Secondary Color Scheme
-  --terra-Button-activeBackgroundColor--secondary: #4e5558;
-  --terra-Button-activeBorderColor--secondary: #4e5558;
-  --terra-Button-activeColor--secondary: #fff;
-  --terra-Button-borderColor--secondary: #bcbfc0;
-  --terra-Button-color--secondary: #4e5558;
-  --terra-Button-disabledBorderColor--secondary: #d3d4d5;
-  --terra-Button-disabledColor--secondary: #909496;
-  --terra-Button-hoverBackgroundColor--secondary: #bcbfc0;
-  --terra-Button-hoverColor--secondary: #222a2e;
+  --terra-button-activeBackgroundColor--secondary: #4e5558;
+  --terra-button-activeBorderColor--secondary: #4e5558;
+  --terra-button-activeColor--secondary: #fff;
+  --terra-button-borderColor--secondary: #bcbfc0;
+  --terra-button-color--secondary: #4e5558;
+  --terra-button-disabledBorderColor--secondary: #d3d4d5;
+  --terra-button-disabledColor--secondary: #909496;
+  --terra-button-hoverBackgroundColor--secondary: #bcbfc0;
+  --terra-button-hoverColor--secondary: #222a2e;
 
   // link
-  --terra-Button-color--link: #0065a3;
-  --terra-Button-activeColor--link: darken(#0065a3, 10%);
-  --terra-Button-disabledColor--link: #909496;
+  --terra-button-color--link: #0065a3;
+  --terra-button-activeColor--link: darken(#0065a3, 10%);
+  --terra-button-disabledColor--link: #909496;
 }
 
 $terra-button-default-color-scheme: (
-  active-background-color: var(--terra-Button-activeBackgroundColor--default),
-  active-border-color: var(--terra-Button-activeBorderColor--default),
-  active-color: var(--terra-Button-activeColor--default),
-  background-color: var(--terra-Button-backgroundColor--default),
-  border-color: var(--terra-Button-borderColor--default),
-  color: var(--terra-Button-color--default),
-  disabled-background-color: var(--terra-Button-disabledBackgroundColor--default),
-  disabled-border-color: var(--terra-Button-disabledBorderColor--default),
-  disabled-color: var(--terra-Button-disabledColor--default),
-  hover-background-color: var(--terra-Button-hoverBackgroundColor--default),
-  hover-color: var(--terra-Button-hoverColor--default)
+  active-background-color: var(--terra-button-activeBackgroundColor--default),
+  active-border-color: var(--terra-button-activeBorderColor--default),
+  active-color: var(--terra-button-activeColor--default),
+  background-color: var(--terra-button-backgroundColor--default),
+  border-color: var(--terra-button-borderColor--default),
+  color: var(--terra-button-color--default),
+  disabled-background-color: var(--terra-button-disabledBackgroundColor--default),
+  disabled-border-color: var(--terra-button-disabledBorderColor--default),
+  disabled-color: var(--terra-button-disabledColor--default),
+  hover-background-color: var(--terra-button-hoverBackgroundColor--default),
+  hover-color: var(--terra-button-hoverColor--default)
 );
 
 $terra-button-primary-color-scheme: (
-  active-background-color: var(--terra-Button-activeBackgroundColor--primary),
-  active-border-color: var(--terra-Button-activeBorderColor--primary),
-  active-color: var(--terra-Button-activeColor--primary),
-  background-color: var(--terra-Button-backgroundColor--primary),
-  border-color: var(--terra-Button-borderColor--primary),
-  color: var(--terra-Button-color--primary),
-  disabled-background-color: var(--terra-Button-disabledBackgroundColor--primary),
-  disabled-border-color: var(--terra-Button-disabledBorderColor--primary),
-  disabled-color: var(--terra-Button-disabledColor--primary),
-  hover-background-color: var(--terra-Button-hoverBackgroundColor--primary),
-  hover-color: var(--terra-Button-hoverColor--primary)
+  active-background-color: var(--terra-button-activeBackgroundColor--primary),
+  active-border-color: var(--terra-button-activeBorderColor--primary),
+  active-color: var(--terra-button-activeColor--primary),
+  background-color: var(--terra-button-backgroundColor--primary),
+  border-color: var(--terra-button-borderColor--primary),
+  color: var(--terra-button-color--primary),
+  disabled-background-color: var(--terra-button-disabledBackgroundColor--primary),
+  disabled-border-color: var(--terra-button-disabledBorderColor--primary),
+  disabled-color: var(--terra-button-disabledColor--primary),
+  hover-background-color: var(--terra-button-hoverBackgroundColor--primary),
+  hover-color: var(--terra-button-hoverColor--primary)
 );
 
 $terra-button-secondary-color-scheme: (
-  active-background-color: var(--terra-Button-activeBackgroundColor--secondary),
-  active-border-color: var(--terra-Button-activeBorderColor--secondary),
-  active-color: var(--terra-Button-activeColor--secondary),
-  border-color: var(--terra-Button-borderColor--secondary),
-  color: var(--terra-Button-color--secondary),
-  disabled-border-color: var(--terra-Button-disabledBorderColor--secondary),
-  disabled-color: var(--terra-Button-disabledColor--secondary),
-  hover-background-color: var(--terra-Button-hoverBackgroundColor--secondary),
-  hover-color: var(--terra-Button-hoverColor--secondary)
+  active-background-color: var(--terra-button-activeBackgroundColor--secondary),
+  active-border-color: var(--terra-button-activeBorderColor--secondary),
+  active-color: var(--terra-button-activeColor--secondary),
+  border-color: var(--terra-button-borderColor--secondary),
+  color: var(--terra-button-color--secondary),
+  disabled-border-color: var(--terra-button-disabledBorderColor--secondary),
+  disabled-color: var(--terra-button-disabledColor--secondary),
+  hover-background-color: var(--terra-button-hoverBackgroundColor--secondary),
+  hover-color: var(--terra-button-hoverColor--secondary)
 );
 
 $terra-button-link-color-scheme: (
-  color: var(--terra-Button-color--link),
-  active-color: var(--terra-Button-activeColor--link),
-  disabled-color: var(--terra-Button-disabledColor--link),
+  color: var(--terra-button-color--link),
+  active-color: var(--terra-button-activeColor--link),
+  disabled-color: var(--terra-button-disabledColor--link),
 );
 
 $terra-button-font-sizes: (
-  tiny: var(--terra-Button-fontSize--tiny),
-  small: var(--terra-Button-fontSize--small),
-  medium: var(--terra-Button-fontSize--medium),
-  large: var(--terra-Button-fontSize--large),
-  huge: var(--terra-Button-fontSize--huge)
+  tiny: var(--terra-button-fontSize--tiny),
+  small: var(--terra-button-fontSize--small),
+  medium: var(--terra-button-fontSize--medium),
+  large: var(--terra-button-fontSize--large),
+  huge: var(--terra-button-fontSize--huge)
 );


### PR DESCRIPTION
### Summary
With converting SCSS variables to CSS custom props, we've diverged on naming the variables.
To help normalize the naming, we've decided CSS custom property names should be all lower-case and separate words with single hyphen.

This resolves #619 

@cerner/terra
