### PR TITLE
Modal custom props

### DIFF
--- a/packages/terra-modal/CHANGELOG.md
+++ b/packages/terra-modal/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Custom Props are now added to the modal, not the portal
 
 1.1.0 - (July 13, 2017)
 ------------------

--- a/packages/terra-modal/src/Modal.jsx
+++ b/packages/terra-modal/src/Modal.jsx
@@ -114,9 +114,9 @@ class Modal extends React.Component {
     return (
       <Portal
         isOpened={isOpen}
-        {...customProps}
       >
         <ModalContent
+          {...customProps}
           closeOnOutsideClick={closeOnOutsideClick}
           ariaLabel={ariaLabel}
           classNameModal={classNameModal}

--- a/packages/terra-modal/tests/nightwatch/ModalTestRoutes.jsx
+++ b/packages/terra-modal/tests/nightwatch/ModalTestRoutes.jsx
@@ -15,6 +15,7 @@ import ModalOverrideRole from './components/ModalOverrideRole';
 import ModalNoFocusableContent from './components/ModalNoFocusableContent';
 import ModalScrollableTrue from './components/ModalScrollableTrue';
 import ModalScrollableFalse from './components/ModalScrollableFalse';
+import ModalCustomProps from './components/ModalCustomProps';
 
 const routes = (
   <div>
@@ -30,6 +31,8 @@ const routes = (
     <Route path="/tests/modal-tests/no-focusable-content" component={ModalNoFocusableContent} />
     <Route path="/tests/modal-tests/scrollable-true" component={ModalScrollableTrue} />
     <Route path="/tests/modal-tests/scrollable-false" component={ModalScrollableFalse} />
+    <Route path="/tests/modal-tests/custom-props" component={ModalCustomProps} />
+
   </div>
 );
 

--- a/packages/terra-modal/tests/nightwatch/ModalTests.jsx
+++ b/packages/terra-modal/tests/nightwatch/ModalTests.jsx
@@ -17,6 +17,7 @@ const ModalTests = () => (
       <li><Link to="/tests/modal-tests/override-role">Override Role</Link></li>
       <li><Link to="/tests/modal-tests/scrollable-true">Scrollable True</Link></li>
       <li><Link to="/tests/modal-tests/scrollable-false">Scrollable False</Link></li>
+      <li><Link to="/tests/modal-tests/custom-props">Custom Props</Link></li>
     </ul>
   </div>
 );

--- a/packages/terra-modal/tests/nightwatch/components/ModalCustomProps.jsx
+++ b/packages/terra-modal/tests/nightwatch/components/ModalCustomProps.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import Modal from '../../../lib/Modal';
+
+class ModalCustomProps extends React.Component {
+  constructor() {
+    super();
+
+    this.state = {
+      isOpen: true,
+    };
+
+    this.handleOpenModal = this.handleOpenModal.bind(this);
+    this.handleCloseModal = this.handleCloseModal.bind(this);
+  }
+
+
+  handleOpenModal() {
+    this.setState({ isOpen: true });
+  }
+
+  handleCloseModal() {
+    this.setState({ isOpen: false });
+  }
+
+  render() {
+    return (
+      <div>
+        <Modal
+          id="custom-props"
+          ariaLabel="Terra Modal"
+          isOpen={this.state.isOpen}
+          onRequestClose={this.handleCloseModal}
+        >
+          <div>
+            <h1>Terra Modal</h1>
+            <h2>Subtitle</h2>
+            <hr />
+            <p>The Terra Modal is appended to the document body.</p>
+            <p>{'Modal is assigned a role of \'document\' for accessibility.'}</p>
+            <button onClick={this.handleCloseModal}>Close Modal</button>
+          </div>
+        </Modal>
+        <button className="button-open-modal" onClick={this.handleOpenModal}>Open Modal</button>
+      </div>
+    );
+  }
+}
+
+export default ModalCustomProps;

--- a/packages/terra-modal/tests/nightwatch/modal-spec.js
+++ b/packages/terra-modal/tests/nightwatch/modal-spec.js
@@ -146,4 +146,10 @@ module.exports = {
       .waitForElementPresent('.terra-Modal', 1000)
       .expect.element('.terra-Modal').to.have.attribute('class').which.equals('terra-Modal terra-Modal--scrollable');
   },
+
+  'custom props': (browser) => {
+    browser
+      .url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/modal-tests/custom-props`)
+      .assert.attributeEquals('div[role="document"]', 'id', 'custom-props');
+  },
 };


### PR DESCRIPTION
### Summary
Custom props are now added to the modal, not the portal component.

Resolves: https://github.com/cerner/terra-core/issues/625

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
