### PR TITLE
Add onInvalidSearch prop to SearchField

### DIFF
--- a/packages/terra-search-field/CHANGELOG.md
+++ b/packages/terra-search-field/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added onInvalidSearch callback for invalid search text entry.
 
 1.1.0 - (July 18, 2017)
 ------------------

--- a/packages/terra-search-field/src/SearchField.jsx
+++ b/packages/terra-search-field/src/SearchField.jsx
@@ -29,6 +29,11 @@ const propTypes = {
    * A callback to perform search. Sends parameter {String} searchText.
    */
   onSearch: PropTypes.func,
+
+  /**
+   * A callback to indicate an invalid search. Sends parameter {String} searchText.
+   */
+  onInvalidSearch: PropTypes.func,
 };
 
 const defaultProps = {
@@ -68,6 +73,8 @@ class SearchField extends React.Component {
 
     if (this.state.searchText.length >= this.props.minimumSearchTextLength && this.props.onSearch) {
       this.props.onSearch(this.state.searchText);
+    } else if (this.props.onInvalidSearch) {
+      this.props.onInvalidSearch(this.state.searchText);
     }
   }
 
@@ -79,15 +86,11 @@ class SearchField extends React.Component {
   }
 
   render() {
-    const { placeholder, ...customProps } = this.props;
+    const { placeholder, searchDelay, minimumSearchTextLength, onSearch, onInvalidSearch, ...customProps } = this.props;
     const searchFieldClassNames = cx([
       'searchfield',
       customProps.className,
     ]);
-
-    delete customProps.onSearch;
-    delete customProps.minimumSearchTextLength;
-    delete customProps.searchDelay;
 
     return (
       <div {...customProps} className={searchFieldClassNames}>

--- a/packages/terra-search-field/tests/jest/SearchField.test.jsx
+++ b/packages/terra-search-field/tests/jest/SearchField.test.jsx
@@ -107,6 +107,19 @@ describe('Auto Search', () => {
     expect(onSearch).not.toBeCalled();
   });
 
+  it('triggers onInvalidSearch if minimum text length is not met', () => {
+    jest.useFakeTimers();
+    const onSearch = jest.fn();
+    const onInvalidSearch = jest.fn();
+    const searchField = shallow(<SearchField onSearch={onSearch} onInvalidSearch={onInvalidSearch} minimumSearchTextLength={5} />);
+
+    searchField.childAt(0).simulate('change', { target: { value: 'Sear' } });
+
+    jest.runAllTimers();
+    expect(onSearch).not.toBeCalled();
+    expect(onInvalidSearch).toBeCalledWith('Sear');
+  });
+
   it('uses standard timeout for search delay when not provided', () => {
     const searchField = shallow(<SearchField />);
 

--- a/packages/terra-search-field/tests/nightwatch/CallbackSearchField.jsx
+++ b/packages/terra-search-field/tests/nightwatch/CallbackSearchField.jsx
@@ -8,16 +8,29 @@ class CallbackSearchField extends React.Component {
 
     this.state = {
       searchText: '',
+      message: '',
     };
+
+    this.handleSearch = this.handleSearch.bind(this);
+    this.handleInvalidSearch = this.handleInvalidSearch.bind(this);
+  }
+
+  handleSearch(searchText) {
+    this.setState({ searchText, message: 'Search Text: ' });
+  }
+
+  handleInvalidSearch(searchText) {
+    this.setState({ searchText, message: 'INVALID Search Text: ' });
   }
 
   render() {
     return (
       <div>
+        <h3> Minimum Search Length is 3 </h3>
+        <SearchField id="searchfield" onSearch={this.handleSearch} onInvalidSearch={this.handleInvalidSearch} minimumSearchTextLength={3} />
         <div id="search-callback-text">
-          Search Text: {this.state.searchText}
+          {this.state.message}{this.state.searchText}
         </div>
-        <SearchField id="searchfield" onSearch={(searchText) => { this.setState({ searchText }); }} />
       </div>
     );
   }

--- a/packages/terra-search-field/tests/nightwatch/SearchFieldTests.jsx
+++ b/packages/terra-search-field/tests/nightwatch/SearchFieldTests.jsx
@@ -6,11 +6,11 @@ import { Link } from 'react-router';
 const SearchFieldTests = () => (
   <div>
     <ul>
-      <li><Link to="/tests/search-field-tests/default">Default SearchField</Link></li>
-      <li><Link to="/tests/search-field-tests/placeholder">Placeholder SearchField</Link></li>
-      <li><Link to="/tests/search-field-tests/callback">Callback SearchField</Link></li>
-      <li><Link to="/tests/search-field-tests/delayed">1000ms Delayed SearchField</Link></li>
-      <li><Link to="/tests/search-field-tests/minimum-length">5 Character Minimum Length SearchField</Link></li>
+      <li><Link to="/tests/search-field-tests/default">SearchField - Default</Link></li>
+      <li><Link to="/tests/search-field-tests/placeholder">SearchField - Placeholder</Link></li>
+      <li><Link to="/tests/search-field-tests/callback">SearchField - Callback for Valid and Invalid Entry</Link></li>
+      <li><Link to="/tests/search-field-tests/delayed">SearchField - 1000ms Delayed </Link></li>
+      <li><Link to="/tests/search-field-tests/minimum-length">SearchField - 5 Character Minimum Length </Link></li>
     </ul>
   </div>
 );

--- a/packages/terra-search-field/tests/nightwatch/search-field-spec.js
+++ b/packages/terra-search-field/tests/nightwatch/search-field-spec.js
@@ -31,11 +31,11 @@ module.exports = {
     browser
       .url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/search-field-tests/callback`)
       .setValue('input[type=search]', 'S')
-      .expect.element('#search-callback-text').text.to.equal('Search Text:').after(250);
+      .expect.element('#search-callback-text').text.to.equal('INVALID Search Text: S').after(250);
 
     browser
       .setValue('input[type=search]', 'e')
-      .expect.element('#search-callback-text').text.to.equal('Search Text: Se').after(250);
+      .expect.element('#search-callback-text').text.to.equal('INVALID Search Text: Se').after(250);
 
     browser
       .setValue('input[type=search]', 'a')

--- a/packages/terra-site/CHANGELOG.md
+++ b/packages/terra-site/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated Search Field example to demonstrate onInvalidSearch.
 
 1.1.0 - (July 18, 2017)
 ------------------

--- a/packages/terra-site/src/examples/search-field/SearchFieldMinimumLength.jsx
+++ b/packages/terra-site/src/examples/search-field/SearchFieldMinimumLength.jsx
@@ -5,18 +5,31 @@ class SearchFieldMinimumLength extends React.Component {
 
   constructor(props) {
     super(props);
+
     this.state = {
       searchText: '',
+      message: 'INVALID Search Text: ',
     };
+
+    this.handleSearch = this.handleSearch.bind(this);
+    this.handleInvalidSearch = this.handleInvalidSearch.bind(this);
+  }
+
+  handleSearch(searchText) {
+    this.setState({ searchText, message: 'Search Text: ' });
+  }
+
+  handleInvalidSearch(searchText) {
+    this.setState({ searchText, message: 'INVALID Search Text: ' });
   }
 
   render() {
     return (
       <div>
         <div>
-          Search Text: {this.state.searchText}
+          {this.state.message}{this.state.searchText}
         </div>
-        <SearchField minimumSearchTextLength={5} onSearch={(searchText) => { this.setState({ searchText }); }} />
+        <SearchField minimumSearchTextLength={5}onSearch={this.handleSearch} onInvalidSearch={this.handleInvalidSearch} />
       </div>
     );
   }


### PR DESCRIPTION
### Summary
Added an `onInvalidSearch()` callback function that would provide users with the option to opted-in for callback for invalid search entry. Invalid search entry would include any `searchText` less than the indicated `minimumSearchTextLength`. 

**Note:** the default `minimumSearchTextLength` is 2, so providing an `onInvalidSearch()` would also act as a clear handler. 

Resolves #541 and addresses needs for a clear handler requested in #643.

@cerner/terra
