### PR TITLE
Add explicit rimraf install as part of heroku prebuild script

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "compile:heroku": "cd packages/terra-site && npm run compile:heroku",
     "danger": "danger",
     "deploy": "lerna run --scope terra-site deploy",
-    "heroku-prebuild": "npm install -g lerna@2.0.0-rc.4 && lerna init",
+    "heroku-prebuild": "npm install rimraf && npm install -g lerna@2.0.0-rc.4 && lerna init",
     "heroku-postbuild": "npm install --only=dev && npm run compile:heroku",
     "jest": "jest",
     "jest:coverage": "jest --coverage",


### PR DESCRIPTION
### Summary
Heroku deployments look to be failing noting unable to find rimraf package. This change explicitly installs rimraf as part of the prebuild process.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
