### PR TITLE
Fixed overlay example code in docs/README

### DIFF
--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated example code in overlay documentation
 
 1.1.0 - (July 26, 2017)
 ------------------

--- a/packages/terra-overlay/docs/README.md
+++ b/packages/terra-overlay/docs/README.md
@@ -16,7 +16,7 @@ A Loading Overlay is a specialized Overlay subcomponent that displays an overlay
 ```jsx
 import React from 'react';
 import Button from 'terra-button';
-import Overlay from 'terra-clinical-overlay';
+import Overlay from 'terra-overlay';
 
 class OverlayExample extends React.Component {
   constructor() {
@@ -53,7 +53,7 @@ export default OverlayExample;
 ```jsx
 import React from 'react';
 import Button from 'terra-button';
-import Overlay.LoadingOverlay from 'terra-clinical-overlay';
+import Overlay.LoadingOverlay from 'terra-overlay';
 
 class LoadingOverlayExample extends React.Component {
   constructor() {


### PR DESCRIPTION
### Summary
Fixed Overlay Example code in docs/README. Switch to terra-overlay, instead of terra-clinical-overlay.