### PR TITLE
Remove mixins dependency from all core packages

### DIFF
--- a/packages/terra-alert/package.json
+++ b/packages/terra-alert/package.json
@@ -30,8 +30,7 @@
     "terra-responsive-element": "^1.0.0",
     "terra-base": "^1.0.0",
     "terra-button": "^1.0.0",
-    "terra-icon": "^1.0.0",
-    "terra-mixins": "^1.0.0"
+    "terra-icon": "^1.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
@@ -39,8 +38,7 @@
     "terra-responsive-element": "^1.0.0",
     "terra-base": "^1.0.0",
     "terra-button": "^1.0.0",
-    "terra-icon": "^1.0.0",
-    "terra-mixins": "^1.0.0"
+    "terra-icon": "^1.0.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-arrange/package.json
+++ b/packages/terra-arrange/package.json
@@ -39,14 +39,12 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "devDependencies": {
     "terra-icon": "^1.2.0",

--- a/packages/terra-badge/package.json
+++ b/packages/terra-badge/package.json
@@ -39,14 +39,12 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "devDependencies": {
     "terra-props-table": "^1.1.0"

--- a/packages/terra-button-group/package.json
+++ b/packages/terra-button-group/package.json
@@ -27,15 +27,13 @@
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "terra-base": "^1.1.0",
-    "terra-button": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-button": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
     "terra-base": "^1.1.0",
-    "terra-button": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-button": "^1.1.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-button/CHANGELOG.md
+++ b/packages/terra-button/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed terra-mixins
 
 1.1.0 - (July 18, 2017)
 ### Changed

--- a/packages/terra-button/package.json
+++ b/packages/terra-button/package.json
@@ -42,13 +42,11 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   }
 }

--- a/packages/terra-button/src/Button.scss
+++ b/packages/terra-button/src/Button.scss
@@ -1,4 +1,3 @@
-@import '~terra-mixins';
 @import './variables';
 @import './mixins';
 

--- a/packages/terra-button/src/Button.scss
+++ b/packages/terra-button/src/Button.scss
@@ -30,8 +30,6 @@
   // stylelint-enable selector-no-qualifying-type
 
   .button {
-    @include terra-text-align-center;
-
     border-radius: var(--terra-button-border-radius);
     border-style: solid;
     border-width: var(--terra-button-border-width);
@@ -45,6 +43,7 @@
     padding-left: var(--terra-button-padding-left);
     padding-right: var(--terra-button-padding-right);
     padding-top: var(--terra-button-padding-top);
+    text-align: center;
     text-decoration: none;
     text-transform: var(--terra-button-text-transform);
     touch-action: manipulation; // Enable fast tap interactiion in webkit browsers; see https://webkit.org/blog/5610/more-responsive-tapping-on-ios/

--- a/packages/terra-content-container/package.json
+++ b/packages/terra-content-container/package.json
@@ -26,14 +26,12 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-grid/CHANGELOG.md
+++ b/packages/terra-grid/CHANGELOG.md
@@ -7,6 +7,9 @@ Unreleased
 * Converted component to use CSS modules
 * Converted SCSS variables to CSS custom properties for theming
 
+### Removed
+* Removed terra-mixins
+
 3.5.1 - (July 18, 2017)
 ------------------
 ### Changed

--- a/packages/terra-grid/package.json
+++ b/packages/terra-grid/package.json
@@ -42,13 +42,11 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   }
 }

--- a/packages/terra-grid/src/Grid.scss
+++ b/packages/terra-grid/src/Grid.scss
@@ -1,4 +1,3 @@
-@import '~terra-mixins';
 @import './variables';
 @import './mixins';
 

--- a/packages/terra-heading/package.json
+++ b/packages/terra-heading/package.json
@@ -27,14 +27,12 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-icon/package.json
+++ b/packages/terra-icon/package.json
@@ -29,14 +29,12 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "scripts": {
     "compilescripts": "npm run compilescripts:clean && npm run compilescripts:build",

--- a/packages/terra-image/package.json
+++ b/packages/terra-image/package.json
@@ -42,13 +42,11 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   }
 }

--- a/packages/terra-list/package.json
+++ b/packages/terra-list/package.json
@@ -27,16 +27,14 @@
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "terra-base": "^1.1.0",
-    "terra-icon": "^1.2.0",
-    "terra-mixins": "^1.7.0"
+    "terra-icon": "^1.2.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
     "terra-arrange": "^1.2.0",
     "terra-base": "^1.1.0",
-    "terra-icon": "^1.2.0",
-    "terra-mixins": "^1.7.0"
+    "terra-icon": "^1.2.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-modal-manager/package.json
+++ b/packages/terra-modal-manager/package.json
@@ -32,14 +32,12 @@
     "react-redux": "^5.0.4",
     "redux": "^3.6.0",
     "terra-app-delegate": "^1.1.0",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
     "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0",
     "terra-modal": "^1.2.0",
     "terra-responsive-element": "^1.1.0",
     "terra-slide-group": "^1.1.0"

--- a/packages/terra-modal/package.json
+++ b/packages/terra-modal/package.json
@@ -33,8 +33,7 @@
     "focus-trap-react": "^3.0.2",
     "prop-types": "^15.5.8",
     "react-portal": "^3.0.0",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-overlay/package.json
+++ b/packages/terra-overlay/package.json
@@ -28,16 +28,14 @@
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "terra-base": "^1.1.0",
-    "terra-icon": "^1.2.0",
-    "terra-mixins": "^1.7.0"
+    "terra-icon": "^1.2.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "focus-trap-react": "^3.0.2",
     "prop-types": "^15.5.8",
     "terra-base": "^1.1.0",
-    "terra-icon": "^1.2.0",
-    "terra-mixins": "^1.7.0"
+    "terra-icon": "^1.2.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-progress-bar/CHANGELOG.md
+++ b/packages/terra-progress-bar/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed terra-mixins
 
 1.1.0 - (July 18, 2017)
 ------------------

--- a/packages/terra-progress-bar/package.json
+++ b/packages/terra-progress-bar/package.json
@@ -42,13 +42,11 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   }
 }

--- a/packages/terra-progress-bar/src/ProgressBar.scss
+++ b/packages/terra-progress-bar/src/ProgressBar.scss
@@ -1,4 +1,3 @@
-@import '~terra-mixins';
 @import './variables';
 @import './mixins';
 

--- a/packages/terra-progress-bar/src/ProgressBar.scss
+++ b/packages/terra-progress-bar/src/ProgressBar.scss
@@ -28,25 +28,27 @@
 
       &::-webkit-progress-value {
         background-color: currentColor;
-        @include terra-border-end(1px solid #FFF);
-        @include terra-border-radius-start(0);
+        border-bottom-left-radius: 0;
+        border-right: 1px solid #fff;
+        border-top-left-radius: 0;
       }
 
       &::-ms-fill {
         background-color: currentColor;
-        @include terra-border-end(1px solid #FFF);
+        border-right: 1px solid #fff;
       }
     }
 
     &[value='100'],
     &[value='0'] {
       &::-webkit-progress-value {
-        @include terra-border-radius-end(0);
-        @include terra-border-end(0 solid #FFF);
+        border-bottom-right-radius: 0;
+        border-right: 0 solid #fff;
+        border-top-right-radius: 0;
       }
 
       &::-ms-fill {
-        @include terra-border-end(0 solid #FFF);
+        border-right: 0 solid #fff;
       }
     }
   }
@@ -66,19 +68,21 @@
       }
 
       &[value]::-moz-progress-bar {
-        @include terra-border-radius-start(0);
         background-color: currentColor;
-        @include terra-border-end(1px solid #FFF);
+        border-bottom-left-radius: 0;
+        border-right: 1px solid #fff;
+        border-top-left-radius: 0;
       }
 
       &[value='100'] {
-        @include terra-border-end(0 solid #FFF);
+        border-right: 0 solid #fff;
       }
 
       &[value='0']::-moz-progress-bar,
       &[value='100']::-moz-progress-bar {
-        @include terra-border-radius-end(0);
-        @include terra-border-end(0 solid #FFF);
+        border-bottom-right-radius: 0;
+        border-right: 0 solid #fff;
+        border-top-right-radius: 0;
       }
     }
   }

--- a/packages/terra-responsive-element/package.json
+++ b/packages/terra-responsive-element/package.json
@@ -26,14 +26,12 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "dependencies": {
     "prop-types": "^15.5.8",
     "resize-observer-polyfill": "^1.4.1",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-search-field/package.json
+++ b/packages/terra-search-field/package.json
@@ -29,8 +29,7 @@
     "terra-base": "^1.1.0",
     "terra-button": "^1.1.0",
     "terra-form": "^1.1.0",
-    "terra-icon": "^1.2.0",
-    "terra-mixins": "^1.7.0"
+    "terra-icon": "^1.2.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
@@ -38,8 +37,7 @@
     "terra-base": "^1.1.0",
     "terra-button": "^1.1.0",
     "terra-form": "^1.1.0",
-    "terra-icon": "^1.2.0",
-    "terra-mixins": "^1.7.0"
+    "terra-icon": "^1.2.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -52,7 +52,6 @@
     "terra-image": "^1.1.0",
     "terra-list": "^1.2.0",
     "terra-markdown": "^1.1.0",
-    "terra-mixins": "^1.7.0",
     "terra-modal": "^1.2.0",
     "terra-modal-manager": "^1.2.0",
     "terra-overlay": "^1.1.0",

--- a/packages/terra-status/package.json
+++ b/packages/terra-status/package.json
@@ -43,13 +43,11 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   }
 }

--- a/packages/terra-text/package.json
+++ b/packages/terra-text/package.json
@@ -27,14 +27,12 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-time-input/package.json
+++ b/packages/terra-time-input/package.json
@@ -27,16 +27,14 @@
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "terra-base": "^1.1.0",
-    "terra-form": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-form": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "moment": "^2.17.1",
     "prop-types": "^15.5.8",
     "terra-base": "^1.1.0",
-    "terra-form": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-form": "^1.1.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-toggle-button/package.json
+++ b/packages/terra-toggle-button/package.json
@@ -30,7 +30,6 @@
     "terra-base": "^1.1.0",
     "terra-button": "^1.1.0",
     "terra-icon": "^1.2.0",
-    "terra-mixins": "^1.7.0",
     "terra-toggle": "^1.1.0"
   },
   "dependencies": {
@@ -40,7 +39,6 @@
     "terra-base": "^1.1.0",
     "terra-button": "^1.1.0",
     "terra-icon": "^1.2.0",
-    "terra-mixins": "^1.7.0",
     "terra-toggle": "^1.1.0"
   },
   "scripts": {

--- a/packages/terra-toggle/package.json
+++ b/packages/terra-toggle/package.json
@@ -26,15 +26,13 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
     "react-animate-height": "^0.9.5",
-    "terra-base": "^1.1.0",
-    "terra-mixins": "^1.7.0"
+    "terra-base": "^1.1.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",


### PR DESCRIPTION
### Summary
With the postcss-rtl plugin, we no longer have a need for the bidi mixins. This PR includes updates to remove the package as a dependency from all core packages. It also includes updates to button and progress-bar to migrate off of using mixins for bidirectional styling.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
