### PR TITLE
Merge data-class customProps

### DIFF
--- a/packages/terra-table/CHANGELOG.md
+++ b/packages/terra-table/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Merge data-class attributes to allow for custom data-classes
 
 1.4.0 - (August 1, 2017)
 ------------------

--- a/packages/terra-table/src/TableCell.jsx
+++ b/packages/terra-table/src/TableCell.jsx
@@ -12,11 +12,14 @@ const propTypes = {
 const TableCell = ({
   content,
   ...customProps
-}) => (
-  <td {...customProps} data-class="cell">
-    {content}
-  </td>
-);
+}) => {
+  const dataClassNames = customProps['data-class'] ? `cell ${customProps['data-class']}` : 'cell';
+  return (
+    <td {...customProps} data-class={dataClassNames}>
+      {content}
+    </td>
+  );
+};
 
 
 TableCell.propTypes = propTypes;

--- a/packages/terra-table/src/TableHeaderCell.jsx
+++ b/packages/terra-table/src/TableHeaderCell.jsx
@@ -40,6 +40,7 @@ const TableHeaderCell = ({
     { [`min-width-${minWidth}`]: minWidth },
     customProps.className,
   ]);
+  const dataClassNames = customProps['data-class'] ? `header-cell ${customProps['data-class']}` : 'header-cell';
 
   const dataSort = {
     'data-sort': sort,
@@ -52,8 +53,9 @@ const TableHeaderCell = ({
     sortIndicator = <span className={cx('sort-indicator')}>{iconDown}</span>;
   }
 
+
   return (
-    <th {...customProps} data-class="header" className={contentClassName} {...dataSort}>
+    <th {...customProps} data-class={dataClassNames} className={contentClassName} {...dataSort}>
       {content}
       {sortIndicator}
     </th>

--- a/packages/terra-table/src/TableSubheader.jsx
+++ b/packages/terra-table/src/TableSubheader.jsx
@@ -22,14 +22,17 @@ const TableSubheader = ({
   content,
   colSpan,
   ...customProps
-}) => (
+}) => {
   // count is based on the number of columns and assigned in the table component which contains this subheader
-  <tr data-class="subheader-row">
-    <td {...customProps} className={cx('subheader', customProps.className)} colSpan={colSpan}>
-      {content}
-    </td>
-  </tr>
-);
+  const dataClassNames = customProps['data-class'] ? `subheader-row ${customProps['data-class']}` : 'subheader-row';
+  return (
+    <tr data-class={dataClassNames}>
+      <td {...customProps} className={cx('subheader', customProps.className)} colSpan={colSpan}>
+        {content}
+      </td>
+    </tr>
+  );
+};
 
 TableSubheader.propTypes = propTypes;
 

--- a/packages/terra-table/tests/jest/__snapshots__/TableHeaderContent.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableHeaderContent.test.jsx.snap
@@ -1,7 +1,7 @@
 exports[`test should render default table header content tag 1`] = `
 <th
   className="min-width-small"
-  data-class="header">
+  data-class="header-cell">
   Column Heading
 </th>
 `;
@@ -9,7 +9,7 @@ exports[`test should render default table header content tag 1`] = `
 exports[`test should render table header content tag with ascending sort indicator 1`] = `
 <th
   className="min-width-small"
-  data-class="header"
+  data-class="header-cell"
   data-sort="asc">
   Column Heading
   <span
@@ -26,7 +26,7 @@ exports[`test should render table header content tag with ascending sort indicat
 exports[`test should render table header content tag with descending sort indicator 1`] = `
 <th
   className="min-width-small"
-  data-class="header"
+  data-class="header-cell"
   data-sort="desc">
   Column Heading
   <span
@@ -43,7 +43,7 @@ exports[`test should render table header content tag with descending sort indica
 exports[`test should render table header content tag with maximum height fixed 1`] = `
 <th
   className="min-width-small"
-  data-class="header">
+  data-class="header-cell">
   Column Heading
 </th>
 `;

--- a/packages/terra-table/tests/nightwatch/components/TableWithSelectableRowsAndSubheaders.jsx
+++ b/packages/terra-table/tests/nightwatch/components/TableWithSelectableRowsAndSubheaders.jsx
@@ -5,14 +5,14 @@ import Table from '../../../lib/Table';
 const TableWithSelectableRowsAndSubheaders = () => (
   <Table isStriped className="Table-Custom">
     <Table.Header className="Header-Custom">
-      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} className="Cell-Custom" />
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} className="HeaderCell-Custom" data-class="HeaderCell-Custom" />
       <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} sort={'asc'} />
       <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
     </Table.Header>
     <Table.SingleSelectableRows className="SingleSelectableRows-Custom">
       <Table.Subheader key="SUBHEADER_0" content={'Single'} />
       <Table.Row key={'PERSON_0'}>
-        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="John Smith" key="NAME" className="Cell-Custom" data-class="Cell-Custom" />
         <Table.Cell content="123 Adams Drive" key="ADDRESS" />
         <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
@@ -21,7 +21,7 @@ const TableWithSelectableRowsAndSubheaders = () => (
         <Table.Cell content="321 Drive Street" key="ADDRESS" />
         <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
       </Table.Row>
-      <Table.Subheader key="SUBHEADER_1" content={'Married'} className="Subheader-Custom" />
+      <Table.Subheader key="SUBHEADER_1" content={'Married'} className="Subheader-Custom" data-class="Subheader-Custom" />
       <Table.Row key={'PERSON_2'}>
         <Table.Cell content="Dave Smith" key="NAME" />
         <Table.Cell content="213 Raymond Road" key="ADDRESS" />

--- a/packages/terra-table/tests/nightwatch/table-spec.js
+++ b/packages/terra-table/tests/nightwatch/table-spec.js
@@ -218,8 +218,16 @@ module.exports = {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/table-tests/table-selectable-subheaders`);
     browser.assert.elementPresent('.Table-Custom');
     browser.assert.elementPresent('.Header-Custom');
+    browser.assert.elementPresent('.HeaderCell-Custom');
     browser.assert.elementPresent('.Cell-Custom');
     browser.assert.elementPresent('.SingleSelectableRows-Custom');
     browser.assert.elementPresent('.Subheader-Custom');
+  },
+
+  'Spreads custom data-classes when provided': (browser) => {
+    browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/table-tests/table-selectable-subheaders`);
+    browser.expect.element('.HeaderCell-Custom').to.have.attribute('data-class').which.contains('HeaderCell-Custom');
+    browser.expect.element('.Cell-Custom').to.have.attribute('data-class').which.contains('Cell-Custom');
+    browser.expect.element('.Subheader-Custom').to.have.attribute('data-class').which.contains('Subheader-Custom');
   },
 };


### PR DESCRIPTION
### Summary
In the conversion to CSS Modules, some components were given the `data-class` attribute for classes that had no styling applied. This PR updates to merge custom data-classes with the existing component's data-attribute value.

@cerner/terra