### PR TITLE
Change Data Picker data-class to name spaced data attrs.

### DIFF
--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Change data-class to be name spaced
 
 1.4.0 - (August 1, 2017)
 ------------------

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -131,7 +131,7 @@ class DatePickerInput extends React.Component {
         <input
           // Create a hidden input for storing the name and value attributes to use when submitting the form.
           // The data stored in the value attribute will be the visible date in the date input but in ISO 8601 format.
-          data-class="hidden-date-input"
+          data-terra-date-input-hidden
           type="hidden"
           name={name}
           value={dateValue}

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -2,7 +2,7 @@ exports[`test should render a default date input 1`] = `
 <div
   class="custom-input">
   <input
-    data-class="hidden-date-input"
+    data-terra-date-input-hidden="true"
     type="hidden" />
   <input
     class="input input"
@@ -31,7 +31,7 @@ exports[`test should render a default date input with all props 1`] = `
 <div
   class="custom-input">
   <input
-    data-class="hidden-date-input"
+    data-terra-date-input-hidden="true"
     name="date-input"
     type="hidden"
     value="2017-01-01" />

--- a/packages/terra-date-picker/tests/nightwatch/date-picker-spec.js
+++ b/packages/terra-date-picker/tests/nightwatch/date-picker-spec.js
@@ -61,14 +61,14 @@ module.exports = {
 
   'Creates a hidden input with a name atribute of "date-input" and an empty value attribute when no date is entered': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/date-picker-tests/default`);
-    browser.expect.element('[data-class="hidden-date-input"]').to.have.attribute('name').which.equals('date-input');
-    browser.expect.element('[data-class="hidden-date-input"]').to.have.attribute('value').which.equals('');
+    browser.expect.element('[data-terra-date-input-hidden]').to.have.attribute('name').which.equals('date-input');
+    browser.expect.element('[data-terra-date-input-hidden]').to.have.attribute('value').which.equals('');
   },
 
   'Creates a hidden input with a default name atribute of "date-input" and sets the value in ISO8601 format when a valid date is entered': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/date-picker-tests/start-date`);
-    browser.expect.element('[data-class="hidden-date-input"]').to.have.attribute('name').which.equals('date-input');
-    browser.expect.element('[data-class="hidden-date-input"]').to.have.attribute('value').which.equals('2017-04-01');
+    browser.expect.element('[data-terra-date-input-hidden]').to.have.attribute('name').which.equals('date-input');
+    browser.expect.element('[data-terra-date-input-hidden]').to.have.attribute('value').which.equals('2017-04-01');
   },
 
   'Creates a hidden input and sets the value attribute as is when an invalid date is entered': (browser) => {
@@ -76,8 +76,8 @@ module.exports = {
     browser.click('[name="terra-date-date-input"]');
     browser.keys('2017');
 
-    browser.expect.element('[data-class="hidden-date-input"]').to.have.attribute('name').which.equals('date-input');
-    browser.expect.element('[data-class="hidden-date-input"]').to.have.attribute('value').which.equals('2017');
+    browser.expect.element('[data-terra-date-input-hidden]').to.have.attribute('name').which.equals('date-input');
+    browser.expect.element('[data-terra-date-input-hidden]').to.have.attribute('value').which.equals('2017');
   },
 
   'Displays the calendar button with a height that matches the input ': (browser) => {


### PR DESCRIPTION
### Summary
In this closed PR https://github.com/cerner/terra-core/pull/694 it was discussed to change `data-class` attributes to be name spaced to the rendering component. 

### More Information
Before the CSS Module conversion, some elements had terra class names to represent the structure of the component but did not apply any styling. In the conversion, the class names of un-styled elements were changed to data-class attributes to maintain this structural representation.


