### PR TITLE
Importing correct classNames function to ensure classes are generated properly

### DIFF
--- a/packages/terra-modal-manager/CHANGELOG.md
+++ b/packages/terra-modal-manager/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Added
 * Added fullscreen size option
 
+### Fixed
+* Correcting container class name
+
 1.4.0 - (August 1, 2017)
 ------------------
 ### Changed

--- a/packages/terra-modal-manager/src/ModalManager.jsx
+++ b/packages/terra-modal-manager/src/ModalManager.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import classNames from 'classnames/bind';
 import Modal from 'terra-modal';
 
 import AppDelegate from 'terra-app-delegate';


### PR DESCRIPTION
### Summary
The ModalManager wasn't importing the correct classNames function, which was causing an issue with one of the generated class names.