### PR TITLE
Update css-loader localIndentName Config

### DIFF
--- a/packages/terra-site/webpack.config.js
+++ b/packages/terra-site/webpack.config.js
@@ -36,7 +36,7 @@ module.exports = {
           options: {
             sourceMap: true,
             importLoaders: 2,
-            localIdentName: '[path]___[name]__[local]___[hash:base64:5]',
+            localIdentName: '[name]__[local]___[hash:base64:5]',
           },
         }, {
           loader: 'postcss-loader',


### PR DESCRIPTION
### Summary
Our current css-loader localIndentName configuration is:

` localIdentName: '[path]__[name]__[local]___[hash:base64:5]`

updated to:

`localIdentName: '[name]__[local]___[hash:base64:5]`

Thanks for contributing to Terra. 
@cerner/terra
