### PR TITLE
fixing generate-example script to create IconStatic.jsx component in terra-site

### DIFF
--- a/packages/terra-icon/scripts/src/generate-example/generateStaticIcons.js
+++ b/packages/terra-icon/scripts/src/generate-example/generateStaticIcons.js
@@ -1,12 +1,12 @@
 /* eslint-disable */
 import fs from 'fs';
 
-const outputfile = fs.createWriteStream('../../packages/terra-site/src/examples/icon/IconThemeable.jsx', { flags: 'w' });
+const outputfile = fs.createWriteStream('../../packages/terra-site/src/examples/icon/IconStatic.jsx', { flags: 'w' });
 
 const generateIconAll = iconObjs => new Promise((resolve) => {
 
   const staticIcons = iconObjs.filter(function(iconObj){
-    if (iconObj.themeable) {
+    if (!iconObj.themeable) {
       return iconObj;
     }
   });


### PR DESCRIPTION

### Summary
Running `npm run migrate-cerner-one-icons` is not generating the IconStatic.jsx component in terra-site. 