### PR TITLE
Explicitly set font-size / line-height for person name

### DIFF
--- a/packages/terra-demographics-banner/CHANGELOG.md
+++ b/packages/terra-demographics-banner/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Explicitly set font-size / line-height for person name
 
 1.7.0 - (September 5, 2017)
 ------------------

--- a/packages/terra-demographics-banner/src/DemographicsBanner.scss
+++ b/packages/terra-demographics-banner/src/DemographicsBanner.scss
@@ -27,7 +27,13 @@
 
   .person-name {
     flex: 2;
+    font-size: 1.143rem;
+    line-height: 1;
     margin: 0;
+
+    @media screen and (min-width: 768px) {
+      font-size: 1.286rem;
+    }
   }
 
   .identifiers {


### PR DESCRIPTION
### Summary
Explicitly set line-height and font-size on demographics banner heading. This resolves #535 

### Deployment Link
https://terra-core-deployed-pr-779.herokuapp.com/static/#/site/demographics-banner

@cerner/terra
