### PR TITLE
Update var name to avoid conflicts with legacy code

### DIFF
--- a/packages/terra-responsive-element/CHANGELOG.md
+++ b/packages/terra-responsive-element/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Update SCSS variable name for breakpoints to avoid conflicts with legacy code
 
 1.6.0 - (September 5, 2017)
 ------------------

--- a/packages/terra-responsive-element/src/breakpoints.scss
+++ b/packages/terra-responsive-element/src/breakpoints.scss
@@ -1,4 +1,4 @@
-$terra-breakpoints: (
+$terra-responsive-breakpoints: (
   tiny: 544,
   small: 768,
   medium: 992,
@@ -8,7 +8,7 @@ $terra-breakpoints: (
 
 :export {
   // Create responsive styles
-  @each $property, $value in $terra-breakpoints {
+  @each $property, $value in $terra-responsive-breakpoints {
     #{$property}: $value;
   }
 }


### PR DESCRIPTION
### Summary
We've found in some cases the `$terra-breakpoints` variable in the responsive element can conflict with the variable named the same in terra-legacy-theme. This causes the CSS modules export to be reported as string values instead of numeric values. This update ensures this variable is unique in our code and avoids conflicts with existing terra variable names.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
