### PR TITLE
Fixed -var() statements

### DIFF
--- a/packages/terra-grid/CHANGELOG.md
+++ b/packages/terra-grid/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Fix `-var()` syntax.
 
 3.11.0 - (September 7, 2017)
 ------------------

--- a/packages/terra-grid/src/Grid.scss
+++ b/packages/terra-grid/src/Grid.scss
@@ -13,7 +13,7 @@
     flex-grow: 0;
     flex-shrink: 1;
     flex-wrap: wrap;
-    margin-left: -var(--terra-grid-gutter-width, 1rem);
+    margin-left: calc(var(--terra-grid-gutter-width, 1rem) * -1);
   }
 
   .column {

--- a/packages/terra-popup/CHANGELOG.md
+++ b/packages/terra-popup/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Fix `-var()` syntax.
 
 1.7.0 - (September 7, 2017)
 ------------------

--- a/packages/terra-popup/src/PopupArrow.scss
+++ b/packages/terra-popup/src/PopupArrow.scss
@@ -34,7 +34,7 @@
       &::after {
         border-bottom-color: #fff;
         border-top-width: 0;
-        left: -var(--terra-popup-arrow-inner-size, 10px);
+        left: calc(var(--terra-popup-arrow-inner-size, 10px) * -1);
         top: var(--terra-popup-arrow-inner-inset-size, 2px);
       }
     }
@@ -50,7 +50,7 @@
         border-bottom-width: 0;
         border-top-color: var(--terra-popup-arrow-inner-color, #fff);
         bottom: var(--terra-popup-arrow-inner-inset-size, 2px);
-        left: -var(--terra-popup-arrow-inner-size, 10px);
+        left: calc(var(--terra-popup-arrow-inner-size, 10px) * -1);
       }
     }
 
@@ -65,7 +65,7 @@
         border-left-width: 0;
         border-right-color: var(--terra-popup-arrow-inner-color, #fff);
         left: var(--terra-popup-arrow-inner-inset-size, 2px);
-        top: -var(--terra-popup-arrow-inner-size, 10px);
+        top: calc(var(--terra-popup-arrow-inner-size, 10px) * -1);
       }
     }
 
@@ -80,7 +80,7 @@
         border-left-color: var(--terra-popup-arrow-inner-color, #fff);
         border-right-width: 0;
         right: var(--terra-popup-arrow-inner-inset-size, 2px);
-        top: -var(--terra-popup-arrow-inner-size, 10px);
+        top: calc(var(--terra-popup-arrow-inner-size, 10px) * -1);
       }
     }
   }


### PR DESCRIPTION
### Summary
In our code we were using syntax of `-var()`. This is actually invalid syntax but was appearing to work because the postcss plugin was interpreting the var() statement and then putting the negative sign in front of the output. 

I've corrected the syntax by using calc(). 


### Additional Details
We may want to consider adding a default lint rule to prevent this from happening in the future.

