### PR TITLE
Added MultipleSelectableRows to terra-table

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,6 +29,7 @@ Cerner Corporation
 - Michael Hemesath [@mhemesath]
 - Umesh Shimpi [@us044466]
 - Rishi Asthana [@rasthana]
+- Daniel Vu [@dv297]
 
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
@@ -62,3 +63,4 @@ Cerner Corporation
 [@us044466]: https://github.com/us044466
 [@brhoades]: https://github.com/brhoades
 [@rasthana]: https://github.com/rasthana
+[@dv297]: https://github.com/dv297

--- a/packages/terra-site/src/examples/table/Index.jsx
+++ b/packages/terra-site/src/examples/table/Index.jsx
@@ -9,6 +9,7 @@ import { version } from 'terra-list/package.json';
 /* eslint-disable import/no-webpack-loader-syntax, import/first, import/no-unresolved, import/extensions */
 import TableSrc from '!raw-loader!terra-table/src/Table';
 import SingleSelectableRowsSrc from '!raw-loader!terra-table/src/SingleSelectableRows';
+import MultipleSelectableRowsSrc from '!raw-loader!terra-table/src/MultipleSelectableRows';
 import TableHeaderSrc from '!raw-loader!terra-table/src/TableHeader';
 import TableHeaderCellSrc from '!raw-loader!terra-table/src/TableHeaderCell';
 import TableRowSrc from '!raw-loader!terra-table/src/TableRow';
@@ -22,7 +23,8 @@ import NoPaddingTable from './NoPaddingTable';
 import StripedTable from './StripedTable';
 import TableWithHighlightedRows from './TableWithHighlightedRows';
 import SingleRowSelectableTable from './SingleRowSelectableTable';
-import TableWithNonSelectableRow from './TableWithNonSelectableRow';
+import SingleRowSelectableTableWithNonSelectableRow from './SingleRowSelectableTableWithNonSelectableRow';
+import MultipleRowsSelectableTable from './MultipleRowsSelectableTable';
 import TableWithSortingIndicator from './TableWithSortingIndicator';
 import TableWithLongContent from './TableWithLongContent';
 import TableWithCustomCells from './TableWithCustomCells';
@@ -38,6 +40,7 @@ const TableExamples = () => (
     <PropsTable id="props-tableSubheader" src={TableSubheaderSrc} componentName="Table Subheader" />
     <PropsTable id="props-tableRows" src={TableRowsSrc} componentName="Table Rows" />
     <PropsTable id="props-singleSelectableRows" src={SingleSelectableRowsSrc} componentName="Single Selectable Rows" />
+    <PropsTable id="props-multipleSelectableRows" src={MultipleSelectableRowsSrc} componentName="Multiple Selectable Rows" />
     <PropsTable id="props-tableRow" src={TableRowSrc} componentName="Table Row" />
     <PropsTable id="props-tablecell" src={TableCellSrc} componentName="Table Cell" />
     <br />
@@ -54,12 +57,14 @@ const TableExamples = () => (
     <h2>Table with some rows selected. Table will not select or deselect any row</h2>
     <TableWithHighlightedRows />
     <br />
-    <h2>Selectable table</h2>
+    <h2>Single Row Selectable table</h2>
     <SingleRowSelectableTable />
     <br />
-    <h2>Selectable table with second row as non selectable</h2>
-    <TableWithNonSelectableRow />
+    <h2>Single Row Selectable table with second row as non selectable</h2>
+    <SingleRowSelectableTableWithNonSelectableRow />
     <br />
+    <h2>Multiple Row Selectable table</h2>
+    <MultipleRowsSelectableTable />
     <h2>Table with sorting indicator</h2>
     <TableWithSortingIndicator />
     <br />

--- a/packages/terra-site/src/examples/table/MultipleRowsSelectableTable.jsx
+++ b/packages/terra-site/src/examples/table/MultipleRowsSelectableTable.jsx
@@ -1,0 +1,32 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import Table from 'terra-table';
+
+const MultipleRowsSelectableTable = () => (
+  <Table isStriped={false}>
+    <Table.Header>
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+    </Table.Header>
+    <Table.MultipleSelectableRows>
+      <Table.Row isSelected key={'PERSON_0'}>
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Row key={'PERSON_1'}>
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Row key={'PERSON_2'}>
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+    </Table.MultipleSelectableRows>
+  </Table>
+);
+
+export default MultipleRowsSelectableTable;

--- a/packages/terra-site/src/examples/table/SingleRowSelectableTableWithNonSelectableRow.jsx
+++ b/packages/terra-site/src/examples/table/SingleRowSelectableTableWithNonSelectableRow.jsx
@@ -1,0 +1,32 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import Table from 'terra-table';
+
+const TableWithNonSelectableRow = () => (
+  <Table isStriped={false}>
+    <Table.Header>
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+    </Table.Header>
+    <Table.SingleSelectableRows>
+      <Table.Row isSelected key={'PERSON_0'}>
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Row isSelectable={false} key={'PERSON_1'}>
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Row key={'PERSON_2'}>
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+    </Table.SingleSelectableRows>
+  </Table>
+);
+
+export default TableWithNonSelectableRow;

--- a/packages/terra-table/CHANGELOG.md
+++ b/packages/terra-table/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added MultipleSelectableRows component
 
 1.9.0 - (September 7, 2017)
 ------------------

--- a/packages/terra-table/docs/README.md
+++ b/packages/terra-table/docs/README.md
@@ -40,7 +40,7 @@ import Table from 'terra-table';
   </Table.Rows>
 </Table>
 ```
-### Selectable Table
+### Single Selectable Row Table
 ```jsx
 import React from 'react';
 import Table from 'terra-table';
@@ -68,6 +68,37 @@ import Table from 'terra-table';
       <Table.Cell content={'Table Data'} key={'COLUMN_2'} />
     </Table.Row>
   </Table.SingleSelectableRows>
+</Table>
+```
+
+### Multiple Row Selectable Table
+```jsx
+import React from 'react';
+import Table from 'terra-table';
+
+<Table isStriped={false}>
+  <Table.Header>
+    <Table.HeaderCell content={'Column Heading 1'} key={'COLUMN_0'} minWidth={'small'} />
+    <Table.HeaderCell content={'Column Heading 2'} key={'COLUMN_1'} minWidth={'medium'} />
+    <Table.HeaderCell content={'Column Heading 3'} key={'COLUMN_2'} minWidth={'large'} />
+  </Table.Header>
+  <Table.MultipleSelectableRows>
+    <Table.Row isSelected={true} key={'ROW_0'}>
+      <Table.Cell content={'Table Data'} key={'COLUMN_0'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_1'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_2'} />
+    </Table.Row>
+    <Table.Row key={'ROW_1'}>
+      <Table.Cell content={'Table Data'} key={'COLUMN_0'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_1'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_2'} />
+    </Table.Row>
+    <Table.Row key={'ROW_2'}>
+      <Table.Cell content={'Table Data'} key={'COLUMN_0'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_1'} />
+      <Table.Cell content={'Table Data'} key={'COLUMN_2'} />
+    </Table.Row>
+  </Table.MultipleSelectableRows>
 </Table>
 ```
 

--- a/packages/terra-table/package.json
+++ b/packages/terra-table/package.json
@@ -42,7 +42,7 @@
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
-    "props-table": "props-table ./src/Table.jsx ./src/TableCell.jsx ./src/TableHeader.jsx ./src/TableRow.jsx ./src/TableRows.jsx ./src/TableSubheader.jsx --out-dir ./docs/props-table",
+    "props-table": "props-table ./src/Table.jsx ./src/TableCell.jsx ./src/TableHeader.jsx ./src/TableRow.jsx ./src/TableRows.jsx ./src/TableSubheader.jsx ./src/SingleSelectableRows.jsx ./src/MultipleSelectableRows.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
     "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"

--- a/packages/terra-table/src/MultipleSelectableRows.jsx
+++ b/packages/terra-table/src/MultipleSelectableRows.jsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import 'terra-base/lib/baseStyles';
+import TableRows from './TableRows';
+import TableRow from './TableRow';
+
+const KEYCODES = {
+  ENTER: 13,
+  SPACE: 32,
+};
+
+const propTypes = {
+  /**
+   * The children passed to the component
+   */
+  children: PropTypes.node,
+  /**
+   * A callback function for onChange action. Has the following parameters:
+   * <ul>
+   *   <li>the event triggering the onChange</li>
+   *   <li>the sorted list of the indexes for the rows selected</li>
+   *   <li>the index of the last item selected</li>
+   * </ul>
+   */
+  onChange: PropTypes.func,
+};
+
+const defaultProps = {
+  onChange: undefined,
+};
+
+class MultipleSelectableRows extends React.Component {
+  static selectedRowIndexes(rows) {
+    if (!rows || !rows.length) {
+      return [];
+    }
+
+    // Find the rows which are selected and are selectable
+    const selectedIndexes = [];
+    for (let i = 0; i < rows.length; i += 1) {
+      if (rows[i].props.isSelected) {
+        selectedIndexes.push(i);
+      }
+    }
+    return selectedIndexes;
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedIndexes: MultipleSelectableRows.selectedRowIndexes(this.props.children),
+    };
+  }
+
+  handleOnChange(event, index) {
+    return () => {
+      if (this.props.onChange) {
+        const selectedIndexes = this.state.selectedIndexes.sort();
+        this.props.onChange(event, selectedIndexes, index);
+      }
+    };
+  }
+
+  updateSelectedIndexes(index, postStateChangeCallback) {
+    if (!this.state.selectedIndexes.includes(index)) {
+      this.setState({
+        selectedIndexes: [...this.state.selectedIndexes, index],
+      }, postStateChangeCallback);
+    } else {
+      const indexToSlice = this.state.selectedIndexes.indexOf(index);
+      this.setState({
+        selectedIndexes: [
+          ...this.state.selectedIndexes.slice(0, indexToSlice),
+          ...this.state.selectedIndexes.slice(indexToSlice + 1),
+        ],
+      }, postStateChangeCallback);
+    }
+  }
+
+  wrappedOnClickForRow(row, index) {
+    return (event) => {
+      event.preventDefault();
+      const handleOnChange = this.handleOnChange(event, index);
+      this.updateSelectedIndexes(index, handleOnChange);
+    };
+  }
+
+  wrappedOnKeyDownForRow(row, index) {
+    const initialOnKeyDown = row.props.onKeyDown;
+
+    return (event) => {
+      if (event.nativeEvent.keyCode === KEYCODES.ENTER || event.nativeEvent.keyCode === KEYCODES.SPACE) {
+        const handleOnChange = this.handleOnChange(event, index);
+        this.updateSelectedIndexes(index, handleOnChange);
+      }
+
+      if (initialOnKeyDown) {
+        initialOnKeyDown(event);
+      }
+    };
+  }
+
+  newPropsForRow(row, index, onClick, onKeyDown) {
+    const isSelected = this.state.selectedIndexes.indexOf(index) !== -1;
+    const newProps = {};
+
+    newProps.isSelected = isSelected;
+
+    // Set the default isSelectable attribute to true, unless the consumer specifies the row isSelectable as false.
+    newProps.isSelectable = true;
+    if (row.props.isSelectable === false) {
+      newProps.isSelectable = row.props.isSelectable;
+    }
+
+    // If selectable, add tabIndex on rows to navigate through keyboard tab key for selectable row and add
+    // onClick and onKeyDown functions.
+    if (newProps.isSelectable) {
+      newProps.tabIndex = '0';
+      newProps.onClick = onClick;
+      newProps.onKeyDown = onKeyDown;
+    }
+
+    return newProps;
+  }
+
+  clonedChildItems(rows) {
+    return React.Children.map(rows, (row, index) => {
+      if (row.type === TableRow) {
+        const wrappedOnClick = this.wrappedOnClickForRow(row, index);
+        const wrappedOnKeyDown = this.wrappedOnKeyDownForRow(row, index);
+        const newProps = this.newPropsForRow(row, index, wrappedOnClick, wrappedOnKeyDown);
+        return React.cloneElement(row, newProps);
+      }
+      return row;
+    });
+  }
+
+  render() {
+    const { children, onChange, ...customProps } = this.props;
+    const clonedChildItems = this.clonedChildItems(children);
+
+    return (
+      <TableRows {...customProps}>
+        {clonedChildItems}
+      </TableRows>
+    );
+  }
+}
+
+MultipleSelectableRows.propTypes = propTypes;
+MultipleSelectableRows.defaultProps = defaultProps;
+
+export default MultipleSelectableRows;

--- a/packages/terra-table/src/Table.jsx
+++ b/packages/terra-table/src/Table.jsx
@@ -8,6 +8,7 @@ import TableRows from './TableRows';
 import TableRow from './TableRow';
 import TableCell from './TableCell';
 import TableSingleSelectableRows from './SingleSelectableRows';
+import TableMultipleSelectableRows from './MultipleSelectableRows';
 import TableSubheader from './TableSubheader';
 import styles from './Table.scss';
 
@@ -60,6 +61,7 @@ Table.HeaderCell = TableHeaderCell;
 Table.Row = TableRow;
 Table.Cell = TableCell;
 Table.SingleSelectableRows = TableSingleSelectableRows;
+Table.MultipleSelectableRows = TableMultipleSelectableRows;
 Table.Subheader = TableSubheader;
 
 export default Table;

--- a/packages/terra-table/tests/jest/MultipleSelectableRows.test.jsx
+++ b/packages/terra-table/tests/jest/MultipleSelectableRows.test.jsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import Table from '../../src/Table';
+
+// Constants
+const cellData1 = <Table.Cell content="John Smith" key="NAME" />;
+const cellData2 = <Table.Cell content="123 Adams Drive" key="ADDRESS" />;
+const cellData3 = <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />;
+const rowData = [cellData1, cellData2, cellData3];
+const row1 = <Table.Row key="PERSON_0" className="PERSON_0">{rowData}</Table.Row>;
+const row2 = <Table.Row key="PERSON_1" className="PERSON_1">{rowData}</Table.Row>;
+const rows = [row1, row2];
+
+// Snapshot test
+it('should render MultipleSelectableRows tag', () => {
+  const defaultTableRows = <Table.MultipleSelectableRows>{rows}</Table.MultipleSelectableRows>;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+});
+
+it('should render MultipleSelectableRows with no rows', () => {
+  const defaultTableRows = <Table.MultipleSelectableRows />;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+});
+
+it('should render MultipleSelectableRows with one row', () => {
+  const defaultTableRows = <Table.MultipleSelectableRows>{[row1]}</Table.MultipleSelectableRows>;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+});
+
+it('should render MultipleSelectableRows one selectable row and one non-selectable row', () => {
+  const row3 = <Table.Row isSelectable={false} key="PERSON_1" >{rowData}</Table.Row>;
+  const defaultTableRows = <Table.MultipleSelectableRows>{[row1, row3]}</Table.MultipleSelectableRows>;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+});
+
+it('should not select row on click if row is not selectable', () => {
+  const row3 = <Table.Row key="PERSON_1" className="PERSON_1" isSelectable={false}>{rowData}</Table.Row>;
+  const defaultTableRows = <Table.MultipleSelectableRows>{[row1, row3]}</Table.MultipleSelectableRows>;
+  const tableRows = shallow(defaultTableRows);
+
+  tableRows.find('.PERSON_1').simulate('click', { preventDefault() {} });
+  expect(tableRows).toMatchSnapshot();
+});
+
+it('should select multiple rows', () => {
+  const defaultTableRows = shallow(<Table.MultipleSelectableRows>{rows}</Table.MultipleSelectableRows>);
+
+  defaultTableRows.find('.PERSON_0').simulate('click', { preventDefault() {} });
+  expect(defaultTableRows).toMatchSnapshot();
+
+  defaultTableRows.find('.PERSON_1').simulate('click', { preventDefault() {} });
+  expect(defaultTableRows).toMatchSnapshot();
+});
+
+it('should have one row preselected if it was declared as selectable and selected', () => {
+  const row3 = <Table.Row isSelectable isSelected key="PERSON_1">{rowData}</Table.Row>;
+  const defaultTableRows = <Table.MultipleSelectableRows>{[row1, row3]}</Table.MultipleSelectableRows>;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+});
+
+it('should have multiple rows that are not selected and can be clicked if isSelected and isSelectable are undefined', () => {
+  const row3 = <Table.Row className="PERSON_1" key="PERSON_1">{rowData}</Table.Row>;
+  const row4 = <Table.Row className="PERSON_2" key="PERSON_2">{rowData}</Table.Row>;
+  const defaultTableRows = <Table.MultipleSelectableRows>{[row3, row4]}</Table.MultipleSelectableRows>;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+
+  tableRows.find('.PERSON_1').simulate('click', { preventDefault() {} });
+  tableRows.find('.PERSON_2').simulate('click', { preventDefault() {} });
+  expect(tableRows).toMatchSnapshot();
+});
+
+it('should have multiple rows that are not selected and cannot be clicked if isSelectable is false and isSelected is undefined', () => {
+  const row3 = <Table.Row className="PERSON_1" key="PERSON_1" isSelectable={false}>{rowData}</Table.Row>;
+  const row4 = <Table.Row className="PERSON_2" key="PERSON_2" isSelectable={false}>{rowData}</Table.Row>;
+  const defaultTableRows = <Table.MultipleSelectableRows>{[row3, row4]}</Table.MultipleSelectableRows>;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+
+  tableRows.find('.PERSON_1').simulate('click', { preventDefault() {} });
+  tableRows.find('.PERSON_2').simulate('click', { preventDefault() {} });
+  expect(tableRows).toMatchSnapshot();
+});
+
+it('should have multiple rows that are not selected and can be clicked if isSelectable is true and isSelected is undefined', () => {
+  const row3 = <Table.Row className="PERSON_1" key="PERSON_1" isSelectable>{rowData}</Table.Row>;
+  const row4 = <Table.Row className="PERSON_2" key="PERSON_2" isSelectable>{rowData}</Table.Row>;
+  const defaultTableRows = <Table.MultipleSelectableRows>{[row3, row4]}</Table.MultipleSelectableRows>;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+
+  tableRows.find('.PERSON_1').simulate('click', { preventDefault() {} });
+  tableRows.find('.PERSON_2').simulate('click', { preventDefault() {} });
+  expect(tableRows).toMatchSnapshot();
+});
+
+it('should have multiple rows that are not selected and can be clicked if isSelectable is undefined and isSelected is false', () => {
+  const row3 = <Table.Row className="PERSON_1" key="PERSON_1" isSelected={false}>{rowData}</Table.Row>;
+  const row4 = <Table.Row className="PERSON_2" key="PERSON_2" isSelected={false}>{rowData}</Table.Row>;
+  const defaultTableRows = <Table.MultipleSelectableRows>{[row3, row4]}</Table.MultipleSelectableRows>;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+
+  tableRows.find('.PERSON_1').simulate('click', { preventDefault() {} });
+  tableRows.find('.PERSON_2').simulate('click', { preventDefault() {} });
+  expect(tableRows).toMatchSnapshot();
+});
+
+it('should have multiple rows that are selected and can be clicked if isSelectable is undefined and isSelected is true', () => {
+  const row3 = <Table.Row className="PERSON_1" key="PERSON_1" isSelected>{rowData}</Table.Row>;
+  const row4 = <Table.Row className="PERSON_2" key="PERSON_2" isSelected>{rowData}</Table.Row>;
+  const defaultTableRows = <Table.MultipleSelectableRows>{[row3, row4]}</Table.MultipleSelectableRows>;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+
+  tableRows.find('.PERSON_1').simulate('click', { preventDefault() {} });
+  tableRows.find('.PERSON_2').simulate('click', { preventDefault() {} });
+  expect(tableRows).toMatchSnapshot();
+});
+
+it('should have multiple rows that are not selected and can be clicked if isSelectable is true and isSelected is false', () => {
+  const row3 = <Table.Row className="PERSON_1" key="PERSON_1" isSelectable isSelected={false}>{rowData}</Table.Row>;
+  const row4 = <Table.Row className="PERSON_2" key="PERSON_2" isSelectable isSelected={false}>{rowData}</Table.Row>;
+  const defaultTableRows = <Table.MultipleSelectableRows>{[row3, row4]}</Table.MultipleSelectableRows>;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+
+  tableRows.find('.PERSON_1').simulate('click', { preventDefault() {} });
+  tableRows.find('.PERSON_2').simulate('click', { preventDefault() {} });
+  expect(tableRows).toMatchSnapshot();
+});
+
+it('should have multiple rows that are selected and cannot be clicked if isSelectable is false and isSelected is true', () => {
+  const row3 = <Table.Row className="PERSON_1" key="PERSON_1" isSelectable={false} isSelected>{rowData}</Table.Row>;
+  const row4 = <Table.Row className="PERSON_2" key="PERSON_2" isSelectable={false} isSelected>{rowData}</Table.Row>;
+  const defaultTableRows = <Table.MultipleSelectableRows>{[row3, row4]}</Table.MultipleSelectableRows>;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+
+  tableRows.find('.PERSON_1').simulate('click', { preventDefault() {} });
+  tableRows.find('.PERSON_2').simulate('click', { preventDefault() {} });
+  expect(tableRows).toMatchSnapshot();
+});
+
+it('should have multiple rows that are selected and can be clicked if isSelectable is true and isSelected is true', () => {
+  const row3 = <Table.Row className="PERSON_1" key="PERSON_1" isSelectable isSelected>{rowData}</Table.Row>;
+  const row4 = <Table.Row className="PERSON_2" key="PERSON_2" isSelectable isSelected>{rowData}</Table.Row>;
+  const defaultTableRows = <Table.MultipleSelectableRows>{[row3, row4]}</Table.MultipleSelectableRows>;
+  const tableRows = shallow(defaultTableRows);
+  expect(tableRows).toMatchSnapshot();
+
+  tableRows.find('.PERSON_1').simulate('click', { preventDefault() {} });
+  tableRows.find('.PERSON_2').simulate('click', { preventDefault() {} });
+  expect(tableRows).toMatchSnapshot();
+});

--- a/packages/terra-table/tests/jest/SingleSelectableRows.test.jsx
+++ b/packages/terra-table/tests/jest/SingleSelectableRows.test.jsx
@@ -42,7 +42,7 @@ it('should render SingleSelectableRows one selectable row and one non-selectable
   expect(tableRows).toMatchSnapshot();
 });
 
-it('should select an row', () => {
+it('should select a row', () => {
   const defaultTableRows = shallow(<Table.SingleSelectableRows>{rows}</Table.SingleSelectableRows>);
 
   defaultTableRows.find('.PERSON_0').simulate('click', { preventDefault() {} });

--- a/packages/terra-table/tests/jest/__snapshots__/MultipleSelectableRows.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/MultipleSelectableRows.test.jsx.snap
@@ -1,0 +1,714 @@
+exports[`test should have multiple rows that are not selected and can be clicked if isSelectable is true and isSelected is false 1`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are not selected and can be clicked if isSelectable is true and isSelected is false 2`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are not selected and can be clicked if isSelectable is true and isSelected is undefined 1`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are not selected and can be clicked if isSelectable is true and isSelected is undefined 2`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are not selected and can be clicked if isSelectable is undefined and isSelected is false 1`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are not selected and can be clicked if isSelectable is undefined and isSelected is false 2`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are not selected and can be clicked if isSelected and isSelectable are undefined 1`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are not selected and can be clicked if isSelected and isSelectable are undefined 2`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are not selected and cannot be clicked if isSelectable is false and isSelected is undefined 1`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={false}
+    isSelected={false}>
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={false}
+    isSelected={false}>
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are not selected and cannot be clicked if isSelectable is false and isSelected is undefined 2`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={false}
+    isSelected={false}>
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={false}
+    isSelected={false}>
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are selected and can be clicked if isSelectable is true and isSelected is true 1`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are selected and can be clicked if isSelectable is true and isSelected is true 2`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are selected and can be clicked if isSelectable is undefined and isSelected is true 1`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are selected and can be clicked if isSelectable is undefined and isSelected is true 2`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are selected and cannot be clicked if isSelectable is false and isSelected is true 1`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={false}
+    isSelected={true}>
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={false}
+    isSelected={true}>
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have multiple rows that are selected and cannot be clicked if isSelectable is false and isSelected is true 2`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={false}
+    isSelected={true}>
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_2"
+    isSelectable={false}
+    isSelected={true}>
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should have one row preselected if it was declared as selectable and selected 1`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_0"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should not select row on click if row is not selectable 1`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_0"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={false}
+    isSelected={false}>
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should render MultipleSelectableRows one selectable row and one non-selectable row 1`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_0"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    isSelectable={false}
+    isSelected={false}>
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should render MultipleSelectableRows tag 1`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_0"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should render MultipleSelectableRows with no rows 1`] = `<TableRows />`;
+
+exports[`test should render MultipleSelectableRows with one row 1`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_0"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should select multiple rows 1`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_0"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;
+
+exports[`test should select multiple rows 2`] = `
+<TableRows>
+  <TableRow
+    className="PERSON_0"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+  <TableRow
+    className="PERSON_1"
+    isSelectable={true}
+    isSelected={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0">
+    <TableCell
+      content="John Smith" />
+    <TableCell
+      content="123 Adams Drive" />
+    <TableCell
+      content="111-222-3333" />
+  </TableRow>
+</TableRows>
+`;

--- a/packages/terra-table/tests/jest/__snapshots__/SingleSelectableRows.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/SingleSelectableRows.test.jsx.snap
@@ -114,7 +114,7 @@ exports[`test should render SingleSelectableRows with one row 1`] = `
 </TableRows>
 `;
 
-exports[`test should select an row 1`] = `
+exports[`test should select a row 1`] = `
 <TableRows>
   <TableRow
     className="PERSON_0"
@@ -147,7 +147,7 @@ exports[`test should select an row 1`] = `
 </TableRows>
 `;
 
-exports[`test should select an row 2`] = `
+exports[`test should select a row 2`] = `
 <TableRows>
   <TableRow
     className="PERSON_0"

--- a/packages/terra-table/tests/nightwatch/TableTestRoutes.jsx
+++ b/packages/terra-table/tests/nightwatch/TableTestRoutes.jsx
@@ -16,6 +16,12 @@ import TableWithHighlightedRows from './components/TableWithHighlightedRows';
 import TableWithSortIndicator from './components/TableWithSortIndicator';
 import TableWithSubheaders from './components/TableWithSubheaders';
 import TableWithSelectableRowsAndSubheaders from './components/TableWithSelectableRowsAndSubheaders';
+import MultipleRowSelectableTableMultipleRows from './components/MultipleRowSelectableTableMultipleRows';
+import MultipleRowSelectableTableSingleRow from './components/MultipleRowSelectableTableSingleRow';
+import MultipleRowSelectableTableNoRows from './components/MultipleRowSelectableTableNoRows';
+import MultipleRowSelectableTableOnChange from './components/MultipleRowSelectableTableOnChange';
+import MultipleRowSelectableTableSubheaders from './components/MultipleRowSelectableTableSubheaders';
+import MultipleRowSelectableTablePreselectedRow from './components/MultipleRowSelectableTablePreselectedRow';
 
 const routes = (
   <div>
@@ -33,6 +39,12 @@ const routes = (
     <Route path="/tests/table-tests/table-sort-indicator" component={TableWithSortIndicator} />
     <Route path="/tests/table-tests/table-subheaders" component={TableWithSubheaders} />
     <Route path="/tests/table-tests/table-selectable-subheaders" component={TableWithSelectableRowsAndSubheaders} />
+    <Route path="/tests/table-tests/multiple-selectable-table-single-row" component={MultipleRowSelectableTableSingleRow} />
+    <Route path="/tests/table-tests/multiple-selectable-table-no-rows" component={MultipleRowSelectableTableNoRows} />
+    <Route path="/tests/table-tests/multiple-selectable-table-multiple-rows" component={MultipleRowSelectableTableMultipleRows} />
+    <Route path="/tests/table-tests/multiple-selectable-table-onchange" component={MultipleRowSelectableTableOnChange} />
+    <Route path="/tests/table-tests/multiple-selectable-table-subheaders" component={MultipleRowSelectableTableSubheaders} />
+    <Route path="/tests/table-tests/multiple-selectable-table-preselected-row" component={MultipleRowSelectableTablePreselectedRow} />
   </div>
 );
 

--- a/packages/terra-table/tests/nightwatch/TableTests.jsx
+++ b/packages/terra-table/tests/nightwatch/TableTests.jsx
@@ -19,6 +19,12 @@ const TableTests = () => (
       <li><Link to="/tests/table-tests/selectable-table-onchange">Selectable Table - OnChange</Link></li>
       <li><Link to="/tests/table-tests/table-subheaders">Table - Subheaders</Link></li>
       <li><Link to="/tests/table-tests/table-selectable-subheaders">Selectable Table - Subheaders</Link></li>
+      <li><Link to="/tests/table-tests/multiple-selectable-table-single-row">Multiple Selectable Table - Single Row</Link></li>
+      <li><Link to="/tests/table-tests/multiple-selectable-table-no-rows">Multiple Selectable Table - No Rows</Link></li>
+      <li><Link to="/tests/table-tests/multiple-selectable-table-multiple-rows">Multiple Selectable Table - Multiple Rows</Link></li>
+      <li><Link to="/tests/table-tests/multiple-selectable-table-onchange">Multiple Selectable Table - On Change</Link></li>
+      <li><Link to="/tests/table-tests/multiple-selectable-table-subheaders">Multiple Selectable Table - Subheaders</Link></li>
+      <li><Link to="/tests/table-tests/multiple-selectable-table-preselected-row">Multiple Selectable Table - Preselected Row</Link></li>
     </ul>
   </div>
 );

--- a/packages/terra-table/tests/nightwatch/components/MultipleRowSelectableTableMultipleRows.jsx
+++ b/packages/terra-table/tests/nightwatch/components/MultipleRowSelectableTableMultipleRows.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Table from '../../../lib/Table';
+
+const MultipleRowSelectableTableMultipleRows = () => (
+  <Table isStriped={false}>
+    <Table.Header>
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+    </Table.Header>
+    <Table.MultipleSelectableRows>
+      <Table.Row key={'PERSON_0'}>
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Row key={'PERSON_1'}>
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Row key={'PERSON_2'}>
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+    </Table.MultipleSelectableRows>
+  </Table>
+);
+
+export default MultipleRowSelectableTableMultipleRows;

--- a/packages/terra-table/tests/nightwatch/components/MultipleRowSelectableTableNoRows.jsx
+++ b/packages/terra-table/tests/nightwatch/components/MultipleRowSelectableTableNoRows.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Table from '../../../lib/Table';
+
+const MultipleRowSelectableTableNoRows = () => (
+  <Table isStriped={false}>
+    <Table.Header>
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+    </Table.Header>
+    <Table.MultipleSelectableRows />
+  </Table>
+);
+
+export default MultipleRowSelectableTableNoRows;

--- a/packages/terra-table/tests/nightwatch/components/MultipleRowSelectableTableOnChange.jsx
+++ b/packages/terra-table/tests/nightwatch/components/MultipleRowSelectableTableOnChange.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import Table from '../../../lib/Table';
+
+class MultipleRowsSelectableTable extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { selectedIndexes: [] };
+    this.handleSelection = this.handleSelection.bind(this);
+  }
+
+  handleSelection(event, selectedIndexes) {
+    this.setState({ selectedIndexes });
+  }
+
+  render() {
+    return (
+      <div>
+        <div id="selected-index">
+          <h3>Selected Item: {JSON.stringify(this.state.selectedIndexes)}</h3>
+        </div>
+        <Table isStriped={false}>
+          <Table.Header>
+            <Table.HeaderCell content="Name" key="NAME" minWidth="small" />
+            <Table.HeaderCell content="Address" key="ADDRESS" minWidth="medium" />
+            <Table.HeaderCell content="Phone Number" key="PHONE_NUMBER" minWidth="large" />
+          </Table.Header>
+          <Table.MultipleSelectableRows onChange={this.handleSelection}>
+            <Table.Row key="PERSON_0">
+              <Table.Cell content="John Smith" key="NAME" />
+              <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+              <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+            </Table.Row>
+            <Table.Row key="PERSON_1">
+              <Table.Cell content="Jane Smith" key="NAME" />
+              <Table.Cell content="321 Drive Street" key="ADDRESS" />
+              <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+            </Table.Row>
+            <Table.Row key="PERSON_2">
+              <Table.Cell content="Dave Smith" key="NAME" />
+              <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+              <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+            </Table.Row>
+          </Table.MultipleSelectableRows>
+        </Table>
+      </div>
+    );
+  }
+}
+
+export default MultipleRowsSelectableTable;

--- a/packages/terra-table/tests/nightwatch/components/MultipleRowSelectableTablePreselectedRow.jsx
+++ b/packages/terra-table/tests/nightwatch/components/MultipleRowSelectableTablePreselectedRow.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import Table from '../../../lib/Table';
+
+const MultipleRowSelectableTableMultipleRows = () => (
+  <Table isStriped={false}>
+    <Table.Header>
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Preselected?'} key={'PRESELECTED'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Is Selection Changeable'} key={'IS_SELECTABLE'} minWidth={'large'} />
+    </Table.Header>
+    <Table.MultipleSelectableRows>
+      <Table.Row key={'PERSON_0'}>
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="undefined" key="PRESELECTED" />
+        <Table.Cell content="undefined" key="IS_SELECTABLE" />
+      </Table.Row>
+      <Table.Row key={'PERSON_1'} isSelectable={false}>
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="undefined" key="PRESELECTED" />
+        <Table.Cell content="false" key="IS_SELECTABLE" />
+      </Table.Row>
+      <Table.Row key={'PERSON_2'} isSelectable>
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="undefined" key="PRESELECTED" />
+        <Table.Cell content="true" key="IS_SELECTABLE" />
+      </Table.Row>
+      <Table.Row key={'PERSON_3'} isSelected={false}>
+        <Table.Cell content="Jim Smith" key="NAME" />
+        <Table.Cell content="false" key="PRESELECTED" />
+        <Table.Cell content="undefined" key="IS_SELECTABLE" />
+      </Table.Row>
+      <Table.Row key={'PERSON_4'} isSelected>
+        <Table.Cell content="Ann Smith" key="NAME" />
+        <Table.Cell content="true" key="PRESELECTED" />
+        <Table.Cell content="undefined" key="IS_SELECTABLE" />
+      </Table.Row>
+      <Table.Row key={'PERSON_5'} isSelected={false} isSelectable={false}>
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="false" key="PRESELECTED" />
+        <Table.Cell content="false" key="IS_SELECTABLE" />
+      </Table.Row>
+      <Table.Row key={'PERSON_6'} isSelected={false} isSelectable>
+        <Table.Cell content="Jack Smith" key="NAME" />
+        <Table.Cell content="false" key="PRESELECTED" />
+        <Table.Cell content="true" key="IS_SELECTABLE" />
+      </Table.Row>
+      <Table.Row key={'PERSON_7'} isSelected isSelectable={false}>
+        <Table.Cell content="Joe Smith" key="NAME" />
+        <Table.Cell content="true" key="PRESELECTED" />
+        <Table.Cell content="false" key="IS_SELECTABLE" />
+      </Table.Row>
+      <Table.Row key={'PERSON_8'} isSelected isSelectable>
+        <Table.Cell content="Jill Smith" key="NAME" />
+        <Table.Cell content="true" key="PRESELECTED" />
+        <Table.Cell content="true" key="IS_SELECTABLE" />
+      </Table.Row>
+    </Table.MultipleSelectableRows>
+  </Table>
+);
+
+export default MultipleRowSelectableTableMultipleRows;

--- a/packages/terra-table/tests/nightwatch/components/MultipleRowSelectableTableSingleRow.jsx
+++ b/packages/terra-table/tests/nightwatch/components/MultipleRowSelectableTableSingleRow.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Table from '../../../lib/Table';
+
+const MultipleRowSelectableTableSingleRow = () => (
+  <Table isStriped={false}>
+    <Table.Header>
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+    </Table.Header>
+    <Table.MultipleSelectableRows>
+      <Table.Row key={'PERSON_0'}>
+        <Table.Cell content="John Smith" key="NAME" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+    </Table.MultipleSelectableRows>
+  </Table>
+);
+
+export default MultipleRowSelectableTableSingleRow;

--- a/packages/terra-table/tests/nightwatch/components/MultipleRowSelectableTableSubheaders.jsx
+++ b/packages/terra-table/tests/nightwatch/components/MultipleRowSelectableTableSubheaders.jsx
@@ -1,0 +1,39 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import Table from '../../../lib/Table';
+
+const TableWithMultipleSelectableRowsAndSubheaders = () => (
+  <Table isStriped className="Table-Custom">
+    <Table.Header className="Header-Custom">
+      <Table.HeaderCell content={'Name'} key={'NAME'} minWidth={'small'} className="HeaderCell-Custom" />
+      <Table.HeaderCell content={'Address'} key={'ADDRESS'} minWidth={'medium'} sort={'asc'} />
+      <Table.HeaderCell content={'Phone Number'} key={'PHONE_NUMBER'} minWidth={'large'} />
+    </Table.Header>
+    <Table.MultipleSelectableRows className="SingleSelectableRows-Custom">
+      <Table.Subheader key="SUBHEADER_0" content={'Single'} />
+      <Table.Row key={'PERSON_0'}>
+        <Table.Cell content="John Smith" key="NAME" className="Cell-Custom" />
+        <Table.Cell content="123 Adams Drive" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Row key={'PERSON_1'}>
+        <Table.Cell content="Jane Smith" key="NAME" />
+        <Table.Cell content="321 Drive Street" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Subheader key="SUBHEADER_1" content={'Married'} className="Subheader-Custom" />
+      <Table.Row key={'PERSON_2'}>
+        <Table.Cell content="Dave Smith" key="NAME" />
+        <Table.Cell content="213 Raymond Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+      <Table.Row key={'PERSON_3'}>
+        <Table.Cell content="Mike Smith" key="NAME" />
+        <Table.Cell content="132 Rock Road" key="ADDRESS" />
+        <Table.Cell content="111-222-3333" key="PHONE_NUMBER" />
+      </Table.Row>
+    </Table.MultipleSelectableRows>
+  </Table>
+);
+
+export default TableWithMultipleSelectableRowsAndSubheaders;

--- a/packages/terra-table/tests/nightwatch/table-spec.js
+++ b/packages/terra-table/tests/nightwatch/table-spec.js
@@ -65,7 +65,7 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
       .assert.elementPresent('tr[class*="is-selectable"]');
   },
 
-  'Display a selectable table and highlights the selected row upon clicking': (browser) => {
+  'Display a single selectable table and highlights the selected row upon clicking': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/table-tests/selectable-table`);
     browser.click('[class*="row"]:nth-child(1)');
     browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.contains('is-selected');
@@ -83,7 +83,7 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
     browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.contains('is-selected');
   },
 
-  'Toggle aria-selected on seletable rows': (browser) => {
+  'Toggle aria-selected on single selectable rows': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/table-tests/selectable-table`);
     browser.click('[class*="row"]:nth-child(1)');
     browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('aria-selected').which.contains('true');
@@ -101,7 +101,7 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
     browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('aria-selected').which.contains('true');
   },
 
-  'Display a selectable table and highlights the selected row upon enter': (browser) => {
+  'Display a single selectable table and highlights the selected row upon enter': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/table-tests/selectable-table`);
 
     browser.sendKeys('[class*="row"]:nth-child(1)', browser.Keys.ENTER);
@@ -120,7 +120,7 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
     browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.contains('is-selected');
   },
 
-  'Display a selectable table and highlights the selected row upon space keydown': (browser) => {
+  'Display a single selectable table and highlights the selected row upon space keydown': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/table-tests/selectable-table`);
 
     browser.sendKeys('[class*="row"]:nth-child(1)', browser.Keys.SPACE);
@@ -139,7 +139,7 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
     browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.contains('is-selected');
   },
 
-  'Display a selectable table with a subheader': (browser) => {
+  'Display a single selectable table with a subheader': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/table-tests/table-selectable-subheaders`);
     browser.expect.element('tbody tr:nth-child(1)').to.have.attribute('data-terra-table-subheader-row');
     browser.assert.containsText('tbody tr:nth-child(1) td:nth-child(1)', 'Single');
@@ -155,7 +155,7 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
     browser.assert.containsText('tbody tr:nth-child(4) td:nth-child(1)', 'Married');
   },
 
-  'Triggers onChange for selectable table upon clicking a row': (browser) => {
+  'Triggers onChange for a single selectable table upon clicking a row': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/table-tests/selectable-table-onchange`);
 
     browser.click('[class*="row"]:nth-child(1)');
@@ -194,7 +194,7 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
     browser.assert.elementNotPresent('[class*="row"]:nth-child(2)');
   },
 
-  'Displays a selectable table with no rows': (browser) => {
+  'Displays a single selectable table with no rows': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/table-tests/selectable-table-no-rows`);
     browser.assert.elementNotPresent('[class*="row"]:nth-child(1)');
   },
@@ -207,5 +207,166 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
     browser.assert.elementPresent('.Cell-Custom');
     browser.assert.elementPresent('.SingleSelectableRows-Custom');
     browser.assert.elementPresent('.Subheader-Custom');
+  },
+
+  'Display a multiple selectable table with a subheader': (browser) => {
+    browser.url(`${browser.launchUrl}}/#/tests/table-tests/multiple-selectable-table-subheaders`);
+    browser.expect.element('tbody tr:nth-child(1)').to.have.attribute('data-terra-table-subheader-row');
+    browser.assert.containsText('tbody tr:nth-child(1) td:nth-child(1)', 'Single');
+    browser.expect.element('tbody tr:nth-child(4)').to.have.attribute('data-terra-table-subheader-row');
+    browser.assert.containsText('tbody tr:nth-child(4) td:nth-child(1)', 'Married');
+  },
+
+  'Displays a multiple selectable table with only one row': (browser) => {
+    browser.url(`${browser.launchUrl}/#/tests/table-tests/multiple-selectable-table-single-row`);
+    browser.assert.elementPresent('[class*="row"]:nth-child(1)');
+    browser.assert.elementNotPresent('[class*="row"]:nth-child(2)');
+  },
+
+  'Displays a multiple selectable table with no rows': (browser) => {
+    browser.url(`${browser.launchUrl}/#/tests/table-tests/multiple-selectable-table-no-rows`);
+    browser.assert.elementNotPresent('[class*="row"]:nth-child(1)');
+  },
+
+  'Triggers onChange for multiple selectable table upon clicking a row': (browser) => {
+    browser.url(`${browser.launchUrl}/#/tests/table-tests/multiple-selectable-table-onchange`);
+
+    browser.click('[class*="row"]:nth-child(1)');
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.assert.containsText('#selected-index', '[0]');
+
+    browser.sendKeys('[class*="row"]:nth-child(2)', browser.Keys.ENTER);
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.assert.containsText('#selected-index', '[0,1]');
+
+    browser.sendKeys('[class*="row"]:nth-child(3)', browser.Keys.SPACE);
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.contains('is-selected');
+    browser.assert.containsText('#selected-index', '[0,1,2]');
+  },
+
+  'Display a multiple selectable table and highlights the selected row upon enter': (browser) => {
+    browser.url(`${browser.launchUrl}/#/tests/table-tests/multiple-selectable-table-multiple-rows`);
+
+    browser.sendKeys('[class*="row"]:nth-child(1)', browser.Keys.ENTER);
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.not.contains('is-selected');
+
+    browser.sendKeys('[class*="row"]:nth-child(2)', browser.Keys.ENTER);
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.not.contains('is-selected');
+
+    browser.sendKeys('[class*="row"]:nth-child(3)', browser.Keys.ENTER);
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.contains('is-selected');
+  },
+
+  'Display a multiple selectable table and highlights the selected row upon space keydown': (browser) => {
+    browser.url(`${browser.launchUrl}/#/tests/table-tests/multiple-selectable-table-multiple-rows`);
+
+    browser.sendKeys('[class*="row"]:nth-child(1)', browser.Keys.SPACE);
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.not.contains('is-selected');
+
+    browser.sendKeys('[class*="row"]:nth-child(2)', browser.Keys.SPACE);
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.not.contains('is-selected');
+
+    browser.sendKeys('[class*="row"]:nth-child(3)', browser.Keys.SPACE);
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.contains('is-selected');
+  },
+
+  'Display a multiple selectable table and removes highlight from already selected row upon click': (browser) => {
+    browser.url(`${browser.launchUrl}/#/tests/table-tests/multiple-selectable-table-multiple-rows`);
+
+    browser.click('[class*="row"]:nth-child(1)');
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.not.contains('is-selected');
+
+    browser.click('[class*="row"]:nth-child(1)');
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.not.contains('is-selected');
+  },
+
+  'Display a multiple selectable table and removes highlight from already selected row upon enter': (browser) => {
+    browser.url(`${browser.launchUrl}/#/tests/table-tests/multiple-selectable-table-multiple-rows`);
+
+    browser.sendKeys('[class*="row"]:nth-child(1)', browser.Keys.ENTER);
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.not.contains('is-selected');
+
+    browser.sendKeys('[class*="row"]:nth-child(1)', browser.Keys.ENTER);
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.not.contains('is-selected');
+  },
+
+  'Display a multiple selectable table and removes highlight from already selected row upon space keydown': (browser) => {
+    browser.url(`${browser.launchUrl}/#/tests/table-tests/multiple-selectable-table-multiple-rows`);
+
+    browser.sendKeys('[class*="row"]:nth-child(1)', browser.Keys.SPACE);
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.not.contains('is-selected');
+
+    browser.sendKeys('[class*="row"]:nth-child(1)', browser.Keys.SPACE);
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.not.contains('is-selected');
+  },
+
+  'Displays a multiple selectable table with a preselected row': (browser) => {
+    browser.url(`${browser.launchUrl}/#/tests/table-tests/multiple-selectable-table-preselected-row`);
+
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.click('[class*="row"]:nth-child(1)');
+    browser.expect.element('[class*="row"]:nth-child(1)').to.have.attribute('class').which.contains('is-selected');
+
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.click('[class*="row"]:nth-child(2)');
+    browser.expect.element('[class*="row"]:nth-child(2)').to.have.attribute('class').which.not.contains('is-selected');
+
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.click('[class*="row"]:nth-child(3)');
+    browser.expect.element('[class*="row"]:nth-child(3)').to.have.attribute('class').which.contains('is-selected');
+
+    browser.expect.element('[class*="row"]:nth-child(4)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.click('[class*="row"]:nth-child(4)');
+    browser.expect.element('[class*="row"]:nth-child(4)').to.have.attribute('class').which.contains('is-selected');
+
+    browser.expect.element('[class*="row"]:nth-child(5)').to.have.attribute('class').which.contains('is-selected');
+    browser.click('[class*="row"]:nth-child(5)');
+    browser.expect.element('[class*="row"]:nth-child(5)').to.have.attribute('class').which.not.contains('is-selected');
+
+    browser.expect.element('[class*="row"]:nth-child(6)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.click('[class*="row"]:nth-child(6)');
+    browser.expect.element('[class*="row"]:nth-child(6)').to.have.attribute('class').which.not.contains('is-selected');
+
+    browser.expect.element('[class*="row"]:nth-child(7)').to.have.attribute('class').which.not.contains('is-selected');
+    browser.click('[class*="row"]:nth-child(7)');
+    browser.expect.element('[class*="row"]:nth-child(7)').to.have.attribute('class').which.contains('is-selected');
+
+    browser.expect.element('[class*="row"]:nth-child(8)').to.have.attribute('class').which.contains('is-selected');
+    browser.click('[class*="row"]:nth-child(8)');
+    browser.expect.element('[class*="row"]:nth-child(8)').to.have.attribute('class').which.contains('is-selected');
+
+    browser.expect.element('[class*="row"]:nth-child(9)').to.have.attribute('class').which.contains('is-selected');
+    browser.click('[class*="row"]:nth-child(9)');
+    browser.expect.element('[class*="row"]:nth-child(9)').to.have.attribute('class').which.not.contains('is-selected');
   },
 });


### PR DESCRIPTION
### Summary
This pull request adds a new component called `MultipleSelectableRows` to terra-table. This allows the user to select multiple rows from a table.

### Additional Details
I logged issue #794 , where the `isSelected` prop is not honored without the `isSelectable` prop set as true in `SingleSelectableRows`. I changed the behavior of this in the `MultipleSelectableRows` component so that if you defined `isSelected`, it would be selected, regardless if you defined `isSelectable`. As mentioned in the issue, `isSelectable` is kind of a confusing name at this point, as `isSelected` could be `true` while `isSelectable` is false (in cases where you would want the row to be permanently hard-coded as selected). The desired behavior and interactions of these two props should probably be discussed.

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
