### PR TITLE
Update to jest v21

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "express": "^4.15.2",
     "glob": "^7.1.1",
     "identity-obj-proxy": "^3.0.0",
-    "jest": "^18.0.0",
+    "jest": "^21.0.2",
     "lerna": "2.0.0-rc.4",
     "load-json-file": "^2.0.0",
     "react": "^15.5.4",

--- a/packages/terra-alert/tests/jest/__snapshots__/Alert.test.jsx.snap
+++ b/packages/terra-alert/tests/jest/__snapshots__/Alert.test.jsx.snap
@@ -1,3 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`Alert of type advisory with text content should render an Alert component of type advisory 1`] = `
 <IntlProvider
   locale="en-US"
@@ -11,27 +13,34 @@ exports[`Alert of type advisory with text content should render an Alert compone
       "Terra.alert.success": "Success.",
       "Terra.alert.warning": "Warning.",
     }
-  }>
+  }
+>
   <Alert
     action={null}
     customIcon={null}
     customStatusColor=""
     onDismiss={null}
     title=""
-    type="advisory">
+    type="advisory"
+  >
     <ResponsiveElement
       defaultElement={
         <div
           className="advisory narrow"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon" />
+              className="icon"
+            />
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Advisory.
               </strong>
               <div>
@@ -46,15 +55,20 @@ exports[`Alert of type advisory with text content should render an Alert compone
       tiny={
         <div
           className="advisory wide"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon" />
+              className="icon"
+            />
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Advisory.
               </strong>
               <div>
@@ -64,7 +78,8 @@ exports[`Alert of type advisory with text content should render an Alert compone
           </div>
           
         </div>
-      }>
+      }
+    >
       <div />
     </ResponsiveElement>
   </Alert>
@@ -84,31 +99,39 @@ exports[`Alert of type alert with text content should render an Alert component 
       "Terra.alert.success": "Success.",
       "Terra.alert.warning": "Warning.",
     }
-  }>
+  }
+>
   <Alert
     action={null}
     customIcon={null}
     customStatusColor=""
     onDismiss={null}
     title=""
-    type="alert">
+    type="alert"
+  >
     <ResponsiveElement
       defaultElement={
         <div
           className="alert narrow"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconAlert
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Alert.
               </strong>
               <div>
@@ -123,19 +146,25 @@ exports[`Alert of type alert with text content should render an Alert component 
       tiny={
         <div
           className="alert wide"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconAlert
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Alert.
               </strong>
               <div>
@@ -145,7 +174,8 @@ exports[`Alert of type alert with text content should render an Alert component 
           </div>
           
         </div>
-      }>
+      }
+    >
       <div />
     </ResponsiveElement>
   </Alert>
@@ -165,18 +195,21 @@ exports[`Alert of type custom with custom title and text content should render a
       "Terra.alert.success": "Success.",
       "Terra.alert.warning": "Warning.",
     }
-  }>
+  }
+>
   <Alert
     action={null}
     customIcon={
       <IconHelp
         viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg" />
+        xmlns="http://www.w3.org/2000/svg"
+      />
     }
     customStatusColor="orange"
     onDismiss={null}
     title="Help!"
-    type="custom">
+    type="custom"
+  >
     <ResponsiveElement
       defaultElement={
         <div
@@ -185,19 +218,25 @@ exports[`Alert of type custom with custom title and text content should render a
             Object {
               "color": "orange",
             }
-          }>
+          }
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconHelp
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section-custom">
+              className="section-custom"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Help!
               </strong>
               <div>
@@ -216,19 +255,25 @@ exports[`Alert of type custom with custom title and text content should render a
             Object {
               "color": "orange",
             }
-          }>
+          }
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconHelp
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section-custom">
+              className="section-custom"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Help!
               </strong>
               <div>
@@ -238,7 +283,8 @@ exports[`Alert of type custom with custom title and text content should render a
           </div>
           
         </div>
-      }>
+      }
+    >
       <div />
     </ResponsiveElement>
   </Alert>
@@ -258,31 +304,39 @@ exports[`Alert of type error with text content should render an Alert component 
       "Terra.alert.success": "Success.",
       "Terra.alert.warning": "Warning.",
     }
-  }>
+  }
+>
   <Alert
     action={null}
     customIcon={null}
     customStatusColor=""
     onDismiss={null}
     title=""
-    type="error">
+    type="error"
+  >
     <ResponsiveElement
       defaultElement={
         <div
           className="error narrow"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconError
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Error.
               </strong>
               <div>
@@ -297,19 +351,25 @@ exports[`Alert of type error with text content should render an Alert component 
       tiny={
         <div
           className="error wide"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconError
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Error.
               </strong>
               <div>
@@ -319,7 +379,8 @@ exports[`Alert of type error with text content should render an Alert component 
           </div>
           
         </div>
-      }>
+      }
+    >
       <div />
     </ResponsiveElement>
   </Alert>
@@ -339,31 +400,39 @@ exports[`Alert of type info with custom title and HTML content should render an 
       "Terra.alert.success": "Success.",
       "Terra.alert.warning": "Warning.",
     }
-  }>
+  }
+>
   <Alert
     action={null}
     customIcon={null}
     customStatusColor=""
     onDismiss={null}
     title="Gettysburg Address"
-    type="info">
+    type="info"
+  >
     <ResponsiveElement
       defaultElement={
         <div
           className="info narrow"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconInformation
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Gettysburg Address
               </strong>
               <div>
@@ -380,19 +449,25 @@ exports[`Alert of type info with custom title and HTML content should render an 
       tiny={
         <div
           className="info wide"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconInformation
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Gettysburg Address
               </strong>
               <div>
@@ -404,7 +479,8 @@ exports[`Alert of type info with custom title and HTML content should render an 
           </div>
           
         </div>
-      }>
+      }
+    >
       <div />
     </ResponsiveElement>
   </Alert>
@@ -424,31 +500,39 @@ exports[`Alert of type info with text content should render an Alert component o
       "Terra.alert.success": "Success.",
       "Terra.alert.warning": "Warning.",
     }
-  }>
+  }
+>
   <Alert
     action={null}
     customIcon={null}
     customStatusColor=""
     onDismiss={null}
     title=""
-    type="info">
+    type="info"
+  >
     <ResponsiveElement
       defaultElement={
         <div
           className="info narrow"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconInformation
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Information.
               </strong>
               <div>
@@ -463,19 +547,25 @@ exports[`Alert of type info with text content should render an Alert component o
       tiny={
         <div
           className="info wide"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconInformation
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Information.
               </strong>
               <div>
@@ -485,7 +575,8 @@ exports[`Alert of type info with text content should render an Alert component o
           </div>
           
         </div>
-      }>
+      }
+    >
       <div />
     </ResponsiveElement>
   </Alert>
@@ -505,7 +596,8 @@ exports[`Alert of type success with an action button text content should render 
       "Terra.alert.success": "Success.",
       "Terra.alert.warning": "Warning.",
     }
-  }>
+  }
+>
   <Alert
     action={
       <Button
@@ -517,30 +609,38 @@ exports[`Alert of type success with an action button text content should render 
         size="medium"
         text="Action"
         type="button"
-        variant="primary" />
+        variant="primary"
+      />
     }
     customIcon={null}
     customStatusColor=""
     onDismiss={null}
     title=""
-    type="success">
+    type="success"
+  >
     <ResponsiveElement
       defaultElement={
         <div
           className="success narrow"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-narrow">
+            className="body-narrow"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconSuccess
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Success.
               </strong>
               <div>
@@ -549,7 +649,8 @@ exports[`Alert of type success with an action button text content should render 
             </div>
           </div>
           <div
-            className="actions">
+            className="actions"
+          >
             <Button
               isBlock={false}
               isCompact={false}
@@ -559,7 +660,8 @@ exports[`Alert of type success with an action button text content should render 
               size="medium"
               text="Action"
               type="button"
-              variant="primary" />
+              variant="primary"
+            />
             
           </div>
         </div>
@@ -568,19 +670,25 @@ exports[`Alert of type success with an action button text content should render 
       tiny={
         <div
           className="success wide"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconSuccess
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Success.
               </strong>
               <div>
@@ -589,7 +697,8 @@ exports[`Alert of type success with an action button text content should render 
             </div>
           </div>
           <div
-            className="actions">
+            className="actions"
+          >
             <Button
               isBlock={false}
               isCompact={false}
@@ -599,11 +708,13 @@ exports[`Alert of type success with an action button text content should render 
               size="medium"
               text="Action"
               type="button"
-              variant="primary" />
+              variant="primary"
+            />
             
           </div>
         </div>
-      }>
+      }
+    >
       <div />
     </ResponsiveElement>
   </Alert>
@@ -623,31 +734,39 @@ exports[`Alert of type success with text content should render an Alert componen
       "Terra.alert.success": "Success.",
       "Terra.alert.warning": "Warning.",
     }
-  }>
+  }
+>
   <Alert
     action={null}
     customIcon={null}
     customStatusColor=""
     onDismiss={null}
     title=""
-    type="success">
+    type="success"
+  >
     <ResponsiveElement
       defaultElement={
         <div
           className="success narrow"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconSuccess
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Success.
               </strong>
               <div>
@@ -662,19 +781,25 @@ exports[`Alert of type success with text content should render an Alert componen
       tiny={
         <div
           className="success wide"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconSuccess
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Success.
               </strong>
               <div>
@@ -684,7 +809,8 @@ exports[`Alert of type success with text content should render an Alert componen
           </div>
           
         </div>
-      }>
+      }
+    >
       <div />
     </ResponsiveElement>
   </Alert>
@@ -704,31 +830,39 @@ exports[`Alert of type warning with text content should render an Alert componen
       "Terra.alert.success": "Success.",
       "Terra.alert.warning": "Warning.",
     }
-  }>
+  }
+>
   <Alert
     action={null}
     customIcon={null}
     customStatusColor=""
     onDismiss={null}
     title=""
-    type="warning">
+    type="warning"
+  >
     <ResponsiveElement
       defaultElement={
         <div
           className="warning narrow"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconWarning
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Warning.
               </strong>
               <div>
@@ -743,19 +877,25 @@ exports[`Alert of type warning with text content should render an Alert componen
       tiny={
         <div
           className="warning wide"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconWarning
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Warning.
               </strong>
               <div>
@@ -765,7 +905,8 @@ exports[`Alert of type warning with text content should render an Alert componen
           </div>
           
         </div>
-      }>
+      }
+    >
       <div />
     </ResponsiveElement>
   </Alert>
@@ -785,34 +926,44 @@ exports[`Alert with no props should render a default component 1`] = `
       "Terra.alert.success": "Success.",
       "Terra.alert.warning": "Warning.",
     }
-  }>
+  }
+>
   <Alert
     action={null}
     customIcon={null}
     customStatusColor=""
     onDismiss={null}
     title=""
-    type="alert">
+    type="alert"
+  >
     <ResponsiveElement
       defaultElement={
         <div
           className="alert narrow"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconAlert
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Alert.
               </strong>
-              <div />
+              <div>
+                
+              </div>
             </div>
           </div>
           
@@ -822,27 +973,36 @@ exports[`Alert with no props should render a default component 1`] = `
       tiny={
         <div
           className="alert wide"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconAlert
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Alert.
               </strong>
-              <div />
+              <div>
+                
+              </div>
             </div>
           </div>
           
         </div>
-      }>
+      }
+    >
       <div />
     </ResponsiveElement>
   </Alert>
@@ -862,7 +1022,8 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
       "Terra.alert.success": "Success.",
       "Terra.alert.warning": "Warning.",
     }
-  }>
+  }
+>
   <Alert
     action={
       <Button
@@ -874,17 +1035,20 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
         size="medium"
         text="Action"
         type="button"
-        variant="primary" />
+        variant="primary"
+      />
     }
     customIcon={
       <IconHelp
         viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg" />
+        xmlns="http://www.w3.org/2000/svg"
+      />
     }
     customStatusColor="orange"
     onDismiss={[Function]}
     title="Help!"
-    type="custom">
+    type="custom"
+  >
     <ResponsiveElement
       defaultElement={
         <div
@@ -893,19 +1057,25 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
             Object {
               "color": "orange",
             }
-          }>
+          }
+        >
           <div
-            className="body-narrow">
+            className="body-narrow"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconHelp
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section-custom">
+              className="section-custom"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Help!
               </strong>
               <div>
@@ -914,7 +1084,8 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
             </div>
           </div>
           <div
-            className="actions-custom">
+            className="actions-custom"
+          >
             <Button
               isBlock={false}
               isCompact={false}
@@ -924,7 +1095,8 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
               size="medium"
               text="Action"
               type="button"
-              variant="primary" />
+              variant="primary"
+            />
             <Button
               isBlock={false}
               isCompact={false}
@@ -934,7 +1106,8 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
               size="medium"
               text="Dismiss"
               type="button"
-              variant="secondary" />
+              variant="secondary"
+            />
           </div>
         </div>
       }
@@ -946,19 +1119,25 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
             Object {
               "color": "orange",
             }
-          }>
+          }
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconHelp
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section-custom">
+              className="section-custom"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Help!
               </strong>
               <div>
@@ -967,7 +1146,8 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
             </div>
           </div>
           <div
-            className="actions-custom">
+            className="actions-custom"
+          >
             <Button
               isBlock={false}
               isCompact={false}
@@ -977,7 +1157,8 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
               size="medium"
               text="Action"
               type="button"
-              variant="primary" />
+              variant="primary"
+            />
             <Button
               isBlock={false}
               isCompact={false}
@@ -987,10 +1168,12 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
               size="medium"
               text="Dismiss"
               type="button"
-              variant="secondary" />
+              variant="secondary"
+            />
           </div>
         </div>
-      }>
+      }
+    >
       <div />
     </ResponsiveElement>
   </Alert>
@@ -1010,31 +1193,39 @@ exports[`Dismissible Alert that includes actions section should render an alert 
       "Terra.alert.success": "Success.",
       "Terra.alert.warning": "Warning.",
     }
-  }>
+  }
+>
   <Alert
     action={null}
     customIcon={null}
     customStatusColor=""
     onDismiss={[Function]}
     title=""
-    type="alert">
+    type="alert"
+  >
     <ResponsiveElement
       defaultElement={
         <div
           className="alert narrow"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-narrow">
+            className="body-narrow"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconAlert
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Alert.
               </strong>
               <div>
@@ -1043,7 +1234,8 @@ exports[`Dismissible Alert that includes actions section should render an alert 
             </div>
           </div>
           <div
-            className="actions">
+            className="actions"
+          >
             <Button
               isBlock={false}
               isCompact={false}
@@ -1053,7 +1245,8 @@ exports[`Dismissible Alert that includes actions section should render an alert 
               size="medium"
               text="Dismiss"
               type="button"
-              variant="secondary" />
+              variant="secondary"
+            />
           </div>
         </div>
       }
@@ -1061,19 +1254,25 @@ exports[`Dismissible Alert that includes actions section should render an alert 
       tiny={
         <div
           className="alert wide"
-          style={Object {}}>
+          style={Object {}}
+        >
           <div
-            className="body-std">
+            className="body-std"
+          >
             <div
-              className="icon">
+              className="icon"
+            >
               <IconAlert
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </div>
             <div
-              className="section">
+              className="section"
+            >
               <strong
-                className="title">
+                className="title"
+              >
                 Alert.
               </strong>
               <div>
@@ -1082,7 +1281,8 @@ exports[`Dismissible Alert that includes actions section should render an alert 
             </div>
           </div>
           <div
-            className="actions">
+            className="actions"
+          >
             <Button
               isBlock={false}
               isCompact={false}
@@ -1092,10 +1292,12 @@ exports[`Dismissible Alert that includes actions section should render an alert 
               size="medium"
               text="Dismiss"
               type="button"
-              variant="secondary" />
+              variant="secondary"
+            />
           </div>
         </div>
-      }>
+      }
+    >
       <div />
     </ResponsiveElement>
   </Alert>

--- a/packages/terra-arrange/tests/jest/__snapshots__/Arrange.test.jsx.snap
+++ b/packages/terra-arrange/tests/jest/__snapshots__/Arrange.test.jsx.snap
@@ -1,22 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`Arrange default should render a arrange component with given fit and fill 1`] = `
 <div
-  className="arrange">
+  className="arrange"
+>
   <div
-    className="fit">
+    className="fit"
+  >
     <img
       alt="panda"
-      src="http:///uploads/2016/09/telegraph-1.jpg" />
+      src="http:///uploads/2016/09/telegraph-1.jpg"
+    />
   </div>
   <div
-    className="fill">
+    className="fill"
+  >
     <div>
       FIll text
     </div>
   </div>
   <div
-    className="fit">
+    className="fit"
+  >
     <a
-      href="http://www.example.com" />
+      href="http://www.example.com"
+    />
   </div>
 </div>
 `;
@@ -24,98 +32,123 @@ exports[`Arrange default should render a arrange component with given fit and fi
 exports[`Arrange should render a arrange component with given className and id 1`] = `
 <div
   className="arrange testA testB testC"
-  id="testkey">
+  id="testkey"
+>
   <div
-    className="fit">
+    className="fit"
+  >
     <img
       alt="panda"
-      src="http:///uploads/2016/09/telegraph-1.jpg" />
+      src="http:///uploads/2016/09/telegraph-1.jpg"
+    />
   </div>
   <div
-    className="fill">
+    className="fill"
+  >
     <div>
       FIll text
     </div>
   </div>
   <div
-    className="fit" />
+    className="fit"
+  />
 </div>
 `;
 
 exports[`Arrange when two fits and one fill is passed with align set should render a arrange component with fit and fill aligned to bottom 1`] = `
 <div
-  className="arrange">
+  className="arrange"
+>
   <div
-    className="fit bottom">
+    className="fit bottom"
+  >
     <img
       alt="panda"
-      src="http:///uploads/2016/09/telegraph-1.jpg" />
+      src="http:///uploads/2016/09/telegraph-1.jpg"
+    />
   </div>
   <div
-    className="fill bottom">
+    className="fill bottom"
+  >
     <div>
       FIll text
     </div>
   </div>
   <div
-    className="fit bottom" />
+    className="fit bottom"
+  />
 </div>
 `;
 
 exports[`Arrange when two fits and one fill is passed with align set should render a arrange component with fit and fill aligned to center 1`] = `
 <div
-  className="arrange">
+  className="arrange"
+>
   <div
-    className="fit center" />
+    className="fit center"
+  />
   <div
-    className="fill center">
+    className="fill center"
+  >
     <div>
       FIll text
     </div>
   </div>
   <div
-    className="fit center">
+    className="fit center"
+  >
     <a
-      href="http://www.example.com" />
+      href="http://www.example.com"
+    />
   </div>
 </div>
 `;
 
 exports[`Arrange when two fits and one fill is passed with align set should render a arrange component with fit and fill aligned to stretch 1`] = `
 <div
-  className="arrange">
+  className="arrange"
+>
   <div
-    className="fit stretch">
+    className="fit stretch"
+  >
     <img
       alt="panda"
-      src="http:///uploads/2016/09/telegraph-1.jpg" />
+      src="http:///uploads/2016/09/telegraph-1.jpg"
+    />
   </div>
   <div
-    className="fill stretch">
+    className="fill stretch"
+  >
     <div>
       FIll text
     </div>
   </div>
   <div
-    className="fit stretch" />
+    className="fit stretch"
+  />
 </div>
 `;
 
 exports[`Arrange when two fits and one fill is passed with align set should render a arrange component with fit and fill aligned to top 1`] = `
 <div
-  className="arrange">
+  className="arrange"
+>
   <div
-    className="fit" />
+    className="fit"
+  />
   <div
-    className="fill">
+    className="fill"
+  >
     <div>
       FIll text
     </div>
   </div>
   <div
-    className="fit">
+    className="fit"
+  >
     <a
-      href="http://www.example.com" />
+      href="http://www.example.com"
+    />
   </div>
 </div>
 `;

--- a/packages/terra-badge/tests/jest/__snapshots__/Badge.test.jsx.snap
+++ b/packages/terra-badge/tests/jest/__snapshots__/Badge.test.jsx.snap
@@ -1,64 +1,81 @@
-exports[`test should render a badge component in the order, icon and text with medium size 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a badge component in the order, icon and text with medium size 1`] = `
 <span
-  className="badge medium default">
+  className="badge medium default"
+>
   <img
-    alt="Test icon" />
+    alt="Test icon"
+  />
   <span
-    className="text">
+    className="text"
+  >
     Test value
   </span>
 </span>
 `;
 
-exports[`test should render a badge component in the order, text and icon with info intent 1`] = `
+exports[`should render a badge component in the order, text and icon with info intent 1`] = `
 <span
-  className="badge small info">
+  className="badge small info"
+>
   <span
-    className="text">
+    className="text"
+  >
     Test value
   </span>
   <img
-    alt="Test icon" />
+    alt="Test icon"
+  />
 </span>
 `;
 
-exports[`test should render a badge component with icon and medium size 1`] = `
+exports[`should render a badge component with icon and medium size 1`] = `
 <span
-  className="badge medium default">
+  className="badge medium default"
+>
   <img
-    alt="Test icon" />
+    alt="Test icon"
+  />
 </span>
 `;
 
-exports[`test should render a badge component with icon and warning intent 1`] = `
+exports[`should render a badge component with icon and warning intent 1`] = `
 <span
-  className="badge small warning">
+  className="badge small warning"
+>
   <img
-    alt="Test icon" />
+    alt="Test icon"
+  />
 </span>
 `;
 
-exports[`test should render a badge component with text and large size 1`] = `
+exports[`should render a badge component with text and large size 1`] = `
 <span
-  className="badge large default">
+  className="badge large default"
+>
   <span
-    className="text">
+    className="text"
+  >
     Large
   </span>
 </span>
 `;
 
-exports[`test should render a badge component with text and secondary intent 1`] = `
+exports[`should render a badge component with text and secondary intent 1`] = `
 <span
-  className="badge small secondary">
+  className="badge small secondary"
+>
   <span
-    className="text">
+    className="text"
+  >
     Secondary
   </span>
 </span>
 `;
 
-exports[`test should render a default component with nothing 1`] = `
+exports[`should render a default component with nothing 1`] = `
 <span
-  className="badge small default" />
+  className="badge small default"
+/>
 `;

--- a/packages/terra-base/tests/jest/__snapshots__/Base.test.jsx.snap
+++ b/packages/terra-base/tests/jest/__snapshots__/Base.test.jsx.snap
@@ -1,56 +1,63 @@
-exports[`test should render the component with customMessages 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render the component with customMessages 1`] = `
 <I18nProvider
   locale="en-US"
   messages={
     Object {
       "App.test": "App test",
     }
-  }>
+  }
+>
   <div>
     customMessages
   </div>
 </I18nProvider>
 `;
 
-exports[`test should render the component with merged attributes 1`] = `
+exports[`should render the component with merged attributes 1`] = `
 <I18nProvider
   locale="en-US"
-  messages={Object {}}>
+  messages={Object {}}
+>
   <div
     className="TestClass"
     data-mock="data"
-    id="TestId">
+    id="TestId"
+  >
     String
   </div>
 </I18nProvider>
 `;
 
-exports[`test should support rendering a string as children 1`] = `
+exports[`should support rendering a string as children 1`] = `
 <I18nProvider
   locale="en-US"
-  messages={Object {}}>
+  messages={Object {}}
+>
   <div>
     String
   </div>
 </I18nProvider>
 `;
 
-exports[`test should support rendering a string as the translationsLoadingPlaceholder prop 1`] = `
+exports[`should support rendering a string as the translationsLoadingPlaceholder prop 1`] = `
 <div>
   String
 </div>
 `;
 
-exports[`test should support rendering a string without translation 1`] = `
+exports[`should support rendering a string without translation 1`] = `
 <div>
   String
 </div>
 `;
 
-exports[`test should support rendering an array of elements as a children 1`] = `
+exports[`should support rendering an array of elements as a children 1`] = `
 <I18nProvider
   locale="en-US"
-  messages={Object {}}>
+  messages={Object {}}
+>
   <div>
     <h1>
       Heading
@@ -65,10 +72,11 @@ exports[`test should support rendering an array of elements as a children 1`] = 
 </I18nProvider>
 `;
 
-exports[`test should support rendering an element as children 1`] = `
+exports[`should support rendering an element as children 1`] = `
 <I18nProvider
   locale="en-US"
-  messages={Object {}}>
+  messages={Object {}}
+>
   <div>
     <p>
       Element
@@ -77,7 +85,7 @@ exports[`test should support rendering an element as children 1`] = `
 </I18nProvider>
 `;
 
-exports[`test should support rendering an element as the translationsLoadingPlaceholder prop 1`] = `
+exports[`should support rendering an element as the translationsLoadingPlaceholder prop 1`] = `
 <div>
   <p>
     Element

--- a/packages/terra-button-group/tests/jest/__snapshots__/ButtonGroup.test.jsx.snap
+++ b/packages/terra-button-group/tests/jest/__snapshots__/ButtonGroup.test.jsx.snap
@@ -1,173 +1,205 @@
-exports[`test should render a button group with buttons 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a button group with buttons 1`] = `
 <div
-  className="button-group">
+  className="button-group"
+>
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={false}
-    variant="default" />
+    variant="default"
+  />
 </div>
 `;
 
-exports[`test should render a button group with children 1`] = `
+exports[`should render a button group with children 1`] = `
 <div
-  className="button-group">
+  className="button-group"
+>
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={false}
-    variant="default" />
+    variant="default"
+  />
 </div>
 `;
 
-exports[`test should render a button group with size = huge 1`] = `
+exports[`should render a button group with size = huge 1`] = `
 <div
-  className="button-group">
+  className="button-group"
+>
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={false}
     size="huge"
-    variant="default" />
+    variant="default"
+  />
 </div>
 `;
 
-exports[`test should render a button group with size = large 1`] = `
+exports[`should render a button group with size = large 1`] = `
 <div
-  className="button-group">
+  className="button-group"
+>
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={false}
     size="large"
-    variant="default" />
+    variant="default"
+  />
 </div>
 `;
 
-exports[`test should render a button group with size = medium 1`] = `
+exports[`should render a button group with size = medium 1`] = `
 <div
-  className="button-group">
+  className="button-group"
+>
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={false}
     size="medium"
-    variant="default" />
+    variant="default"
+  />
 </div>
 `;
 
-exports[`test should render a button group with size = small 1`] = `
+exports[`should render a button group with size = small 1`] = `
 <div
-  className="button-group">
+  className="button-group"
+>
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={false}
     size="small"
-    variant="default" />
+    variant="default"
+  />
 </div>
 `;
 
-exports[`test should render a button group with size = tiny 1`] = `
+exports[`should render a button group with size = tiny 1`] = `
 <div
-  className="button-group">
+  className="button-group"
+>
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={false}
     size="tiny"
-    variant="default" />
+    variant="default"
+  />
 </div>
 `;
 
-exports[`test should render a button group with variant = default 1`] = `
+exports[`should render a button group with variant = default 1`] = `
 <div
-  className="button-group">
+  className="button-group"
+>
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={false}
-    variant="default" />
+    variant="default"
+  />
 </div>
 `;
 
-exports[`test should render a button group with variant = secondary 1`] = `
+exports[`should render a button group with variant = secondary 1`] = `
 <div
-  className="button-group">
+  className="button-group"
+>
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={false}
-    variant="secondary" />
+    variant="secondary"
+  />
 </div>
 `;
 
-exports[`test should render a compact button group 1`] = `
+exports[`should render a compact button group 1`] = `
 <div
-  className="button-group">
+  className="button-group"
+>
   <ButtonGroupButton
     isCompact={true}
     isReversed={false}
     isSelected={false}
-    variant="default" />
+    variant="default"
+  />
 </div>
 `;
 
-exports[`test should render a default component 1`] = `
+exports[`should render a default component 1`] = `
 <div
-  className="button-group">
+  className="button-group"
+>
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={false}
-    variant="default" />
+    variant="default"
+  />
 </div>
 `;
 
-exports[`test should render a selectable button group 1`] = `
+exports[`should render a selectable button group 1`] = `
 <div
-  className="button-group">
+  className="button-group"
+>
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={false}
     onClick={[Function]}
-    variant="default" />
+    variant="default"
+  />
 </div>
 `;
 
-exports[`test should select a button 1`] = `
+exports[`should select a button 1`] = `
 <div
-  className="button-group">
+  className="button-group"
+>
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={true}
     onClick={[Function]}
-    variant="default" />
+    variant="default"
+  />
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={false}
     onClick={[Function]}
-    variant="default" />
+    variant="default"
+  />
 </div>
 `;
 
-exports[`test should select a button 2`] = `
+exports[`should select a button 2`] = `
 <div
-  className="button-group">
+  className="button-group"
+>
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={false}
     onClick={[Function]}
-    variant="default" />
+    variant="default"
+  />
   <ButtonGroupButton
     isCompact={false}
     isReversed={false}
     isSelected={true}
     onClick={[Function]}
-    variant="default" />
+    variant="default"
+  />
 </div>
 `;

--- a/packages/terra-button-group/tests/jest/__snapshots__/ButtonGroupButton.test.jsx.snap
+++ b/packages/terra-button-group/tests/jest/__snapshots__/ButtonGroupButton.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test should render a default component 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default component 1`] = `
 <Button
   aria-selected={false}
   className="button-group-button"
@@ -7,10 +9,11 @@ exports[`test should render a default component 1`] = `
   isDisabled={false}
   isReversed={false}
   type="button"
-  variant="default" />
+  variant="default"
+/>
 `;
 
-exports[`test should render as selected 1`] = `
+exports[`should render as selected 1`] = `
 <Button
   aria-selected={true}
   className="button-group-button is-active"
@@ -19,16 +22,18 @@ exports[`test should render as selected 1`] = `
   isDisabled={false}
   isReversed={false}
   type="button"
-  variant="default" />
+  variant="default"
+/>
 `;
 
-exports[`test should render with icon and text 1`] = `
+exports[`should render with icon and text 1`] = `
 <Button
   aria-selected={false}
   className="button-group-button"
   icon={
     <img
-      alt="icon" />
+      alt="icon"
+    />
   }
   isBlock={false}
   isCompact={false}
@@ -36,16 +41,18 @@ exports[`test should render with icon and text 1`] = `
   isReversed={false}
   text="text"
   type="button"
-  variant="default" />
+  variant="default"
+/>
 `;
 
-exports[`test should render with icon and text reversed 1`] = `
+exports[`should render with icon and text reversed 1`] = `
 <Button
   aria-selected={false}
   className="button-group-button"
   icon={
     <img
-      alt="icon" />
+      alt="icon"
+    />
   }
   isBlock={false}
   isCompact={false}
@@ -53,26 +60,29 @@ exports[`test should render with icon and text reversed 1`] = `
   isReversed={true}
   text="text"
   type="button"
-  variant="default" />
+  variant="default"
+/>
 `;
 
-exports[`test should render with icon only 1`] = `
+exports[`should render with icon only 1`] = `
 <Button
   aria-selected={false}
   className="button-group-button"
   icon={
     <img
-      alt="icon" />
+      alt="icon"
+    />
   }
   isBlock={false}
   isCompact={false}
   isDisabled={false}
   isReversed={false}
   type="button"
-  variant="default" />
+  variant="default"
+/>
 `;
 
-exports[`test should render with text 1`] = `
+exports[`should render with text 1`] = `
 <Button
   aria-selected={false}
   className="button-group-button"
@@ -82,5 +92,6 @@ exports[`test should render with text 1`] = `
   isReversed={false}
   text="text"
   type="button"
-  variant="default" />
+  variant="default"
+/>
 `;

--- a/packages/terra-button/tests/jest/__snapshots__/Button.test.jsx.snap
+++ b/packages/terra-button/tests/jest/__snapshots__/Button.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test should render a Button with merged attributes 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a Button with merged attributes 1`] = `
 <button
   aria-disabled={false}
   className="button default TestClass"
@@ -9,114 +11,131 @@ exports[`test should render a Button with merged attributes 1`] = `
       "height": "100px",
     }
   }
-  type="button" />
+  type="button"
+/>
 `;
 
-exports[`test should render a button with type equal to button 1`] = `
+exports[`should render a button with type equal to button 1`] = `
 <button
   aria-disabled={false}
   className="button default"
   disabled={false}
-  type="button" />
+  type="button"
+/>
 `;
 
-exports[`test should render a button with type equal to reset 1`] = `
+exports[`should render a button with type equal to reset 1`] = `
 <button
   aria-disabled={false}
   className="button default"
   disabled={false}
-  type="reset" />
+  type="reset"
+/>
 `;
 
-exports[`test should render a button with type equal to submit 1`] = `
+exports[`should render a button with type equal to submit 1`] = `
 <button
   aria-disabled={false}
   className="button default"
   disabled={false}
-  type="submit" />
+  type="submit"
+/>
 `;
 
-exports[`test should render a default button 1`] = `
+exports[`should render a default button 1`] = `
 <button
   aria-disabled={false}
   className="button default"
   disabled={false}
-  type="button" />
+  type="button"
+/>
 `;
 
-exports[`test should render a link button 1`] = `
+exports[`should render a link button 1`] = `
 <button
   aria-disabled={false}
   className="button link"
   disabled={false}
-  type="button" />
+  type="button"
+/>
 `;
 
-exports[`test should render a primary button 1`] = `
+exports[`should render a primary button 1`] = `
 <button
   aria-disabled={false}
   className="button primary"
   disabled={false}
-  type="button" />
+  type="button"
+/>
 `;
 
-exports[`test should render a secondary button 1`] = `
+exports[`should render a secondary button 1`] = `
 <button
   aria-disabled={false}
   className="button secondary"
   disabled={false}
-  type="button" />
+  type="button"
+/>
 `;
 
-exports[`test should render an icon 1`] = `
+exports[`should render an icon 1`] = `
 <button
   aria-disabled={false}
   className="button default tiny"
   disabled={false}
-  type="button">
+  type="button"
+>
   <img
-    alt="icon" />
+    alt="icon"
+  />
 </button>
 `;
 
-exports[`test should render an icon and a text 1`] = `
+exports[`should render an icon and a text 1`] = `
 <button
   aria-disabled={false}
   className="button default tiny"
   disabled={false}
-  type="button">
+  type="button"
+>
   <img
-    alt="icon" />
+    alt="icon"
+  />
   <span
-    className="text">
+    className="text"
+  >
     text
   </span>
 </button>
 `;
 
-exports[`test should render as an anchor when provided an href 1`] = `
+exports[`should render as an anchor when provided an href 1`] = `
 <a
   aria-disabled={false}
   className="button default"
   disabled={false}
   href="MockHref"
-  type="button">
+  type="button"
+>
   <span
-    className="text">
+    className="text"
+  >
     href
   </span>
 </a>
 `;
 
-exports[`test should render as disabled when set 1`] = `
+exports[`should render as disabled when set 1`] = `
 <button
   aria-disabled={true}
   className="button default is-disabled"
   disabled={true}
   tabIndex="-1"
-  type="button">
+  type="button"
+>
   <span
-    className="text">
+    className="text"
+  >
     Disabled
   </span>
 </button>

--- a/packages/terra-card/tests/jest/__snapshots__/Card.test.jsx.snap
+++ b/packages/terra-card/tests/jest/__snapshots__/Card.test.jsx.snap
@@ -1,4 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`Card should render a default component 1`] = `
 <div
-  className="card" />
+  className="card"
+/>
 `;

--- a/packages/terra-content-container/tests/jest/__snapshots__/ContentContainer.test.jsx.snap
+++ b/packages/terra-content-container/tests/jest/__snapshots__/ContentContainer.test.jsx.snap
@@ -1,55 +1,73 @@
-exports[`test should render a default component 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default component 1`] = `
 <div
-  className="content-container">
+  className="content-container"
+>
   <div
-    className="header" />
+    className="header"
+  />
   <div
-    className="main">
+    className="main"
+  >
     <div
-      className="normalizer" />
+      className="normalizer"
+    />
   </div>
 </div>
 `;
 
-exports[`test should render a header 1`] = `
+exports[`should render a header 1`] = `
 <div
-  className="content-container">
+  className="content-container"
+>
   <div
-    className="header">
+    className="header"
+  >
     <p>
       Header
     </p>
   </div>
   <div
-    className="main">
+    className="main"
+  >
     <div
-      className="normalizer" />
+      className="normalizer"
+    />
   </div>
 </div>
 `;
 
-exports[`test should render as fill 1`] = `
+exports[`should render as fill 1`] = `
 <div
-  className="content-container fill">
+  className="content-container fill"
+>
   <div
-    className="header" />
+    className="header"
+  />
   <div
-    className="main">
+    className="main"
+  >
     <div
-      className="normalizer" />
+      className="normalizer"
+    />
   </div>
 </div>
 `;
 
-exports[`test should render content 1`] = `
+exports[`should render content 1`] = `
 <div
-  className="content-container">
+  className="content-container"
+>
   <div
-    className="header" />
+    className="header"
+  />
   <div
-    className="main">
+    className="main"
+  >
     <div
-      className="normalizer">
+      className="normalizer"
+    >
       <p>
         test content
       </p>

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -1,17 +1,23 @@
-exports[`test should render a default date input 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default date input 1`] = `
 <div
-  class="custom-input">
+  class="custom-input"
+>
   <input
     data-terra-date-input-hidden="true"
-    type="hidden" />
+    type="hidden"
+  />
   <input
     class="input input"
     name="terra-date-undefined"
-    type="text" />
+    type="text"
+  />
   <button
     aria-disabled="false"
     class="button default compact button"
-    type="button">
+    type="button"
+  >
     <svg
       aria-hidden="true"
       class="icon"
@@ -19,33 +25,39 @@ exports[`test should render a default date input 1`] = `
       height="1em"
       viewbox="0 0 48 48"
       width="1em"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <path
-        d="M43 6h-4V2.2C39 1 38 0 36.8 0h-1.7C33.9.1 33 1 33 2.2V6H15V2.2C15 1 14 0 12.8 0h-1.7C9.9.1 9 1 9 2.2V6H5c-1.1 0-2 .9-2 2v38c0 1.1.9 2 2 2h24c1.3-.1 2.5-.6 3.4-1.4l11.2-11.1c.8-.9 1.3-2.1 1.4-3.4V8c0-1.1-.9-2-2-2zM6 21h36v10H30c-1.1 0-2 .9-2 2v12H6V21zm25 22.8V34h9.8L31 43.8z" />
+        d="M43 6h-4V2.2C39 1 38 0 36.8 0h-1.7C33.9.1 33 1 33 2.2V6H15V2.2C15 1 14 0 12.8 0h-1.7C9.9.1 9 1 9 2.2V6H5c-1.1 0-2 .9-2 2v38c0 1.1.9 2 2 2h24c1.3-.1 2.5-.6 3.4-1.4l11.2-11.1c.8-.9 1.3-2.1 1.4-3.4V8c0-1.1-.9-2-2-2zM6 21h36v10H30c-1.1 0-2 .9-2 2v12H6V21zm25 22.8V34h9.8L31 43.8z"
+      />
     </svg>
   </button>
 </div>
 `;
 
-exports[`test should render a default date input with all props 1`] = `
+exports[`should render a default date input with all props 1`] = `
 <div
-  class="custom-input">
+  class="custom-input"
+>
   <input
     data-terra-date-input-hidden="true"
     name="date-input"
     type="hidden"
-    value="2017-01-01" />
+    value="2017-01-01"
+  />
   <input
     class="input input"
     id="terra-date-input"
     name="terra-date-date-input"
     placeholder="MM/DD/YYYY"
     type="text"
-    value="01/01/2017" />
+    value="01/01/2017"
+  />
   <button
     aria-disabled="false"
     class="button default compact button"
-    type="button">
+    type="button"
+  >
     <svg
       aria-hidden="true"
       class="icon"
@@ -53,9 +65,11 @@ exports[`test should render a default date input with all props 1`] = `
       height="1em"
       viewbox="0 0 48 48"
       width="1em"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <path
-        d="M43 6h-4V2.2C39 1 38 0 36.8 0h-1.7C33.9.1 33 1 33 2.2V6H15V2.2C15 1 14 0 12.8 0h-1.7C9.9.1 9 1 9 2.2V6H5c-1.1 0-2 .9-2 2v38c0 1.1.9 2 2 2h24c1.3-.1 2.5-.6 3.4-1.4l11.2-11.1c.8-.9 1.3-2.1 1.4-3.4V8c0-1.1-.9-2-2-2zM6 21h36v10H30c-1.1 0-2 .9-2 2v12H6V21zm25 22.8V34h9.8L31 43.8z" />
+        d="M43 6h-4V2.2C39 1 38 0 36.8 0h-1.7C33.9.1 33 1 33 2.2V6H15V2.2C15 1 14 0 12.8 0h-1.7C9.9.1 9 1 9 2.2V6H5c-1.1 0-2 .9-2 2v38c0 1.1.9 2 2 2h24c1.3-.1 2.5-.6 3.4-1.4l11.2-11.1c.8-.9 1.3-2.1 1.4-3.4V8c0-1.1-.9-2-2-2zM6 21h36v10H30c-1.1 0-2 .9-2 2v12H6V21zm25 22.8V34h9.8L31 43.8z"
+      />
     </svg>
   </button>
 </div>

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test should render a date picker with disabled dates 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a date picker with disabled dates 1`] = `
 <DatePicker
   excludeDates={
     Array [
@@ -6,17 +8,19 @@ exports[`test should render a date picker with disabled dates 1`] = `
     ]
   }
   name="date-input"
-  utcOffset={0} />
+  utcOffset={0}
+/>
 `;
 
-exports[`test should render a date picker with filtered dates 1`] = `
+exports[`should render a date picker with filtered dates 1`] = `
 <DatePicker
   filterDate={[Function]}
   name="date-input"
-  utcOffset={0} />
+  utcOffset={0}
+/>
 `;
 
-exports[`test should render a date picker with included dates 1`] = `
+exports[`should render a date picker with included dates 1`] = `
 <DatePicker
   includeDates={
     Array [
@@ -24,38 +28,43 @@ exports[`test should render a date picker with included dates 1`] = `
     ]
   }
   name="date-input"
-  utcOffset={0} />
+  utcOffset={0}
+/>
 `;
 
-exports[`test should render a date picker with min and max dates 1`] = `
+exports[`should render a date picker with min and max dates 1`] = `
 <DatePicker
   maxDate="2017-04-10"
   minDate="2017-04-01"
   name="date-input"
-  utcOffset={0} />
+  utcOffset={0}
+/>
 `;
 
-exports[`test should render a date picker with releaseFocus 1`] = `
+exports[`should render a date picker with releaseFocus 1`] = `
 <DatePicker
   name="date-input"
   releaseFocus={[Function]}
-  utcOffset={0} />
+  utcOffset={0}
+/>
 `;
 
-exports[`test should render a date picker with requestFocus 1`] = `
+exports[`should render a date picker with requestFocus 1`] = `
 <DatePicker
   name="date-input"
   requestFocus={[Function]}
-  utcOffset={0} />
+  utcOffset={0}
+/>
 `;
 
-exports[`test should render a default date input and date picker 1`] = `
+exports[`should render a default date input and date picker 1`] = `
 <DatePicker
   name="date-input"
-  utcOffset={0} />
+  utcOffset={0}
+/>
 `;
 
-exports[`test should render a default date input with custom input attributes 1`] = `
+exports[`should render a default date input with custom input attributes 1`] = `
 <DatePicker
   inputAttributes={
     Object {
@@ -63,5 +72,6 @@ exports[`test should render a default date input with custom input attributes 1`
     }
   }
   name="date-input"
-  utcOffset={0} />
+  utcOffset={0}
+/>
 `;

--- a/packages/terra-demographics-banner/tests/jest/__snapshots__/DemographicsBanner.test.jsx.snap
+++ b/packages/terra-demographics-banner/tests/jest/__snapshots__/DemographicsBanner.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test renders a blank banner wrapper 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a blank banner wrapper 1`] = `
 <DemographicsBanner
   applicationContent={null}
   deceasedDate={null}
@@ -6,15 +8,17 @@ exports[`test renders a blank banner wrapper 1`] = `
   identifiers={Object {}}
   photo={null}
   postMenstrualAge={null}
-  preferredFirstName={null} />
+  preferredFirstName={null}
+/>
 `;
 
-exports[`test renders the banner wrapper with all props 1`] = `
+exports[`renders the banner wrapper with all props 1`] = `
 <DemographicsBanner
   age="25 Years"
   applicationContent={
     <span
-      className="risk-score">
+      className="risk-score"
+    >
       5%
     </span>
   }
@@ -45,8 +49,10 @@ exports[`test renders the banner wrapper with all props 1`] = `
       alt="My Cat"
       isFluid={false}
       src=""
-      variant="default" />
+      variant="default"
+    />
   }
   postMenstrualAge="April 7, 2016"
-  preferredFirstName="John" />
+  preferredFirstName="John"
+/>
 `;

--- a/packages/terra-demographics-banner/tests/jest/__snapshots__/DemographicsBannerDisplay.test.jsx.snap
+++ b/packages/terra-demographics-banner/tests/jest/__snapshots__/DemographicsBannerDisplay.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test renders a banner that has basic information 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a banner that has basic information 1`] = `
 <ResponsiveElement
   defaultElement={
     <Component
@@ -16,7 +18,8 @@ exports[`test renders a banner that has basic information 1`] = `
       photo={null}
       postMenstrualAge={null}
       postMenstrualAgeLabel="PMA"
-      preferredFirstName={null} />
+      preferredFirstName={null}
+    />
   }
   responsiveTo="window"
   small={
@@ -35,11 +38,13 @@ exports[`test renders a banner that has basic information 1`] = `
       photo={null}
       postMenstrualAge={null}
       postMenstrualAgeLabel="PMA"
-      preferredFirstName={null} />
-  } />
+      preferredFirstName={null}
+    />
+  }
+/>
 `;
 
-exports[`test renders a blank banner properly 1`] = `
+exports[`renders a blank banner properly 1`] = `
 <ResponsiveElement
   defaultElement={
     <Component
@@ -57,7 +62,8 @@ exports[`test renders a blank banner properly 1`] = `
       photo={null}
       postMenstrualAge={null}
       postMenstrualAgeLabel="PMA"
-      preferredFirstName={null} />
+      preferredFirstName={null}
+    />
   }
   responsiveTo="window"
   small={
@@ -76,11 +82,13 @@ exports[`test renders a blank banner properly 1`] = `
       photo={null}
       postMenstrualAge={null}
       postMenstrualAgeLabel="PMA"
-      preferredFirstName={null} />
-  } />
+      preferredFirstName={null}
+    />
+  }
+/>
 `;
 
-exports[`test renders gestational date with a default label when the label is not provided 1`] = `
+exports[`renders gestational date with a default label when the label is not provided 1`] = `
 <ResponsiveElement
   defaultElement={
     <Component
@@ -98,7 +106,8 @@ exports[`test renders gestational date with a default label when the label is no
       photo={null}
       postMenstrualAge={null}
       postMenstrualAgeLabel="PMA"
-      preferredFirstName={null} />
+      preferredFirstName={null}
+    />
   }
   responsiveTo="window"
   small={
@@ -117,11 +126,13 @@ exports[`test renders gestational date with a default label when the label is no
       photo={null}
       postMenstrualAge={null}
       postMenstrualAgeLabel="PMA"
-      preferredFirstName={null} />
-  } />
+      preferredFirstName={null}
+    />
+  }
+/>
 `;
 
-exports[`test renders post menstrural date with a default label when the label is not provided 1`] = `
+exports[`renders post menstrural date with a default label when the label is not provided 1`] = `
 <ResponsiveElement
   defaultElement={
     <Component
@@ -139,7 +150,8 @@ exports[`test renders post menstrural date with a default label when the label i
       photo={null}
       postMenstrualAge="April 5, 2016"
       postMenstrualAgeLabel="PMA"
-      preferredFirstName={null} />
+      preferredFirstName={null}
+    />
   }
   responsiveTo="window"
   small={
@@ -158,11 +170,13 @@ exports[`test renders post menstrural date with a default label when the label i
       photo={null}
       postMenstrualAge="April 5, 2016"
       postMenstrualAgeLabel="PMA"
-      preferredFirstName={null} />
-  } />
+      preferredFirstName={null}
+    />
+  }
+/>
 `;
 
-exports[`test renders the banner appropriately for a deceased person 1`] = `
+exports[`renders the banner appropriately for a deceased person 1`] = `
 <ResponsiveElement
   defaultElement={
     <Component
@@ -180,7 +194,8 @@ exports[`test renders the banner appropriately for a deceased person 1`] = `
       photo={null}
       postMenstrualAge={null}
       postMenstrualAgeLabel="PMA"
-      preferredFirstName={null} />
+      preferredFirstName={null}
+    />
   }
   responsiveTo="window"
   small={
@@ -199,18 +214,21 @@ exports[`test renders the banner appropriately for a deceased person 1`] = `
       photo={null}
       postMenstrualAge={null}
       postMenstrualAgeLabel="PMA"
-      preferredFirstName={null} />
-  } />
+      preferredFirstName={null}
+    />
+  }
+/>
 `;
 
-exports[`test renders the banner appropriately for a person with gestational and post menstrual dates 1`] = `
+exports[`renders the banner appropriately for a person with gestational and post menstrual dates 1`] = `
 <ResponsiveElement
   defaultElement={
     <Component
       age="25 Years"
       applicationContent={
         <span
-          className="risk-score">
+          className="risk-score"
+        >
           5%
         </span>
       }
@@ -244,11 +262,13 @@ exports[`test renders the banner appropriately for a person with gestational and
           alt="My Cat"
           isFluid={false}
           src=""
-          variant="default" />
+          variant="default"
+        />
       }
       postMenstrualAge="April 7, 2016"
       postMenstrualAgeLabel="PMA"
-      preferredFirstName="John" />
+      preferredFirstName="John"
+    />
   }
   responsiveTo="window"
   small={
@@ -256,7 +276,8 @@ exports[`test renders the banner appropriately for a person with gestational and
       age="25 Years"
       applicationContent={
         <span
-          className="risk-score">
+          className="risk-score"
+        >
           5%
         </span>
       }
@@ -290,22 +311,26 @@ exports[`test renders the banner appropriately for a person with gestational and
           alt="My Cat"
           isFluid={false}
           src=""
-          variant="default" />
+          variant="default"
+        />
       }
       postMenstrualAge="April 7, 2016"
       postMenstrualAgeLabel="PMA"
-      preferredFirstName="John" />
-  } />
+      preferredFirstName="John"
+    />
+  }
+/>
 `;
 
-exports[`test renders the banner properly for a deceased person with additional application content 1`] = `
+exports[`renders the banner properly for a deceased person with additional application content 1`] = `
 <ResponsiveElement
   defaultElement={
     <Component
       age="25 Years"
       applicationContent={
         <span
-          className="risk-score">
+          className="risk-score"
+        >
           5%
         </span>
       }
@@ -339,11 +364,13 @@ exports[`test renders the banner properly for a deceased person with additional 
           alt="My Cat"
           isFluid={false}
           src=""
-          variant="default" />
+          variant="default"
+        />
       }
       postMenstrualAge={null}
       postMenstrualAgeLabel="PMA"
-      preferredFirstName="John" />
+      preferredFirstName="John"
+    />
   }
   responsiveTo="window"
   small={
@@ -351,7 +378,8 @@ exports[`test renders the banner properly for a deceased person with additional 
       age="25 Years"
       applicationContent={
         <span
-          className="risk-score">
+          className="risk-score"
+        >
           5%
         </span>
       }
@@ -385,22 +413,26 @@ exports[`test renders the banner properly for a deceased person with additional 
           alt="My Cat"
           isFluid={false}
           src=""
-          variant="default" />
+          variant="default"
+        />
       }
       postMenstrualAge={null}
       postMenstrualAgeLabel="PMA"
-      preferredFirstName="John" />
-  } />
+      preferredFirstName="John"
+    />
+  }
+/>
 `;
 
-exports[`test renders the banner that contains additional information 1`] = `
+exports[`renders the banner that contains additional information 1`] = `
 <ResponsiveElement
   defaultElement={
     <Component
       age="25 Years"
       applicationContent={
         <span
-          className="risk-score">
+          className="risk-score"
+        >
           5%
         </span>
       }
@@ -434,11 +466,13 @@ exports[`test renders the banner that contains additional information 1`] = `
           alt="My Cat"
           isFluid={false}
           src=""
-          variant="default" />
+          variant="default"
+        />
       }
       postMenstrualAge={null}
       postMenstrualAgeLabel="PMA"
-      preferredFirstName="John" />
+      preferredFirstName="John"
+    />
   }
   responsiveTo="window"
   small={
@@ -446,7 +480,8 @@ exports[`test renders the banner that contains additional information 1`] = `
       age="25 Years"
       applicationContent={
         <span
-          className="risk-score">
+          className="risk-score"
+        >
           5%
         </span>
       }
@@ -480,10 +515,13 @@ exports[`test renders the banner that contains additional information 1`] = `
           alt="My Cat"
           isFluid={false}
           src=""
-          variant="default" />
+          variant="default"
+        />
       }
       postMenstrualAge={null}
       postMenstrualAgeLabel="PMA"
-      preferredFirstName="John" />
-  } />
+      preferredFirstName="John"
+    />
+  }
+/>
 `;

--- a/packages/terra-demographics-banner/tests/jest/__snapshots__/_LargeDemographicsBannerDisplay.test.jsx.snap
+++ b/packages/terra-demographics-banner/tests/jest/__snapshots__/_LargeDemographicsBannerDisplay.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test renders large banner that contains all valid information 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders large banner that contains all valid information 1`] = `
 <section
   applicationRows={
     Array [
@@ -11,55 +13,72 @@ exports[`test renders large banner that contains all valid information 1`] = `
       },
     ]
   }
-  className="demographics-banner">
+  className="demographics-banner"
+>
   <div
-    className="profile-photo">
+    className="profile-photo"
+  >
     <Image
       alt="My Cat"
       isFluid={false}
       src=""
-      variant="default" />
+      variant="default"
+    />
   </div>
   <div
-    className="content">
+    className="content"
+  >
     <div
-      className="row">
+      className="row"
+    >
       <h1
-        className="person-name">
+        className="person-name"
+      >
         Johnathon Doe
         <span
-          className="preferred-first-name">
+          className="preferred-first-name"
+        >
           John
         </span>
       </h1>
       <div
-        className="application-content">
+        className="application-content"
+      >
         <span
-          className="risk-score">
+          className="risk-score"
+        >
           5%
         </span>
       </div>
     </div>
     <div
-      className="row">
+      className="row"
+    >
       <div
-        className="person-details">
+        className="person-details"
+      >
         <DemographicsBannerValue
-          value="25 Years" />
+          value="25 Years"
+        />
         <DemographicsBannerValue
-          value="Male" />
+          value="Male"
+        />
         <DemographicsBannerValue
           label="DOB"
-          value="May 9, 1993" />
+          value="May 9, 1993"
+        />
       </div>
       <div
-        className="identifiers">
+        className="identifiers"
+      >
         <DemographicsBannerValue
           label="MRN"
-          value={12343} />
+          value={12343}
+        />
         <DemographicsBannerValue
           label="REA"
-          value="3JSDA" />
+          value="3JSDA"
+        />
       </div>
     </div>
   </div>

--- a/packages/terra-demographics-banner/tests/jest/__snapshots__/_SmallDemographicsBannerDisplay.test.jsx.snap
+++ b/packages/terra-demographics-banner/tests/jest/__snapshots__/_SmallDemographicsBannerDisplay.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test renders small banner that contains all valid information 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders small banner that contains all valid information 1`] = `
 <section
   applicationRows={
     Array [
@@ -11,37 +13,48 @@ exports[`test renders small banner that contains all valid information 1`] = `
       },
     ]
   }
-  className="demographics-banner">
+  className="demographics-banner"
+>
   <h1
-    className="person-name">
+    className="person-name"
+  >
     <span>
       Johnathon Doe
       <span
-        className="preferred-first-name">
+        className="preferred-first-name"
+      >
         John
       </span>
     </span>
   </h1>
   <div
-    className="person-details">
+    className="person-details"
+  >
     <DemographicsBannerValue
-      value="25 Years" />
+      value="25 Years"
+    />
     <DemographicsBannerValue
-      value="Male" />
+      value="Male"
+    />
     <DemographicsBannerValue
       label="DOB"
-      value="May 9, 1993" />
+      value="May 9, 1993"
+    />
     <DemographicsBannerValue
       label="MRN"
-      value={12343} />
+      value={12343}
+    />
     <DemographicsBannerValue
       label="REA"
-      value="3JSDA" />
+      value="3JSDA"
+    />
   </div>
   <div
-    className="application-content">
+    className="application-content"
+  >
     <span
-      className="risk-score">
+      className="risk-score"
+    >
       5%
     </span>
   </div>

--- a/packages/terra-dynamic-grid/tests/jest/__snapshots__/DynamicGrid.test.jsx.snap
+++ b/packages/terra-dynamic-grid/tests/jest/__snapshots__/DynamicGrid.test.jsx.snap
@@ -1,3 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`DynamicGrid should render a Grid with merged attributes 1`] = `
 <div
   className="TestClass grid_3hmsj"
@@ -6,24 +8,28 @@ exports[`DynamicGrid should render a Grid with merged attributes 1`] = `
     Object {
       "height": "100px",
     }
-  } />
+  }
+/>
 `;
 
 exports[`DynamicGrid should render a default component 1`] = `
 <div
-  className="grid_3hmsj" />
+  className="grid_3hmsj"
+/>
 `;
 
 exports[`DynamicGrid should render a default component 2`] = `
 <div
-  className="grid_3hmsj">
+  className="grid_3hmsj"
+>
   <Region
     defaultPosition={Object {}}
     huge={Object {}}
     large={Object {}}
     medium={Object {}}
     small={Object {}}
-    tiny={Object {}}>
+    tiny={Object {}}
+  >
     Hello
   </Region>
 </div>

--- a/packages/terra-dynamic-grid/tests/jest/__snapshots__/Region.test.jsx.snap
+++ b/packages/terra-dynamic-grid/tests/jest/__snapshots__/Region.test.jsx.snap
@@ -1,3 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`DynamicGrid should render a Grid with merged attributes 1`] = `
 <div
   className="TestClass region_3hmsj"
@@ -6,11 +8,13 @@ exports[`DynamicGrid should render a Grid with merged attributes 1`] = `
     Object {
       "height": "100px",
     }
-  } />
+  }
+/>
 `;
 
 exports[`DynamicGrid should render a default component 1`] = `
 <div
   className="region_3hmsj"
-  name="foo" />
+  name="foo"
+/>
 `;

--- a/packages/terra-embedded-content-consumer/tests/jest/__snapshots__/EmbeddedContentConsumer.test.jsx.snap
+++ b/packages/terra-embedded-content-consumer/tests/jest/__snapshots__/EmbeddedContentConsumer.test.jsx.snap
@@ -1,6 +1,9 @@
-exports[`test should render the embedded content consumer container 1`] = `<div />`;
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`test should render the embedded content consumer with custom class names 1`] = `
+exports[`should render the embedded content consumer container 1`] = `<div />`;
+
+exports[`should render the embedded content consumer with custom class names 1`] = `
 <div
-  className="container" />
+  className="container"
+/>
 `;

--- a/packages/terra-form/tests/jest/__snapshots__/Control.test.jsx.snap
+++ b/packages/terra-form/tests/jest/__snapshots__/Control.test.jsx.snap
@@ -1,117 +1,143 @@
-exports[`test should render a ChoiceField with a checkbox 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a ChoiceField with a checkbox 1`] = `
 <label
   className="control"
-  required={true}>
+  required={true}
+>
   <Input
     className="input healtheintent-application"
     name="children_present"
     required={false}
     type="checkbox"
-    value="children_present" />
+    value="children_present"
+  />
   <span
-    className="control-label-text healtheintent-label-text">
+    className="control-label-text healtheintent-label-text"
+  >
     Do you have any Children?
   </span>
 </label>
 `;
 
-exports[`test should render a ChoiceField with a radio 1`] = `
+exports[`should render a ChoiceField with a radio 1`] = `
 <label
   className="control"
-  required={true}>
+  required={true}
+>
   <Input
     className="input healtheintent-application"
     name="children_present"
     required={false}
     type="radio"
-    value="children_present" />
+    value="children_present"
+  />
   <span
-    className="control-label-text healtheintent-label-text">
+    className="control-label-text healtheintent-label-text"
+  >
     Do you have any Children?
   </span>
 </label>
 `;
 
-exports[`test should render a default checkbox when type is "checkbox" 1`] = `
+exports[`should render a default checkbox when type is "checkbox" 1`] = `
 <label
-  className="control">
+  className="control"
+>
   <Input
     className="input"
     name={null}
     required={false}
-    type="checkbox" />
+    type="checkbox"
+  />
   <span
-    className="control-label-text" />
+    className="control-label-text"
+  />
 </label>
 `;
 
-exports[`test should render a default checkbox when type is "radio" 1`] = `
+exports[`should render a default checkbox when type is "radio" 1`] = `
 <label
-  className="control">
+  className="control"
+>
   <Input
     className="input"
     name={null}
     required={false}
-    type="radio" />
+    type="radio"
+  />
   <span
-    className="control-label-text" />
+    className="control-label-text"
+  />
 </label>
 `;
 
-exports[`test should render as an controlled checkbox when a checked value and onChange function are passed into the Control 1`] = `
+exports[`should render as an controlled checkbox when a checked value and onChange function are passed into the Control 1`] = `
 <label
-  className="control">
+  className="control"
+>
   <Input
     checked={true}
     className="input"
     name={null}
     onChange={[Function]}
     required={false}
-    type="checkbox" />
+    type="checkbox"
+  />
   <span
-    className="control-label-text" />
+    className="control-label-text"
+  />
 </label>
 `;
 
-exports[`test should render as an controlled radio when a checked value and onChange function are passed into the Control 1`] = `
+exports[`should render as an controlled radio when a checked value and onChange function are passed into the Control 1`] = `
 <label
-  className="control">
+  className="control"
+>
   <Input
     checked={true}
     className="input"
     name={null}
     onChange={[Function]}
     required={false}
-    type="radio" />
+    type="radio"
+  />
   <span
-    className="control-label-text" />
+    className="control-label-text"
+  />
 </label>
 `;
 
-exports[`test should render as an uncontrolled checkbox when just a defaultChecked value is passed into the Control 1`] = `
+exports[`should render as an uncontrolled checkbox when just a defaultChecked value is passed into the Control 1`] = `
 <label
-  className="control">
+  className="control"
+>
   <Input
     className="input"
     defaultChecked={true}
     name={null}
     required={false}
-    type="checkbox" />
+    type="checkbox"
+  />
   <span
-    className="control-label-text" />
+    className="control-label-text"
+  />
 </label>
 `;
 
-exports[`test should render as an uncontrolled radio when just a defaultChecked value is passed into the Control 1`] = `
+exports[`should render as an uncontrolled radio when just a defaultChecked value is passed into the Control 1`] = `
 <label
-  className="control">
+  className="control"
+>
   <Input
     className="input"
     defaultChecked={true}
     name={null}
     required={false}
-    type="radio" />
+    type="radio"
+  />
   <span
-    className="control-label-text" />
+    className="control-label-text"
+  />
 </label>
 `;

--- a/packages/terra-form/tests/jest/__snapshots__/Field.test.jsx.snap
+++ b/packages/terra-form/tests/jest/__snapshots__/Field.test.jsx.snap
@@ -1,29 +1,37 @@
-exports[`test should render a Field when all the possible props are passed into it 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a Field when all the possible props are passed into it 1`] = `
 <div
-  className="field field-inline field-required">
+  className="field field-inline field-required"
+>
   <label
     className="label healtheintent-legend"
-    htmlFor="test">
+    htmlFor="test"
+  >
     Text
   </label>
   <input
     id="test"
     type="text"
-    value="Test" />
+    value="Test"
+  />
   <small
     className="help-text"
-    tabIndex="-1">
+    tabIndex="-1"
+  >
     This is a test input
   </small>
   <small
     className="error"
-    tabIndex="-1">
+    tabIndex="-1"
+  >
     This field is required
   </small>
 </div>
 `;
 
-exports[`test should render a default component 1`] = `
+exports[`should render a default component 1`] = `
 <div
-  className="field" />
+  className="field"
+/>
 `;

--- a/packages/terra-form/tests/jest/__snapshots__/Fieldset.test.jsx.snap
+++ b/packages/terra-form/tests/jest/__snapshots__/Fieldset.test.jsx.snap
@@ -1,33 +1,43 @@
-exports[`test should render a Fieldset when all the possible props are passed into it 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a Fieldset when all the possible props are passed into it 1`] = `
 <fieldset
-  className="fieldset fieldset-inline fieldset-required">
+  className="fieldset fieldset-inline fieldset-required"
+>
   <legend
-    className="legend healtheintent-legend">
+    className="legend healtheintent-legend"
+  >
     Text
   </legend>
   <small
     className="help-text"
-    tabIndex="-1">
+    tabIndex="-1"
+  >
     This is a test input
   </small>
   <small
     className="error"
-    tabIndex="-1">
+    tabIndex="-1"
+  >
     This field is required
   </small>
   <div
-    className="fieldset-children">
+    className="fieldset-children"
+  >
     <input
       type="radio"
-      value="Test" />
+      value="Test"
+    />
   </div>
 </fieldset>
 `;
 
-exports[`test should render a default component 1`] = `
+exports[`should render a default component 1`] = `
 <fieldset
-  className="fieldset">
+  className="fieldset"
+>
   <div
-    className="fieldset-children" />
+    className="fieldset-children"
+  />
 </fieldset>
 `;

--- a/packages/terra-form/tests/jest/__snapshots__/Input.test.jsx.snap
+++ b/packages/terra-form/tests/jest/__snapshots__/Input.test.jsx.snap
@@ -1,42 +1,50 @@
-exports[`test should render a Input with the rest of the props 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a Input with the rest of the props 1`] = `
 <input
   aria-required="true"
   className="input"
   name="foo"
-  required={true} />
+  required={true}
+/>
 `;
 
-exports[`test should render a default component 1`] = `
+exports[`should render a default component 1`] = `
 <input
   className="input"
   name={null}
-  required={false} />
+  required={false}
+/>
 `;
 
-exports[`test should render as controlled when just a default value is passed into the function 1`] = `
+exports[`should render as controlled when just a default value is passed into the function 1`] = `
 <Input
   name={null}
   onChange={[Function]}
   required={false}
-  value="foo">
+  value="foo"
+>
   <input
     className="input"
     name={null}
     onChange={[Function]}
     required={false}
-    value="foo" />
+    value="foo"
+  />
 </Input>
 `;
 
-exports[`test should render as uncontrolled when just a default value is passed into the function 1`] = `
+exports[`should render as uncontrolled when just a default value is passed into the function 1`] = `
 <Input
   defaultValue="foo"
   name={null}
-  required={false}>
+  required={false}
+>
   <input
     className="input"
     defaultValue="foo"
     name={null}
-    required={false} />
+    required={false}
+  />
 </Input>
 `;

--- a/packages/terra-form/tests/jest/__snapshots__/NumberField.test.jsx.snap
+++ b/packages/terra-form/tests/jest/__snapshots__/NumberField.test.jsx.snap
@@ -1,7 +1,9 @@
-exports[`test should render a NumberField when all the possible props are passed into it 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a NumberField when all the possible props are passed into it 1`] = `
 <Field
   error="This field is required"
-  help="Your county\'s office may have this information"
+  help="Your county's office may have this information"
   htmlFor="tax-rate"
   isInline={true}
   label="Sales Tax Rate"
@@ -10,7 +12,8 @@ exports[`test should render a NumberField when all the possible props are passed
       "className": "healtheintent-legend",
     }
   }
-  required={true}>
+  required={true}
+>
   <Input
     className="cernerConsumer-application"
     id="tax-rate"
@@ -19,29 +22,32 @@ exports[`test should render a NumberField when all the possible props are passed
     name="sales_tax_rate"
     required={true}
     step={0.1}
-    type="number" />
+    type="number"
+  />
 </Field>
 `;
 
-exports[`test should render a default component 1`] = `
+exports[`should render a default component 1`] = `
 <Field
   error={null}
   help={null}
   isInline={false}
   label={null}
   labelAttrs={Object {}}
-  required={false}>
+  required={false}
+>
   <Input
     max={null}
     min={null}
     name={null}
     required={false}
     step={null}
-    type="number" />
+    type="number"
+  />
 </Field>
 `;
 
-exports[`test should render as controlled when just a default value is passed into the NumberField 1`] = `
+exports[`should render as controlled when just a default value is passed into the NumberField 1`] = `
 <NumberField
   error={null}
   help={null}
@@ -55,16 +61,19 @@ exports[`test should render as controlled when just a default value is passed in
   onChange={[Function]}
   required={false}
   step={null}
-  value={2}>
+  value={2}
+>
   <Field
     error={null}
     help={null}
     isInline={false}
     label={null}
     labelAttrs={Object {}}
-    required={false}>
+    required={false}
+  >
     <div
-      className="field">
+      className="field"
+    >
       <Input
         max={null}
         min={null}
@@ -73,7 +82,8 @@ exports[`test should render as controlled when just a default value is passed in
         required={false}
         step={null}
         type="number"
-        value={2}>
+        value={2}
+      >
         <input
           className="input"
           max={null}
@@ -83,21 +93,23 @@ exports[`test should render as controlled when just a default value is passed in
           required={false}
           step={null}
           type="number"
-          value={2} />
+          value={2}
+        />
       </Input>
     </div>
   </Field>
 </NumberField>
 `;
 
-exports[`test should render as uncontrolled when just a numeric default value is passed into the NumberField 1`] = `
+exports[`should render as uncontrolled when just a numeric default value is passed into the NumberField 1`] = `
 <Field
   error={null}
   help={null}
   isInline={false}
   label={null}
   labelAttrs={Object {}}
-  required={false}>
+  required={false}
+>
   <Input
     defaultValue={2}
     max={null}
@@ -105,18 +117,20 @@ exports[`test should render as uncontrolled when just a numeric default value is
     name={null}
     required={false}
     step={null}
-    type="number" />
+    type="number"
+  />
 </Field>
 `;
 
-exports[`test should render as uncontrolled when just a string default value is passed into the NumberField 1`] = `
+exports[`should render as uncontrolled when just a string default value is passed into the NumberField 1`] = `
 <Field
   error={null}
   help={null}
   isInline={false}
   label={null}
   labelAttrs={Object {}}
-  required={false}>
+  required={false}
+>
   <Input
     defaultValue="2"
     max={null}
@@ -124,6 +138,7 @@ exports[`test should render as uncontrolled when just a string default value is 
     name={null}
     required={false}
     step={null}
-    type="number" />
+    type="number"
+  />
 </Field>
 `;

--- a/packages/terra-form/tests/jest/__snapshots__/Select.test.jsx.snap
+++ b/packages/terra-form/tests/jest/__snapshots__/Select.test.jsx.snap
@@ -1,36 +1,43 @@
-exports[`test should render a Select component with one option 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a Select component with one option 1`] = `
 <select
   className="select"
   name={null}
-  required={false}>
+  required={false}
+>
   <option
-    value="m">
+    value="m"
+  >
     moo
   </option>
 </select>
 `;
 
-exports[`test should render a Select when all the possible props are passed into it 1`] = `
+exports[`should render a Select when all the possible props are passed into it 1`] = `
 <select
   aria-required="true"
   className="select"
   name="description"
-  required={true}>
+  required={true}
+>
   <option
-    value="m">
+    value="m"
+  >
     moo
   </option>
 </select>
 `;
 
-exports[`test should render a default Select component 1`] = `
+exports[`should render a default Select component 1`] = `
 <select
   className="select"
   name={null}
-  required={false} />
+  required={false}
+/>
 `;
 
-exports[`test should render as controlled when just the required fields and a onChange function is passed into the Select 1`] = `
+exports[`should render as controlled when just the required fields and a onChange function is passed into the Select 1`] = `
 <Select
   choices={null}
   name={null}
@@ -47,25 +54,29 @@ exports[`test should render as controlled when just the required fields and a on
       },
     ]
   }
-  required={false}>
+  required={false}
+>
   <select
     className="select"
     name={null}
     onChange={[Function]}
-    required={false}>
+    required={false}
+  >
     <option
-      value="m">
+      value="m"
+    >
       moo
     </option>
     <option
-      value="b">
+      value="b"
+    >
       boo
     </option>
   </select>
 </Select>
 `;
 
-exports[`test should render as uncontrolled when just the required fields and a default value is passed into the Select 1`] = `
+exports[`should render as uncontrolled when just the required fields and a default value is passed into the Select 1`] = `
 <Select
   choices={null}
   defaultValue="b"
@@ -82,18 +93,22 @@ exports[`test should render as uncontrolled when just the required fields and a 
       },
     ]
   }
-  required={false}>
+  required={false}
+>
   <select
     className="select"
     defaultValue="b"
     name={null}
-    required={false}>
+    required={false}
+  >
     <option
-      value="m">
+      value="m"
+    >
       moo
     </option>
     <option
-      value="b">
+      value="b"
+    >
       boo
     </option>
   </select>

--- a/packages/terra-form/tests/jest/__snapshots__/SelectField.test.jsx.snap
+++ b/packages/terra-form/tests/jest/__snapshots__/SelectField.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test should render a SelectField when all the possible props are passed into it 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a SelectField when all the possible props are passed into it 1`] = `
 <Field
   error="jinkies!"
   help="solve the mystery"
@@ -9,7 +11,8 @@ exports[`test should render a SelectField when all the possible props are passed
       "className": "mystery-van",
     }
   }
-  required={true}>
+  required={true}
+>
   <Select
     choices={null}
     className="scooby-snacks"
@@ -26,18 +29,20 @@ exports[`test should render a SelectField when all the possible props are passed
         },
       ]
     }
-    required={true} />
+    required={true}
+  />
 </Field>
 `;
 
-exports[`test should render a default SelectField component 1`] = `
+exports[`should render a default SelectField component 1`] = `
 <Field
   error={null}
   help={null}
   isInline={false}
   label={null}
   labelAttrs={Object {}}
-  required={false}>
+  required={false}
+>
   <Select
     choices={null}
     name={null}
@@ -49,11 +54,12 @@ exports[`test should render a default SelectField component 1`] = `
         },
       ]
     }
-    required={false} />
+    required={false}
+  />
 </Field>
 `;
 
-exports[`test should render as controlled when just the required fields and a onChange function is passed into the SelectField 1`] = `
+exports[`should render as controlled when just the required fields and a onChange function is passed into the SelectField 1`] = `
 <SelectField
   choices={null}
   error={null}
@@ -76,16 +82,19 @@ exports[`test should render as controlled when just the required fields and a on
     ]
   }
   required={false}
-  selectAttrs={Object {}}>
+  selectAttrs={Object {}}
+>
   <Field
     error={null}
     help={null}
     isInline={false}
     label={null}
     labelAttrs={Object {}}
-    required={false}>
+    required={false}
+  >
     <div
-      className="field">
+      className="field"
+    >
       <Select
         choices={null}
         name={null}
@@ -102,18 +111,22 @@ exports[`test should render as controlled when just the required fields and a on
             },
           ]
         }
-        required={false}>
+        required={false}
+      >
         <select
           className="select"
           name={null}
           onChange={[Function]}
-          required={false}>
+          required={false}
+        >
           <option
-            value="m">
+            value="m"
+          >
             moo
           </option>
           <option
-            value="b">
+            value="b"
+          >
             boo
           </option>
         </select>
@@ -123,7 +136,7 @@ exports[`test should render as controlled when just the required fields and a on
 </SelectField>
 `;
 
-exports[`test should render as uncontrolled when just the required fields and a default value is passed into the SelectField 1`] = `
+exports[`should render as uncontrolled when just the required fields and a default value is passed into the SelectField 1`] = `
 <SelectField
   choices={null}
   defaultValue="b"
@@ -146,16 +159,19 @@ exports[`test should render as uncontrolled when just the required fields and a 
     ]
   }
   required={false}
-  selectAttrs={Object {}}>
+  selectAttrs={Object {}}
+>
   <Field
     error={null}
     help={null}
     isInline={false}
     label={null}
     labelAttrs={Object {}}
-    required={false}>
+    required={false}
+  >
     <div
-      className="field">
+      className="field"
+    >
       <Select
         choices={null}
         defaultValue="b"
@@ -172,18 +188,22 @@ exports[`test should render as uncontrolled when just the required fields and a 
             },
           ]
         }
-        required={false}>
+        required={false}
+      >
         <select
           className="select"
           defaultValue="b"
           name={null}
-          required={false}>
+          required={false}
+        >
           <option
-            value="m">
+            value="m"
+          >
             moo
           </option>
           <option
-            value="b">
+            value="b"
+          >
             boo
           </option>
         </select>

--- a/packages/terra-form/tests/jest/__snapshots__/TextField.test.jsx.snap
+++ b/packages/terra-form/tests/jest/__snapshots__/TextField.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test should render a TextField with the rest of the props 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a TextField with the rest of the props 1`] = `
 <Field
   error="This field is required"
   help="This will not be shared with outside sources"
@@ -10,7 +12,8 @@ exports[`test should render a TextField with the rest of the props 1`] = `
       "className": "healtheintent-legend",
     }
   }
-  required={true}>
+  required={true}
+>
   <Input
     className="healtheintent-application"
     id="email"
@@ -18,28 +21,31 @@ exports[`test should render a TextField with the rest of the props 1`] = `
     minLength={8}
     name="email"
     required={true}
-    type="email" />
+    type="email"
+  />
 </Field>
 `;
 
-exports[`test should render a default TextField component 1`] = `
+exports[`should render a default TextField component 1`] = `
 <Field
   error={null}
   help={null}
   isInline={false}
   label={null}
   labelAttrs={Object {}}
-  required={false}>
+  required={false}
+>
   <Input
     maxLength={null}
     minLength={null}
     name={null}
     required={false}
-    type="text" />
+    type="text"
+  />
 </Field>
 `;
 
-exports[`test should render as controlled when just a default value is passed into the TextField 1`] = `
+exports[`should render as controlled when just a default value is passed into the TextField 1`] = `
 <TextField
   error={null}
   help={null}
@@ -53,16 +59,19 @@ exports[`test should render as controlled when just a default value is passed in
   onChange={[Function]}
   required={false}
   type="text"
-  value="foo">
+  value="foo"
+>
   <Field
     error={null}
     help={null}
     isInline={false}
     label={null}
     labelAttrs={Object {}}
-    required={false}>
+    required={false}
+  >
     <div
-      className="field">
+      className="field"
+    >
       <Input
         maxLength={null}
         minLength={null}
@@ -70,7 +79,8 @@ exports[`test should render as controlled when just a default value is passed in
         onChange={[Function]}
         required={false}
         type="text"
-        value="foo">
+        value="foo"
+      >
         <input
           className="input"
           maxLength={null}
@@ -79,14 +89,15 @@ exports[`test should render as controlled when just a default value is passed in
           onChange={[Function]}
           required={false}
           type="text"
-          value="foo" />
+          value="foo"
+        />
       </Input>
     </div>
   </Field>
 </TextField>
 `;
 
-exports[`test should render as uncontrolled when just a default value is passed into the TextField 1`] = `
+exports[`should render as uncontrolled when just a default value is passed into the TextField 1`] = `
 <TextField
   defaultValue="foo"
   error={null}
@@ -99,23 +110,27 @@ exports[`test should render as uncontrolled when just a default value is passed 
   minLength={null}
   name={null}
   required={false}
-  type="text">
+  type="text"
+>
   <Field
     error={null}
     help={null}
     isInline={false}
     label={null}
     labelAttrs={Object {}}
-    required={false}>
+    required={false}
+  >
     <div
-      className="field">
+      className="field"
+    >
       <Input
         defaultValue="foo"
         maxLength={null}
         minLength={null}
         name={null}
         required={false}
-        type="text">
+        type="text"
+      >
         <input
           className="input"
           defaultValue="foo"
@@ -123,7 +138,8 @@ exports[`test should render as uncontrolled when just a default value is passed 
           minLength={null}
           name={null}
           required={false}
-          type="text" />
+          type="text"
+        />
       </Input>
     </div>
   </Field>

--- a/packages/terra-form/tests/jest/__snapshots__/Textarea.test.jsx.snap
+++ b/packages/terra-form/tests/jest/__snapshots__/Textarea.test.jsx.snap
@@ -1,44 +1,52 @@
-exports[`test should render a TextArea when all the possible props are passed into it 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a TextArea when all the possible props are passed into it 1`] = `
 <textarea
   aria-required="true"
   className="textarea"
   cols={15}
   name="description"
   required={true}
-  rows={5} />
+  rows={5}
+/>
 `;
 
-exports[`test should render a default TextArea component 1`] = `
+exports[`should render a default TextArea component 1`] = `
 <textarea
   className="textarea"
   name={null}
-  required={false} />
+  required={false}
+/>
 `;
 
-exports[`test should render as controlled when just a default value is passed into the Textarea 1`] = `
+exports[`should render as controlled when just a default value is passed into the Textarea 1`] = `
 <Textarea
   name={null}
   onChange={[Function]}
   required={false}
-  value="foo">
+  value="foo"
+>
   <textarea
     className="textarea"
     name={null}
     onChange={[Function]}
     required={false}
-    value="foo" />
+    value="foo"
+  />
 </Textarea>
 `;
 
-exports[`test should render as uncontrolled when just a default value is passed into the Textarea 1`] = `
+exports[`should render as uncontrolled when just a default value is passed into the Textarea 1`] = `
 <Textarea
   defaultValue="foo"
   name={null}
-  required={false}>
+  required={false}
+>
   <textarea
     className="textarea"
     defaultValue="foo"
     name={null}
-    required={false} />
+    required={false}
+  />
 </Textarea>
 `;

--- a/packages/terra-form/tests/jest/__snapshots__/TextareaField.test.jsx.snap
+++ b/packages/terra-form/tests/jest/__snapshots__/TextareaField.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test should render a TextAreaField with the rest of the props 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a TextAreaField with the rest of the props 1`] = `
 <Field
   error="Name is required"
   help="The name given to you at birth."
@@ -6,7 +8,8 @@ exports[`test should render a TextAreaField with the rest of the props 1`] = `
   isInline={true}
   label="Profile Description"
   labelAttrs={Object {}}
-  required={true}>
+  required={true}
+>
   <Textarea
     autoFocus={false}
     cols={null}
@@ -15,29 +18,32 @@ exports[`test should render a TextAreaField with the rest of the props 1`] = `
     minLength={5}
     name="profile_description"
     required={true}
-    rows={null} />
+    rows={null}
+  />
 </Field>
 `;
 
-exports[`test should render a default TextAreaField component 1`] = `
+exports[`should render a default TextAreaField component 1`] = `
 <Field
   error={null}
   help={null}
   isInline={false}
   label={null}
   labelAttrs={Object {}}
-  required={false}>
+  required={false}
+>
   <Textarea
     cols={null}
     maxLength={null}
     minLength={null}
     name={null}
     required={false}
-    rows={null} />
+    rows={null}
+  />
 </Field>
 `;
 
-exports[`test should render as controlled when just a default value is passed into the TextareaField 1`] = `
+exports[`should render as controlled when just a default value is passed into the TextareaField 1`] = `
 <TextareaField
   cols={null}
   error={null}
@@ -52,16 +58,19 @@ exports[`test should render as controlled when just a default value is passed in
   onChange={[Function]}
   required={false}
   rows={null}
-  value="foo">
+  value="foo"
+>
   <Field
     error={null}
     help={null}
     isInline={false}
     label={null}
     labelAttrs={Object {}}
-    required={false}>
+    required={false}
+  >
     <div
-      className="field">
+      className="field"
+    >
       <Textarea
         cols={null}
         maxLength={null}
@@ -70,7 +79,8 @@ exports[`test should render as controlled when just a default value is passed in
         onChange={[Function]}
         required={false}
         rows={null}
-        value="foo">
+        value="foo"
+      >
         <textarea
           className="textarea"
           cols={null}
@@ -80,14 +90,15 @@ exports[`test should render as controlled when just a default value is passed in
           onChange={[Function]}
           required={false}
           rows={null}
-          value="foo" />
+          value="foo"
+        />
       </Textarea>
     </div>
   </Field>
 </TextareaField>
 `;
 
-exports[`test should render as uncontrolled when just a default value is passed into the TextareaField 1`] = `
+exports[`should render as uncontrolled when just a default value is passed into the TextareaField 1`] = `
 <TextareaField
   cols={null}
   defaultValue="foo"
@@ -101,16 +112,19 @@ exports[`test should render as uncontrolled when just a default value is passed 
   minLength={null}
   name={null}
   required={false}
-  rows={null}>
+  rows={null}
+>
   <Field
     error={null}
     help={null}
     isInline={false}
     label={null}
     labelAttrs={Object {}}
-    required={false}>
+    required={false}
+  >
     <div
-      className="field">
+      className="field"
+    >
       <Textarea
         cols={null}
         defaultValue="foo"
@@ -118,7 +132,8 @@ exports[`test should render as uncontrolled when just a default value is passed 
         minLength={null}
         name={null}
         required={false}
-        rows={null}>
+        rows={null}
+      >
         <textarea
           className="textarea"
           cols={null}
@@ -127,7 +142,8 @@ exports[`test should render as uncontrolled when just a default value is passed 
           minLength={null}
           name={null}
           required={false}
-          rows={null} />
+          rows={null}
+        />
       </Textarea>
     </div>
   </Field>

--- a/packages/terra-grid/tests/jest/__snapshots__/Grid.test.jsx.snap
+++ b/packages/terra-grid/tests/jest/__snapshots__/Grid.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test should render a default Grid 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default Grid 1`] = `
 <div>
   <GridRow>
     <GridColumn>

--- a/packages/terra-grid/tests/jest/__snapshots__/GridColumn.test.jsx.snap
+++ b/packages/terra-grid/tests/jest/__snapshots__/GridColumn.test.jsx.snap
@@ -1,20 +1,25 @@
-exports[`test should render a default Column 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default Column 1`] = `
 <div
-  className="column">
+  className="column"
+>
   Test
 </div>
 `;
 
-exports[`test should render column with all size breakpoints 1`] = `
+exports[`should render column with all size breakpoints 1`] = `
 <div
-  className="column column-tiny-12 column-small-3 column-medium-2 column-large-1 column-huge-2">
+  className="column column-tiny-12 column-small-3 column-medium-2 column-large-1 column-huge-2"
+>
   Test
 </div>
 `;
 
-exports[`test should render specified width column 1`] = `
+exports[`should render specified width column 1`] = `
 <div
-  className="column column-3">
+  className="column column-3"
+>
   Test
 </div>
 `;

--- a/packages/terra-grid/tests/jest/__snapshots__/GridRow.test.jsx.snap
+++ b/packages/terra-grid/tests/jest/__snapshots__/GridRow.test.jsx.snap
@@ -1,6 +1,9 @@
-exports[`test should render a default component 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default component 1`] = `
 <div
-  className="grid">
+  className="grid"
+>
   <GridColumn>
     Test
   </GridColumn>

--- a/packages/terra-heading/tests/jest/__snapshots__/Heading.test.jsx.snap
+++ b/packages/terra-heading/tests/jest/__snapshots__/Heading.test.jsx.snap
@@ -1,3 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`Heading should render a heading component 1`] = `
 <h1
   className="heading level-1 weight-700"
@@ -5,7 +7,8 @@ exports[`Heading should render a heading component 1`] = `
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   Test
 </h1>
 `;
@@ -17,7 +20,8 @@ exports[`Heading should render a heading component with color prop set 1`] = `
     Object {
       "color": "#f00",
     }
-  }>
+  }
+>
   Test
 </h1>
 `;
@@ -29,7 +33,8 @@ exports[`Heading should render a heading component with isItalic prop set 1`] = 
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   Test
 </h1>
 `;
@@ -41,7 +46,8 @@ exports[`Heading should render a heading component with isVisuallyHidden prop se
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   Test
 </h1>
 `;
@@ -53,7 +59,8 @@ exports[`Heading should render a heading component with size prop set 1`] = `
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   Test
 </h1>
 `;
@@ -65,7 +72,8 @@ exports[`Heading should render a heading component with weight prop set 1`] = `
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   Test
 </h1>
 `;
@@ -77,7 +85,8 @@ exports[`Heading should support rendering a string as children 1`] = `
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   String
 </h1>
 `;
@@ -89,7 +98,8 @@ exports[`Heading should support rendering an array of elements as a children 1`]
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   <span>
     Element 1
   </span>
@@ -109,7 +119,8 @@ exports[`Heading should support rendering an element as children 1`] = `
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   <span>
     Element
   </span>

--- a/packages/terra-i18n/tests/jest/__snapshots__/I18nProvider.test.jsx.snap
+++ b/packages/terra-i18n/tests/jest/__snapshots__/I18nProvider.test.jsx.snap
@@ -1,3 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`I18nProvider for snapshot tests renders a default I18nProvider 1`] = `
 <IntlProvider
   locale="en"
@@ -5,7 +7,8 @@ exports[`I18nProvider for snapshot tests renders a default I18nProvider 1`] = `
     Object {
       "Terra": "Terra",
     }
-  }>
+  }
+>
   <div>
     <Children />
   </div>

--- a/packages/terra-i18n/tests/jest/__snapshots__/i18nLoader.test.js.snap
+++ b/packages/terra-i18n/tests/jest/__snapshots__/i18nLoader.test.js.snap
@@ -1,3 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`i18nLoader when callback is not function throws error 1`] = `"Second argument must be function"`;
 
 exports[`i18nLoader when locale is not supported throws error 1`] = `"invalidLocale is not supported, supported locales:en,en-US,en-GB,es,de,fi-FI,fr,pt"`;

--- a/packages/terra-icon/tests/jest/__snapshots__/Icon.test.jsx.snap
+++ b/packages/terra-icon/tests/jest/__snapshots__/Icon.test.jsx.snap
@@ -1,3 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`Icon IconAdd should shallow IconBase 1`] = `
 <IconBase
   ariaLabel={null}
@@ -8,9 +10,11 @@ exports[`Icon IconAdd should shallow IconBase 1`] = `
   isSpin={false}
   viewBox="0 0 48 48"
   width="1em"
-  xmlns="http://www.w3.org/2000/svg">
+  xmlns="http://www.w3.org/2000/svg"
+>
   <path
-    d="M48 21H27V0h-6v21H0v6h21v21h6V27h21z" />
+    d="M48 21H27V0h-6v21H0v6h21v21h6V27h21z"
+  />
 </IconBase>
 `;
 
@@ -23,9 +27,11 @@ exports[`Icon IconComment should render IconBase with custom-class 1`] = `
   height="1em"
   viewbox="0 0 48 48"
   width="1em"
-  xmlns="http://www.w3.org/2000/svg">
+  xmlns="http://www.w3.org/2000/svg"
+>
   <path
-    d="M46 2.1H2a2 2 0 0 0-2 2v28a2 2 0 0 0 2 2h31.2L45 45.9V34.1h1a2 2 0 0 0 2-2v-28a2 2 0 0 0-2-2z" />
+    d="M46 2.1H2a2 2 0 0 0-2 2v28a2 2 0 0 0 2 2h31.2L45 45.9V34.1h1a2 2 0 0 0 2-2v-28a2 2 0 0 0-2-2z"
+  />
 </svg>
 `;
 
@@ -40,9 +46,11 @@ exports[`Icon IconComment should shallow IconBase 1`] = `
   isSpin={false}
   viewBox="0 0 48 48"
   width="1em"
-  xmlns="http://www.w3.org/2000/svg">
+  xmlns="http://www.w3.org/2000/svg"
+>
   <path
-    d="M46 2.1H2a2 2 0 0 0-2 2v28a2 2 0 0 0 2 2h31.2L45 45.9V34.1h1a2 2 0 0 0 2-2v-28a2 2 0 0 0-2-2z" />
+    d="M46 2.1H2a2 2 0 0 0-2 2v28a2 2 0 0 0 2 2h31.2L45 45.9V34.1h1a2 2 0 0 0 2-2v-28a2 2 0 0 0-2-2z"
+  />
 </IconBase>
 `;
 
@@ -57,8 +65,10 @@ exports[`Icon IconSpinner should shallow IconBase 1`] = `
   isSpin={true}
   viewBox="0 0 48 48"
   width="1em"
-  xmlns="http://www.w3.org/2000/svg">
+  xmlns="http://www.w3.org/2000/svg"
+>
   <path
-    d="M24 0a3.8 3.8 0 1 1-3.8 3.8A3.8 3.8 0 0 1 24 0zm0 40.4a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm20.2-20.2a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm-40.4 0A3.8 3.8 0 1 1 0 24a3.8 3.8 0 0 1 3.8-3.8zM38.3 5.9a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zM9.7 34.5a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm0-28.6a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm28.6 28.6a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8z" />
+    d="M24 0a3.8 3.8 0 1 1-3.8 3.8A3.8 3.8 0 0 1 24 0zm0 40.4a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm20.2-20.2a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm-40.4 0A3.8 3.8 0 1 1 0 24a3.8 3.8 0 0 1 3.8-3.8zM38.3 5.9a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zM9.7 34.5a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm0-28.6a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm28.6 28.6a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8z"
+  />
 </IconBase>
 `;

--- a/packages/terra-image/tests/jest/__snapshots__/Image.test.jsx.snap
+++ b/packages/terra-image/tests/jest/__snapshots__/Image.test.jsx.snap
@@ -1,13 +1,17 @@
-exports[`test should render a thumbail image component with fluid behavior 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a thumbail image component with fluid behavior 1`] = `
 <img
   alt="thumbnail image"
   class="image thumbnail fluid"
-  src="" />
+  src=""
+/>
 `;
 
-exports[`test should render a thumbail image component with non-fluid behavior 1`] = `
+exports[`should render a thumbail image component with non-fluid behavior 1`] = `
 <img
   alt="thumbnail image"
   class="image thumbnail"
-  src="" />
+  src=""
+/>
 `;

--- a/packages/terra-list/tests/jest/__snapshots__/List.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/List.test.jsx.snap
@@ -1,53 +1,73 @@
-exports[`test should mount with no items 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should mount with no items 1`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ul
-    className="list" />
+    className="list"
+  />
 </List>
 `;
 
-exports[`test should mount with one items 1`] = `
+exports[`should mount with one items 1`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ul
-    className="list">
+    className="list"
+  >
     <ListItem
-      isSelected={false}>
+      isSelected={false}
+    >
       <li
-        className="list-item" />
+        className="list-item"
+      />
     </ListItem>
   </ul>
 </List>
 `;
 
-exports[`test should render isDivided 1`] = `
+exports[`should render isDivided 1`] = `
 <ul
-  className="list divided">
+  className="list divided"
+>
   <ListItem
-    isSelected={false} />
+    isSelected={false}
+  />
   <ListItem
-    isSelected={false} />
+    isSelected={false}
+  />
   <ListItem
-    isSelected={false} />
+    isSelected={false}
+  />
   <ListItem
-    isSelected={false} />
+    isSelected={false}
+  />
   <ListItem
-    isSelected={false} />
+    isSelected={false}
+  />
 </ul>
 `;
 
-exports[`test should render with items 1`] = `
+exports[`should render with items 1`] = `
 <ul
-  className="list">
+  className="list"
+>
   <ListItem
-    isSelected={false} />
+    isSelected={false}
+  />
   <ListItem
-    isSelected={false} />
+    isSelected={false}
+  />
   <ListItem
-    isSelected={false} />
+    isSelected={false}
+  />
   <ListItem
-    isSelected={false} />
+    isSelected={false}
+  />
   <ListItem
-    isSelected={false} />
+    isSelected={false}
+  />
 </ul>
 `;

--- a/packages/terra-list/tests/jest/__snapshots__/ListItem.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/ListItem.test.jsx.snap
@@ -1,15 +1,20 @@
-exports[`test should mount with isSelectable 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should mount with isSelectable 1`] = `
 <ListItem
   isSelectable={true}
-  isSelected={false}>
+  isSelected={false}
+>
   <li
-    className="list-item is-selectable" />
+    className="list-item is-selectable"
+  />
 </ListItem>
 `;
 
-exports[`test should mount with isSelectable and hasChevron 1`] = `
+exports[`should mount with isSelectable and hasChevron 1`] = `
 <li
-  className="list-item is-selectable">
+  className="list-item is-selectable"
+>
   <Arrange
     align="center"
     fill={
@@ -19,7 +24,8 @@ exports[`test should mount with isSelectable and hasChevron 1`] = `
     }
     fitEnd={
       <span
-        className="chevron">
+        className="chevron"
+      >
         <IconChevronRight
           className=""
           data-name="Layer 1"
@@ -27,27 +33,32 @@ exports[`test should mount with isSelectable and hasChevron 1`] = `
           isBidi={true}
           viewBox="0 0 48 48"
           width="0.8em"
-          xmlns="http://www.w3.org/2000/svg" />
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </span>
-    } />
+    }
+  />
 </li>
 `;
 
-exports[`test should render with className 1`] = `
+exports[`should render with className 1`] = `
 <li
-  className="list-item textClass" />
+  className="list-item textClass"
+/>
 `;
 
-exports[`test should render with content 1`] = `
+exports[`should render with content 1`] = `
 <li
-  className="list-item">
+  className="list-item"
+>
   <p>
     text
   </p>
 </li>
 `;
 
-exports[`test should render with selected 1`] = `
+exports[`should render with selected 1`] = `
 <li
-  className="list-item selected" />
+  className="list-item selected"
+/>
 `;

--- a/packages/terra-list/tests/jest/__snapshots__/MultiSelectList.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/MultiSelectList.test.jsx.snap
@@ -1,21 +1,29 @@
-exports[`test should mount with no items 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should mount with no items 1`] = `
 <MultiSelectList
-  isDivided={false}>
+  isDivided={false}
+>
   <List
-    isDivided={false}>
+    isDivided={false}
+  >
     <ul
-      className="list" />
+      className="list"
+    />
   </List>
 </MultiSelectList>
 `;
 
-exports[`test should mount with one item 1`] = `
+exports[`should mount with one item 1`] = `
 <MultiSelectList
-  isDivided={false}>
+  isDivided={false}
+>
   <List
-    isDivided={false}>
+    isDivided={false}
+  >
     <ul
-      className="list">
+      className="list"
+    >
       <ListItem
         className="stuff1"
         content={
@@ -27,12 +35,14 @@ exports[`test should mount with one item 1`] = `
         isSelected={false}
         onClick={[Function]}
         onKeyDown={[Function]}
-        tabIndex="0">
+        tabIndex="0"
+      >
         <li
           className="list-item is-selectable stuff1"
           onClick={[Function]}
           onKeyDown={[Function]}
-          tabIndex="0">
+          tabIndex="0"
+        >
           <p>
             text1
           </p>
@@ -43,14 +53,16 @@ exports[`test should mount with one item 1`] = `
 </MultiSelectList>
 `;
 
-exports[`test should render a default component 1`] = `
+exports[`should render a default component 1`] = `
 <List
-  isDivided={false} />
+  isDivided={false}
+/>
 `;
 
-exports[`test should render with a selectable and non-selectable item 1`] = `
+exports[`should render with a selectable and non-selectable item 1`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ListItem
     className="stuff1"
     content={
@@ -62,16 +74,19 @@ exports[`test should render with a selectable and non-selectable item 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     isSelectable={false}
-    isSelected={false} />
+    isSelected={false}
+  />
 </List>
 `;
 
-exports[`test should render with isDivided 1`] = `
+exports[`should render with isDivided 1`] = `
 <List
-  isDivided={true}>
+  isDivided={true}
+>
   <ListItem
     className="stuff1"
     content={
@@ -83,13 +98,15 @@ exports[`test should render with isDivided 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
 </List>
 `;
 
-exports[`test should render with items 1`] = `
+exports[`should render with items 1`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ListItem
     className="stuff1"
     content={
@@ -101,7 +118,8 @@ exports[`test should render with items 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff2"
     content={
@@ -113,7 +131,8 @@ exports[`test should render with items 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff3"
     content={
@@ -125,7 +144,8 @@ exports[`test should render with items 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff4"
     content={
@@ -137,7 +157,8 @@ exports[`test should render with items 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff5"
     content={
@@ -149,13 +170,15 @@ exports[`test should render with items 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
 </List>
 `;
 
-exports[`test should select an item when maxSelectionCount is 2 1`] = `
+exports[`should select an item when maxSelectionCount is 2 1`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ListItem
     className="stuff1"
     content={
@@ -167,7 +190,8 @@ exports[`test should select an item when maxSelectionCount is 2 1`] = `
     isSelected={true}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff2"
     content={
@@ -179,7 +203,8 @@ exports[`test should select an item when maxSelectionCount is 2 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff3"
     content={
@@ -191,7 +216,8 @@ exports[`test should select an item when maxSelectionCount is 2 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff4"
     content={
@@ -203,7 +229,8 @@ exports[`test should select an item when maxSelectionCount is 2 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff5"
     content={
@@ -215,13 +242,15 @@ exports[`test should select an item when maxSelectionCount is 2 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
 </List>
 `;
 
-exports[`test should select an item when maxSelectionCount is 2 2`] = `
+exports[`should select an item when maxSelectionCount is 2 2`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ListItem
     className="stuff1"
     content={
@@ -233,7 +262,8 @@ exports[`test should select an item when maxSelectionCount is 2 2`] = `
     isSelected={true}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff2"
     content={
@@ -245,7 +275,8 @@ exports[`test should select an item when maxSelectionCount is 2 2`] = `
     isSelected={true}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff3"
     content={
@@ -257,7 +288,8 @@ exports[`test should select an item when maxSelectionCount is 2 2`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff4"
     content={
@@ -269,7 +301,8 @@ exports[`test should select an item when maxSelectionCount is 2 2`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff5"
     content={
@@ -281,13 +314,15 @@ exports[`test should select an item when maxSelectionCount is 2 2`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
 </List>
 `;
 
-exports[`test should select an item when maxSelectionCount is 2 3`] = `
+exports[`should select an item when maxSelectionCount is 2 3`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ListItem
     className="stuff1"
     content={
@@ -299,7 +334,8 @@ exports[`test should select an item when maxSelectionCount is 2 3`] = `
     isSelected={true}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff2"
     content={
@@ -311,7 +347,8 @@ exports[`test should select an item when maxSelectionCount is 2 3`] = `
     isSelected={true}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff3"
     content={
@@ -323,7 +360,8 @@ exports[`test should select an item when maxSelectionCount is 2 3`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff4"
     content={
@@ -335,7 +373,8 @@ exports[`test should select an item when maxSelectionCount is 2 3`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff5"
     content={
@@ -347,13 +386,15 @@ exports[`test should select an item when maxSelectionCount is 2 3`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
 </List>
 `;
 
-exports[`test should select an item when maxSelectionCount is 2 4`] = `
+exports[`should select an item when maxSelectionCount is 2 4`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ListItem
     className="stuff1"
     content={
@@ -365,7 +406,8 @@ exports[`test should select an item when maxSelectionCount is 2 4`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff2"
     content={
@@ -377,7 +419,8 @@ exports[`test should select an item when maxSelectionCount is 2 4`] = `
     isSelected={true}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff3"
     content={
@@ -389,7 +432,8 @@ exports[`test should select an item when maxSelectionCount is 2 4`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff4"
     content={
@@ -401,7 +445,8 @@ exports[`test should select an item when maxSelectionCount is 2 4`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff5"
     content={
@@ -413,6 +458,7 @@ exports[`test should select an item when maxSelectionCount is 2 4`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
 </List>
 `;

--- a/packages/terra-list/tests/jest/__snapshots__/SingleSelectList.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/SingleSelectList.test.jsx.snap
@@ -1,23 +1,31 @@
-exports[`test should mount with no items 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should mount with no items 1`] = `
 <SingleSelectList
   hasChevrons={false}
-  isDivided={false}>
+  isDivided={false}
+>
   <List
-    isDivided={false}>
+    isDivided={false}
+  >
     <ul
-      className="list" />
+      className="list"
+    />
   </List>
 </SingleSelectList>
 `;
 
-exports[`test should mount with one items 1`] = `
+exports[`should mount with one items 1`] = `
 <SingleSelectList
   hasChevrons={false}
-  isDivided={false}>
+  isDivided={false}
+>
   <List
-    isDivided={false}>
+    isDivided={false}
+  >
     <ul
-      className="list">
+      className="list"
+    >
       <ListItem
         className="stuff1"
         content={
@@ -30,12 +38,14 @@ exports[`test should mount with one items 1`] = `
         isSelected={false}
         onClick={[Function]}
         onKeyDown={[Function]}
-        tabIndex="0">
+        tabIndex="0"
+      >
         <li
           className="list-item is-selectable stuff1"
           onClick={[Function]}
           onKeyDown={[Function]}
-          tabIndex="0">
+          tabIndex="0"
+        >
           <p>
             text1
           </p>
@@ -46,14 +56,16 @@ exports[`test should mount with one items 1`] = `
 </SingleSelectList>
 `;
 
-exports[`test should render a default component 1`] = `
+exports[`should render a default component 1`] = `
 <List
-  isDivided={false} />
+  isDivided={false}
+/>
 `;
 
-exports[`test should render with a selectable and non-selectable item 1`] = `
+exports[`should render with a selectable and non-selectable item 1`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ListItem
     className="stuff1"
     content={
@@ -66,17 +78,20 @@ exports[`test should render with a selectable and non-selectable item 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     hasChevron={false}
     isSelectable={false}
-    isSelected={false} />
+    isSelected={false}
+  />
 </List>
 `;
 
-exports[`test should render with hasChevrons 1`] = `
+exports[`should render with hasChevrons 1`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ListItem
     className="stuff1"
     content={
@@ -89,13 +104,15 @@ exports[`test should render with hasChevrons 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
 </List>
 `;
 
-exports[`test should render with isDivided 1`] = `
+exports[`should render with isDivided 1`] = `
 <List
-  isDivided={true}>
+  isDivided={true}
+>
   <ListItem
     className="stuff1"
     content={
@@ -108,13 +125,15 @@ exports[`test should render with isDivided 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
 </List>
 `;
 
-exports[`test should render with items 1`] = `
+exports[`should render with items 1`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ListItem
     className="stuff1"
     content={
@@ -127,7 +146,8 @@ exports[`test should render with items 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff2"
     content={
@@ -140,7 +160,8 @@ exports[`test should render with items 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff3"
     content={
@@ -153,7 +174,8 @@ exports[`test should render with items 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff4"
     content={
@@ -166,7 +188,8 @@ exports[`test should render with items 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff5"
     content={
@@ -179,13 +202,15 @@ exports[`test should render with items 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
 </List>
 `;
 
-exports[`test should select an item 1`] = `
+exports[`should select an item 1`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ListItem
     className="stuff1"
     content={
@@ -198,7 +223,8 @@ exports[`test should select an item 1`] = `
     isSelected={true}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff2"
     content={
@@ -211,7 +237,8 @@ exports[`test should select an item 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff3"
     content={
@@ -224,7 +251,8 @@ exports[`test should select an item 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff4"
     content={
@@ -237,7 +265,8 @@ exports[`test should select an item 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff5"
     content={
@@ -250,13 +279,15 @@ exports[`test should select an item 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
 </List>
 `;
 
-exports[`test should select an item 2`] = `
+exports[`should select an item 2`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ListItem
     className="stuff1"
     content={
@@ -269,7 +300,8 @@ exports[`test should select an item 2`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff2"
     content={
@@ -282,7 +314,8 @@ exports[`test should select an item 2`] = `
     isSelected={true}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff3"
     content={
@@ -295,7 +328,8 @@ exports[`test should select an item 2`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff4"
     content={
@@ -308,7 +342,8 @@ exports[`test should select an item 2`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff5"
     content={
@@ -321,13 +356,15 @@ exports[`test should select an item 2`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
 </List>
 `;
 
-exports[`test should select an item 3`] = `
+exports[`should select an item 3`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ListItem
     className="stuff1"
     content={
@@ -340,7 +377,8 @@ exports[`test should select an item 3`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff2"
     content={
@@ -353,7 +391,8 @@ exports[`test should select an item 3`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff3"
     content={
@@ -366,7 +405,8 @@ exports[`test should select an item 3`] = `
     isSelected={true}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff4"
     content={
@@ -379,7 +419,8 @@ exports[`test should select an item 3`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff5"
     content={
@@ -392,13 +433,15 @@ exports[`test should select an item 3`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
 </List>
 `;
 
-exports[`test should select an item 4`] = `
+exports[`should select an item 4`] = `
 <List
-  isDivided={false}>
+  isDivided={false}
+>
   <ListItem
     className="stuff1"
     content={
@@ -411,7 +454,8 @@ exports[`test should select an item 4`] = `
     isSelected={true}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff2"
     content={
@@ -424,7 +468,8 @@ exports[`test should select an item 4`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff3"
     content={
@@ -437,7 +482,8 @@ exports[`test should select an item 4`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff4"
     content={
@@ -450,7 +496,8 @@ exports[`test should select an item 4`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
   <ListItem
     className="stuff5"
     content={
@@ -463,6 +510,7 @@ exports[`test should select an item 4`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0" />
+    tabIndex="0"
+  />
 </List>
 `;

--- a/packages/terra-menu/tests/jest/__snapshots__/Menu.test.jsx.snap
+++ b/packages/terra-menu/tests/jest/__snapshots__/Menu.test.jsx.snap
@@ -1,3 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`Menu should render a default component 1`] = `
 <div>
   <Menu
@@ -5,11 +7,13 @@ exports[`Menu should render a default component 1`] = `
     isArrowDisplayed={false}
     isOpen={true}
     onRequestClose={[Function]}
-    targetRef={[Function]}>
+    targetRef={[Function]}
+  >
     <MenuItem
       isSelected={false}
       subMenuItems={Array []}
-      text="testing" />
+      text="testing"
+    />
   </Menu>
   <div
     style={
@@ -17,6 +21,7 @@ exports[`Menu should render a default component 1`] = `
         "height": "20px",
         "width": "20px",
       }
-    } />
+    }
+  />
 </div>
 `;

--- a/packages/terra-modal-manager/tests/jest/__snapshots__/ModalManager.test.jsx.snap
+++ b/packages/terra-modal-manager/tests/jest/__snapshots__/ModalManager.test.jsx.snap
@@ -1,13 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`ModalManger - app - should render the ModalManager with given AppDelegate as source 1`] = `
 <div
-  className="container">
+  className="container"
+>
   <TestContainer
     app={
       AppDelegateInstance {
         "disclose": [Function],
         "dismiss": [Function],
       }
-    } />
+    }
+  />
   <Modal
     ariaLabel="Modal"
     classNameModal="small"
@@ -19,23 +23,27 @@ exports[`ModalManger - app - should render the ModalManager with given AppDelega
     isOpen={false}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <SlideGroup
       isAnimated={true}
-      items={Array []} />
+      items={Array []}
+    />
   </Modal>
 </div>
 `;
 
 exports[`ModalManger - focus lost - should render the ModalManager with focus lost 1`] = `
 <div
-  className="container">
+  className="container"
+>
   <TestContainer
     app={
       AppDelegateInstance {
         "disclose": [Function],
       }
-    } />
+    }
+  />
   <Modal
     ariaLabel="Modal"
     classNameModal=""
@@ -47,23 +55,27 @@ exports[`ModalManger - focus lost - should render the ModalManager with focus lo
     isOpen={false}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <SlideGroup
       isAnimated={false}
-      items={Array []} />
+      items={Array []}
+    />
   </Modal>
 </div>
 `;
 
 exports[`ModalManger - isFocused - should render the ModalManager with focus trapped 1`] = `
 <div
-  className="container">
+  className="container"
+>
   <TestContainer
     app={
       AppDelegateInstance {
         "disclose": [Function],
       }
-    } />
+    }
+  />
   <Modal
     ariaLabel="Modal"
     classNameModal=""
@@ -75,23 +87,27 @@ exports[`ModalManger - isFocused - should render the ModalManager with focus tra
     isOpen={false}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <SlideGroup
       isAnimated={false}
-      items={Array []} />
+      items={Array []}
+    />
   </Modal>
 </div>
 `;
 
 exports[`ModalManger - isMaximized - should render the ModalManager as maximized 1`] = `
 <div
-  className="container">
+  className="container"
+>
   <TestContainer
     app={
       AppDelegateInstance {
         "disclose": [Function],
       }
-    } />
+    }
+  />
   <Modal
     ariaLabel="Modal"
     classNameModal=""
@@ -103,23 +119,27 @@ exports[`ModalManger - isMaximized - should render the ModalManager as maximized
     isOpen={false}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <SlideGroup
       isAnimated={false}
-      items={Array []} />
+      items={Array []}
+    />
   </Modal>
 </div>
 `;
 
 exports[`ModalManger - isOpen - should render the ModalManager as open 1`] = `
 <div
-  className="container">
+  className="container"
+>
   <TestContainer
     app={
       AppDelegateInstance {
         "disclose": [Function],
       }
-    } />
+    }
+  />
   <Modal
     ariaLabel="Modal"
     classNameModal="small"
@@ -131,23 +151,27 @@ exports[`ModalManger - isOpen - should render the ModalManager as open 1`] = `
     isOpen={true}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <SlideGroup
       isAnimated={true}
-      items={Array []} />
+      items={Array []}
+    />
   </Modal>
 </div>
 `;
 
 exports[`ModalManger - modal components - should render the ModalManager with given modal contents 1`] = `
 <div
-  className="container">
+  className="container"
+>
   <TestContainer
     app={
       AppDelegateInstance {
         "disclose": [Function],
       }
-    } />
+    }
+  />
   <Modal
     ariaLabel="Modal"
     classNameModal="small"
@@ -159,49 +183,55 @@ exports[`ModalManger - modal components - should render the ModalManager with gi
     isOpen={true}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <SlideGroup
       isAnimated={true}
       items={
         Array [
           <TestContainer
             app={
-                AppDelegateInstance {
-                    "closeDisclosure": [Function],
-                    "disclose": [Function],
-                    "dismiss": [Function],
-                    "maximize": [Function],
-                    "requestFocus": [Function],
-                  }
+              AppDelegateInstance {
+                "closeDisclosure": [Function],
+                "disclose": [Function],
+                "dismiss": [Function],
+                "maximize": [Function],
+                "requestFocus": [Function],
+              }
             }
-            display="NUMBER 1" />,
+            display="NUMBER 1"
+          />,
           <TestContainer
             app={
-                AppDelegateInstance {
-                    "closeDisclosure": [Function],
-                    "disclose": [Function],
-                    "dismiss": [Function],
-                    "goBack": [Function],
-                    "maximize": [Function],
-                    "requestFocus": [Function],
-                  }
+              AppDelegateInstance {
+                "closeDisclosure": [Function],
+                "disclose": [Function],
+                "dismiss": [Function],
+                "goBack": [Function],
+                "maximize": [Function],
+                "requestFocus": [Function],
+              }
             }
-            display="NUMBER 2" />,
+            display="NUMBER 2"
+          />,
         ]
-      } />
+      }
+    />
   </Modal>
 </div>
 `;
 
 exports[`ModalManger - modal components - should render the ModalManager with given modal contents when components cannot be retrieved 1`] = `
 <div
-  className="container">
+  className="container"
+>
   <TestContainer
     app={
       AppDelegateInstance {
         "disclose": [Function],
       }
-    } />
+    }
+  />
   <Modal
     ariaLabel="Modal"
     classNameModal=""
@@ -213,7 +243,8 @@ exports[`ModalManger - modal components - should render the ModalManager with gi
     isOpen={true}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <SlideGroup
       isAnimated={false}
       items={
@@ -221,20 +252,23 @@ exports[`ModalManger - modal components - should render the ModalManager with gi
           undefined,
           undefined,
         ]
-      } />
+      }
+    />
   </Modal>
 </div>
 `;
 
 exports[`ModalManger - modal components - should render the ModalManager with given modal contents when maximized 1`] = `
 <div
-  className="container">
+  className="container"
+>
   <TestContainer
     app={
       AppDelegateInstance {
         "disclose": [Function],
       }
-    } />
+    }
+  />
   <Modal
     ariaLabel="Modal"
     classNameModal=""
@@ -246,49 +280,55 @@ exports[`ModalManger - modal components - should render the ModalManager with gi
     isOpen={true}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <SlideGroup
       isAnimated={false}
       items={
         Array [
           <TestContainer
             app={
-                AppDelegateInstance {
-                    "closeDisclosure": [Function],
-                    "disclose": [Function],
-                    "dismiss": [Function],
-                    "minimize": [Function],
-                    "requestFocus": [Function],
-                  }
+              AppDelegateInstance {
+                "closeDisclosure": [Function],
+                "disclose": [Function],
+                "dismiss": [Function],
+                "minimize": [Function],
+                "requestFocus": [Function],
+              }
             }
-            display="NUMBER 1" />,
+            display="NUMBER 1"
+          />,
           <TestContainer
             app={
-                AppDelegateInstance {
-                    "closeDisclosure": [Function],
-                    "disclose": [Function],
-                    "dismiss": [Function],
-                    "goBack": [Function],
-                    "minimize": [Function],
-                    "requestFocus": [Function],
-                  }
+              AppDelegateInstance {
+                "closeDisclosure": [Function],
+                "disclose": [Function],
+                "dismiss": [Function],
+                "goBack": [Function],
+                "minimize": [Function],
+                "requestFocus": [Function],
+              }
             }
-            display="NUMBER 2" />,
+            display="NUMBER 2"
+          />,
         ]
-      } />
+      }
+    />
   </Modal>
 </div>
 `;
 
 exports[`ModalManger - sizes - should render the ModalManager with huge size 1`] = `
 <div
-  className="container">
+  className="container"
+>
   <TestContainer
     app={
       AppDelegateInstance {
         "disclose": [Function],
       }
-    } />
+    }
+  />
   <Modal
     ariaLabel="Modal"
     classNameModal="huge"
@@ -300,23 +340,27 @@ exports[`ModalManger - sizes - should render the ModalManager with huge size 1`]
     isOpen={false}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <SlideGroup
       isAnimated={true}
-      items={Array []} />
+      items={Array []}
+    />
   </Modal>
 </div>
 `;
 
 exports[`ModalManger - sizes - should render the ModalManager with large size 1`] = `
 <div
-  className="container">
+  className="container"
+>
   <TestContainer
     app={
       AppDelegateInstance {
         "disclose": [Function],
       }
-    } />
+    }
+  />
   <Modal
     ariaLabel="Modal"
     classNameModal="large"
@@ -328,23 +372,27 @@ exports[`ModalManger - sizes - should render the ModalManager with large size 1`
     isOpen={false}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <SlideGroup
       isAnimated={true}
-      items={Array []} />
+      items={Array []}
+    />
   </Modal>
 </div>
 `;
 
 exports[`ModalManger - sizes - should render the ModalManager with medium size 1`] = `
 <div
-  className="container">
+  className="container"
+>
   <TestContainer
     app={
       AppDelegateInstance {
         "disclose": [Function],
       }
-    } />
+    }
+  />
   <Modal
     ariaLabel="Modal"
     classNameModal="medium"
@@ -356,23 +404,27 @@ exports[`ModalManger - sizes - should render the ModalManager with medium size 1
     isOpen={false}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <SlideGroup
       isAnimated={true}
-      items={Array []} />
+      items={Array []}
+    />
   </Modal>
 </div>
 `;
 
 exports[`ModalManger - sizes - should render the ModalManager with small size 1`] = `
 <div
-  className="container">
+  className="container"
+>
   <TestContainer
     app={
       AppDelegateInstance {
         "disclose": [Function],
       }
-    } />
+    }
+  />
   <Modal
     ariaLabel="Modal"
     classNameModal="small"
@@ -384,23 +436,27 @@ exports[`ModalManger - sizes - should render the ModalManager with small size 1`
     isOpen={false}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <SlideGroup
       isAnimated={true}
-      items={Array []} />
+      items={Array []}
+    />
   </Modal>
 </div>
 `;
 
 exports[`ModalManger - sizes - should render the ModalManager with tiny size 1`] = `
 <div
-  className="container">
+  className="container"
+>
   <TestContainer
     app={
       AppDelegateInstance {
         "disclose": [Function],
       }
-    } />
+    }
+  />
   <Modal
     ariaLabel="Modal"
     classNameModal="tiny"
@@ -412,23 +468,27 @@ exports[`ModalManger - sizes - should render the ModalManager with tiny size 1`]
     isOpen={false}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <SlideGroup
       isAnimated={true}
-      items={Array []} />
+      items={Array []}
+    />
   </Modal>
 </div>
 `;
 
 exports[`ModalManger should render the ModalManager with defaults 1`] = `
 <div
-  className="container">
+  className="container"
+>
   <TestContainer
     app={
       AppDelegateInstance {
         "disclose": [Function],
       }
-    } />
+    }
+  />
   <Modal
     ariaLabel="Modal"
     classNameModal="small"
@@ -440,10 +500,12 @@ exports[`ModalManger should render the ModalManager with defaults 1`] = `
     isOpen={false}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <SlideGroup
       isAnimated={true}
-      items={Array []} />
+      items={Array []}
+    />
   </Modal>
 </div>
 `;

--- a/packages/terra-modal/tests/jest/__snapshots__/Modal.test.jsx.snap
+++ b/packages/terra-modal/tests/jest/__snapshots__/Modal.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test should mount an open modal 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should mount an open modal 1`] = `
 <ModalExample>
   <div>
     <Modal
@@ -12,22 +14,25 @@ exports[`test should mount an open modal 1`] = `
       isOpen={true}
       isScrollable={false}
       onRequestClose={[Function]}
-      role="document">
+      role="document"
+    >
       <Portal
         isOpened={true}
         onClose={[Function]}
         onOpen={[Function]}
-        onUpdate={[Function]} />
+        onUpdate={[Function]}
+      />
     </Modal>
     <button
-      onClick={[Function]}>
+      onClick={[Function]}
+    >
       Open Modal
     </button>
   </div>
 </ModalExample>
 `;
 
-exports[`test should render an open modal 1`] = `
+exports[`should render an open modal 1`] = `
 <div>
   <button>
     Open Modal
@@ -35,7 +40,7 @@ exports[`test should render an open modal 1`] = `
 </div>
 `;
 
-exports[`test should shallow an open modal 1`] = `
+exports[`should shallow an open modal 1`] = `
 <div>
   <Modal
     ariaLabel="Terra Modal"
@@ -48,19 +53,22 @@ exports[`test should shallow an open modal 1`] = `
     isOpen={true}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document">
+    role="document"
+  >
     <div>
       <h1>
         Terra Modal
       </h1>
       <button
-        onClick={[Function]}>
+        onClick={[Function]}
+      >
         Close Modal
       </button>
     </div>
   </Modal>
   <button
-    onClick={[Function]}>
+    onClick={[Function]}
+  >
     Open Modal
   </button>
 </div>

--- a/packages/terra-overlay/tests/jest/__snapshots__/LoadingOverlay.test.jsx.snap
+++ b/packages/terra-overlay/tests/jest/__snapshots__/LoadingOverlay.test.jsx.snap
@@ -1,12 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`LoadingOverlay should render a null component when isOpen is not provided 1`] = `null`;
 
 exports[`LoadingOverlay when isOpen is provided should render with message prop 1`] = `
 <div>
   <div
     class="overlay fullscreen light loading-overlay"
-    tabindex="0">
+    tabindex="0"
+  >
     <div
-      class="content">
+      class="content"
+    >
       <svg
         aria-hidden="true"
         class="icon icon"
@@ -15,12 +19,15 @@ exports[`LoadingOverlay when isOpen is provided should render with message prop 
         height="36"
         viewbox="0 0 48 48"
         width="36"
-        xmlns="http://www.w3.org/2000/svg">
+        xmlns="http://www.w3.org/2000/svg"
+      >
         <path
-          d="M24 0a3.8 3.8 0 1 1-3.8 3.8A3.8 3.8 0 0 1 24 0zm0 40.4a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm20.2-20.2a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm-40.4 0A3.8 3.8 0 1 1 0 24a3.8 3.8 0 0 1 3.8-3.8zM38.3 5.9a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zM9.7 34.5a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm0-28.6a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm28.6 28.6a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8z" />
+          d="M24 0a3.8 3.8 0 1 1-3.8 3.8A3.8 3.8 0 0 1 24 0zm0 40.4a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm20.2-20.2a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm-40.4 0A3.8 3.8 0 1 1 0 24a3.8 3.8 0 0 1 3.8-3.8zM38.3 5.9a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zM9.7 34.5a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm0-28.6a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm28.6 28.6a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8z"
+        />
       </svg>
       <div
-        class="message">
+        class="message"
+      >
         Loading!
       </div>
     </div>
@@ -32,9 +39,11 @@ exports[`LoadingOverlay when isOpen is provided the default LoadingOverlay shoul
 <div>
   <div
     class="overlay fullscreen light loading-overlay"
-    tabindex="0">
+    tabindex="0"
+  >
     <div
-      class="content">
+      class="content"
+    >
       <svg
         aria-hidden="true"
         class="icon icon"
@@ -43,12 +52,15 @@ exports[`LoadingOverlay when isOpen is provided the default LoadingOverlay shoul
         height="36"
         viewbox="0 0 48 48"
         width="36"
-        xmlns="http://www.w3.org/2000/svg">
+        xmlns="http://www.w3.org/2000/svg"
+      >
         <path
-          d="M24 0a3.8 3.8 0 1 1-3.8 3.8A3.8 3.8 0 0 1 24 0zm0 40.4a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm20.2-20.2a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm-40.4 0A3.8 3.8 0 1 1 0 24a3.8 3.8 0 0 1 3.8-3.8zM38.3 5.9a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zM9.7 34.5a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm0-28.6a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm28.6 28.6a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8z" />
+          d="M24 0a3.8 3.8 0 1 1-3.8 3.8A3.8 3.8 0 0 1 24 0zm0 40.4a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm20.2-20.2a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm-40.4 0A3.8 3.8 0 1 1 0 24a3.8 3.8 0 0 1 3.8-3.8zM38.3 5.9a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zM9.7 34.5a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm0-28.6a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8zm28.6 28.6a3.8 3.8 0 1 1-3.8 3.8 3.8 3.8 0 0 1 3.8-3.8z"
+        />
       </svg>
       <div
-        class="message">
+        class="message"
+      >
         Loading...
       </div>
     </div>

--- a/packages/terra-overlay/tests/jest/__snapshots__/Overlay.test.jsx.snap
+++ b/packages/terra-overlay/tests/jest/__snapshots__/Overlay.test.jsx.snap
@@ -1,3 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`Overlay should render a null component when isOpen is not provided 1`] = `null`;
 
 exports[`Overlay when isOpen is provided -backgroundStyle- should render with the clear backgroundStyle 1`] = `
@@ -6,13 +8,16 @@ exports[`Overlay when isOpen is provided -backgroundStyle- should render with th
   active={true}
   focusTrapOptions={Object {}}
   paused={false}
-  tag="div">
+  tag="div"
+>
   <div
     className="overlay fullscreen clear"
     onClick={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <div
-      className="content" />
+      className="content"
+    />
   </div>
 </FocusTrap>
 `;
@@ -23,13 +28,16 @@ exports[`Overlay when isOpen is provided -backgroundStyle- should render with th
   active={true}
   focusTrapOptions={Object {}}
   paused={false}
-  tag="div">
+  tag="div"
+>
   <div
     className="overlay fullscreen dark"
     onClick={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <div
-      className="content" />
+      className="content"
+    />
   </div>
 </FocusTrap>
 `;
@@ -40,13 +48,16 @@ exports[`Overlay when isOpen is provided -backgroundStyle- should render with th
   active={true}
   focusTrapOptions={Object {}}
   paused={false}
-  tag="div">
+  tag="div"
+>
   <div
     className="overlay fullscreen light"
     onClick={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <div
-      className="content" />
+      className="content"
+    />
   </div>
 </FocusTrap>
 `;
@@ -57,13 +68,16 @@ exports[`Overlay when isOpen is provided -default Overlay when isOpen- should re
   active={true}
   focusTrapOptions={Object {}}
   paused={false}
-  tag="div">
+  tag="div"
+>
   <div
     className="overlay fullscreen light"
     onClick={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <div
-      className="content" />
+      className="content"
+    />
   </div>
 </FocusTrap>
 `;
@@ -74,13 +88,16 @@ exports[`Overlay when isOpen is provided should render with content 1`] = `
   active={true}
   focusTrapOptions={Object {}}
   paused={false}
-  tag="div">
+  tag="div"
+>
   <div
     className="overlay fullscreen light"
     onClick={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <div
-      className="content">
+      className="content"
+    >
       Overlay message
     </div>
   </div>
@@ -91,9 +108,11 @@ exports[`Overlay when isOpen is provided should render with isRelativeToContaine
 <div
   className="overlay container light"
   onClick={[Function]}
-  tabIndex="0">
+  tabIndex="0"
+>
   <div
-    className="content" />
+    className="content"
+  />
 </div>
 `;
 
@@ -103,13 +122,16 @@ exports[`Overlay when isOpen is provided should render with isScrollable 1`] = `
   active={true}
   focusTrapOptions={Object {}}
   paused={false}
-  tag="div">
+  tag="div"
+>
   <div
     className="overlay fullscreen light scrollable"
     onClick={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <div
-      className="content" />
+      className="content"
+    />
   </div>
 </FocusTrap>
 `;
@@ -120,13 +142,16 @@ exports[`Overlay when isOpen is provided should render with onRequestClose 1`] =
   active={true}
   focusTrapOptions={Object {}}
   paused={false}
-  tag="div">
+  tag="div"
+>
   <div
     className="overlay fullscreen light"
     onClick={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <div
-      className="content" />
+      className="content"
+    />
   </div>
 </FocusTrap>
 `;

--- a/packages/terra-overlay/tests/jest/__snapshots__/OverlayContainer.test.jsx.snap
+++ b/packages/terra-overlay/tests/jest/__snapshots__/OverlayContainer.test.jsx.snap
@@ -1,18 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`OverlayContainer should render a default component 1`] = `
 <div
   className="overlay-container"
-  tabIndex="-1" />
+  tabIndex="-1"
+/>
 `;
 
 exports[`OverlayContainer should render when children are provided 1`] = `
 <div
   className="overlay-container"
-  tabIndex="-1">
+  tabIndex="-1"
+>
   <Overlay
     backgroundStyle="light"
     isOpen={false}
     isRelativeToContainer={false}
-    isScrollable={false} />
+    isScrollable={false}
+  />
   Some Text Content
 </div>
 `;

--- a/packages/terra-popup/tests/jest/__snapshots__/Popup.test.jsx.snap
+++ b/packages/terra-popup/tests/jest/__snapshots__/Popup.test.jsx.snap
@@ -1,11 +1,14 @@
-exports[`test should render a default component 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default component 1`] = `
 <div>
   <div
-    style="height:20px;width:20px;" />
+    style="height:20px;width:20px;"
+  />
 </div>
 `;
 
-exports[`test should shallow a default component 1`] = `
+exports[`should shallow a default component 1`] = `
 <div>
   <Popup
     boundingRef={null}
@@ -21,7 +24,8 @@ exports[`test should shallow a default component 1`] = `
     onRequestClose={[Function]}
     releaseFocus={[Function]}
     requestFocus={[Function]}
-    targetRef={[Function]}>
+    targetRef={[Function]}
+  >
     <p>
       this is popup content
     </p>
@@ -32,6 +36,7 @@ exports[`test should shallow a default component 1`] = `
         "height": "20px",
         "width": "20px",
       }
-    } />
+    }
+  />
 </div>
 `;

--- a/packages/terra-profile-image/tests/jest/__snapshots__/ProfileImage.test.jsx.snap
+++ b/packages/terra-profile-image/tests/jest/__snapshots__/ProfileImage.test.jsx.snap
@@ -1,26 +1,31 @@
-exports[`test should render a hidden profile image and a visible avatar image 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a hidden profile image and a visible avatar image 1`] = `
 <div>
   <div
-    className="hidden">
+    className="hidden"
+  >
     <img
       className="image"
       height="75"
       onError={[Function]}
       onLoad={[Function]}
       src="profile.jpg"
-      width="75" />
+      width="75"
+    />
   </div>
   <div>
     <img
       className="image"
       height="75"
       src={Object {}}
-      width="75" />
+      width="75"
+    />
   </div>
 </div>
 `;
 
-exports[`test should render the avatar image 1`] = `
+exports[`should render the avatar image 1`] = `
 <div>
   <div>
     <img
@@ -28,12 +33,13 @@ exports[`test should render the avatar image 1`] = `
       className="image"
       height="75"
       src={Object {}}
-      width="75" />
+      width="75"
+    />
   </div>
 </div>
 `;
 
-exports[`test should render the profile image 1`] = `
+exports[`should render the profile image 1`] = `
 <div>
   <div>
     <img
@@ -43,7 +49,8 @@ exports[`test should render the profile image 1`] = `
       onError={[Function]}
       onLoad={[Function]}
       src="profile.jpg"
-      width="75" />
+      width="75"
+    />
   </div>
 </div>
 `;

--- a/packages/terra-progress-bar/tests/jest/__snapshots__/ProgressBar.test.jsx.snap
+++ b/packages/terra-progress-bar/tests/jest/__snapshots__/ProgressBar.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test should render a ProgressBar component with default heightSize 50% fill and custom props and style 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a ProgressBar component with default heightSize 50% fill and custom props and style 1`] = `
 <progress
   aria-valuemax={100}
   aria-valuemin={0}
@@ -12,10 +14,11 @@ exports[`test should render a ProgressBar component with default heightSize 50% 
     }
   }
   tabIndex="-1"
-  value={50} />
+  value={50}
+/>
 `;
 
-exports[`test should render a ProgressBar component with large heightSize and 60% fill 1`] = `
+exports[`should render a ProgressBar component with large heightSize and 60% fill 1`] = `
 <progress
   aria-valuemax={100}
   aria-valuemin={0}
@@ -29,10 +32,11 @@ exports[`test should render a ProgressBar component with large heightSize and 60
     }
   }
   tabIndex="-1"
-  value={60} />
+  value={60}
+/>
 `;
 
-exports[`test should render a ProgressBar component with tiny heightSize and 15% fill 1`] = `
+exports[`should render a ProgressBar component with tiny heightSize and 15% fill 1`] = `
 <progress
   aria-valuemax={100}
   aria-valuemin={0}
@@ -45,10 +49,11 @@ exports[`test should render a ProgressBar component with tiny heightSize and 15%
     }
   }
   tabIndex="-1"
-  value={15} />
+  value={15}
+/>
 `;
 
-exports[`test should render a default component 1`] = `
+exports[`should render a default component 1`] = `
 <progress
   aria-valuemax={100}
   aria-valuemin={0}
@@ -61,5 +66,6 @@ exports[`test should render a default component 1`] = `
     }
   }
   tabIndex="-1"
-  value={0} />
+  value={0}
+/>
 `;

--- a/packages/terra-props-table/tests/jest/__snapshots__/generateMarkdown.test.js.snap
+++ b/packages/terra-props-table/tests/jest/__snapshots__/generateMarkdown.test.js.snap
@@ -1,3 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`generateMarkdown with valid input should generate a markdown table 1`] = `
 "## ComponentName Props Table
 | Prop Name | Type | Is Required | Default Value | Description |

--- a/packages/terra-props-table/tests/jest/__snapshots__/generatePropRow.test.js.snap
+++ b/packages/terra-props-table/tests/jest/__snapshots__/generatePropRow.test.js.snap
@@ -1,4 +1,6 @@
-exports[`test should return a markdown row 1`] = `"| children| \`node\`| \`required\`| \`center\`| The component(s) that will be wrapped by \`<Base />\`.|"`;
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should return a markdown row 1`] = `"| children| \`node\`| \`required\`| \`center\`| The component(s) that will be wrapped by \`<Base />\`.|"`;
 
 exports[`when defaultValue is not present should return a markdown row without defaultValue 1`] = `"| children| \`node\`| \`required\`| | The component(s) that will be wrapped by \`<Base />\`.|"`;
 

--- a/packages/terra-props-table/tests/jest/__snapshots__/generateProps.test.js.snap
+++ b/packages/terra-props-table/tests/jest/__snapshots__/generateProps.test.js.snap
@@ -1,3 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`generateProps should return a props markdown table 1`] = `
 "| Prop Name | Type | Is Required | Default Value | Description |
 |-|-|-|-|-|

--- a/packages/terra-responsive-element/tests/jest/__snapshots__/ResponsiveElement.test.jsx.snap
+++ b/packages/terra-responsive-element/tests/jest/__snapshots__/ResponsiveElement.test.jsx.snap
@@ -1,6 +1,9 @@
-exports[`test should apply classes passed in through props 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should apply classes passed in through props 1`] = `
 <div
-  className="TestClass" />
+  className="TestClass"
+/>
 `;
 
-exports[`test should render a default component 1`] = `<div />`;
+exports[`should render a default component 1`] = `<div />`;

--- a/packages/terra-search-field/tests/jest/__snapshots__/SearchField.test.jsx.snap
+++ b/packages/terra-search-field/tests/jest/__snapshots__/SearchField.test.jsx.snap
@@ -1,6 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`Snapshots renders a basic search field 1`] = `
 <div
-  className="searchfield">
+  className="searchfield"
+>
   <Input
     className="input"
     name={null}
@@ -8,7 +11,8 @@ exports[`Snapshots renders a basic search field 1`] = `
     placeholder=""
     required={false}
     type="search"
-    value="" />
+    value=""
+  />
   <Button
     className="button"
     isBlock={false}
@@ -17,18 +21,21 @@ exports[`Snapshots renders a basic search field 1`] = `
     isReversed={false}
     onClick={[Function]}
     type="button"
-    variant="default">
+    variant="default"
+  >
     <IconSearch
       data-name="Layer 1"
       viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg" />
+      xmlns="http://www.w3.org/2000/svg"
+    />
   </Button>
 </div>
 `;
 
 exports[`Snapshots renders a search field with a placeholder 1`] = `
 <div
-  className="searchfield">
+  className="searchfield"
+>
   <Input
     className="input"
     name={null}
@@ -36,7 +43,8 @@ exports[`Snapshots renders a search field with a placeholder 1`] = `
     placeholder="Test"
     required={false}
     type="search"
-    value="" />
+    value=""
+  />
   <Button
     className="button"
     isBlock={false}
@@ -45,18 +53,21 @@ exports[`Snapshots renders a search field with a placeholder 1`] = `
     isReversed={false}
     onClick={[Function]}
     type="button"
-    variant="default">
+    variant="default"
+  >
     <IconSearch
       data-name="Layer 1"
       viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg" />
+      xmlns="http://www.w3.org/2000/svg"
+    />
   </Button>
 </div>
 `;
 
 exports[`Snapshots renders a search field with a value 1`] = `
 <div
-  className="searchfield">
+  className="searchfield"
+>
   <Input
     className="input"
     name={null}
@@ -64,7 +75,8 @@ exports[`Snapshots renders a search field with a value 1`] = `
     placeholder=""
     required={false}
     type="search"
-    value="Test" />
+    value="Test"
+  />
   <Button
     className="button"
     isBlock={false}
@@ -73,11 +85,13 @@ exports[`Snapshots renders a search field with a value 1`] = `
     isReversed={false}
     onClick={[Function]}
     type="button"
-    variant="default">
+    variant="default"
+  >
     <IconSearch
       data-name="Layer 1"
       viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg" />
+      xmlns="http://www.w3.org/2000/svg"
+    />
   </Button>
 </div>
 `;

--- a/packages/terra-slide-group/tests/jest/__snapshots__/Slide.test.jsx.snap
+++ b/packages/terra-slide-group/tests/jest/__snapshots__/Slide.test.jsx.snap
@@ -1,21 +1,27 @@
-exports[`test should render a default Slide 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default Slide 1`] = `
 <div
   aria-hidden={null}
-  className="slide">
+  className="slide"
+>
   <div
-    className="slide-shadow" />
+    className="slide-shadow"
+  />
   <div>
     Slide Content
   </div>
 </div>
 `;
 
-exports[`test should render a hidden Slide 1`] = `
+exports[`should render a hidden Slide 1`] = `
 <div
   aria-hidden={true}
-  className="slide">
+  className="slide"
+>
   <div
-    className="slide-shadow" />
+    className="slide-shadow"
+  />
   <div>
     Slide Content
   </div>

--- a/packages/terra-slide-group/tests/jest/__snapshots__/SlideGroup.test.jsx.snap
+++ b/packages/terra-slide-group/tests/jest/__snapshots__/SlideGroup.test.jsx.snap
@@ -1,6 +1,9 @@
-exports[`test should render a SlideGroup with animation enabled 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a SlideGroup with animation enabled 1`] = `
 <div
-  className="slide-group">
+  className="slide-group"
+>
   <CSSTransitionGroup
     transitionAppear={false}
     transitionEnter={true}
@@ -14,21 +17,25 @@ exports[`test should render a SlideGroup with animation enabled 1`] = `
         "leave": "leave",
         "leaveActive": "leave-active",
       }
-    }>
+    }
+  >
     <Slide
-      isHidden={true}>
+      isHidden={true}
+    >
       <div>
         First
       </div>
     </Slide>
     <Slide
-      isHidden={true}>
+      isHidden={true}
+    >
       <div>
         Second
       </div>
     </Slide>
     <Slide
-      isHidden={false}>
+      isHidden={false}
+    >
       <div>
         Third
       </div>
@@ -37,9 +44,10 @@ exports[`test should render a SlideGroup with animation enabled 1`] = `
 </div>
 `;
 
-exports[`test should render a default SlideGroup 1`] = `
+exports[`should render a default SlideGroup 1`] = `
 <div
-  className="slide-group">
+  className="slide-group"
+>
   <CSSTransitionGroup
     transitionAppear={false}
     transitionEnter={false}
@@ -53,21 +61,25 @@ exports[`test should render a default SlideGroup 1`] = `
         "leave": "leave",
         "leaveActive": "leave-active",
       }
-    }>
+    }
+  >
     <Slide
-      isHidden={true}>
+      isHidden={true}
+    >
       <div>
         First
       </div>
     </Slide>
     <Slide
-      isHidden={true}>
+      isHidden={true}
+    >
       <div>
         Second
       </div>
     </Slide>
     <Slide
-      isHidden={false}>
+      isHidden={false}
+    >
       <div>
         Third
       </div>

--- a/packages/terra-slide-panel/tests/jest/__snapshots__/SlidePanel.test.jsx.snap
+++ b/packages/terra-slide-panel/tests/jest/__snapshots__/SlidePanel.test.jsx.snap
@@ -1,71 +1,88 @@
-exports[`test should override user provided attributes that aren't className 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should override user provided attributes that aren't className 1`] = `
 <div
   className="slide-panel pad-this-slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
-  data-test-attr="ahoy thar">
+  data-test-attr="ahoy thar"
+>
   <div
     aria-hidden="true"
-    className="panel" />
+    className="panel"
+  />
   <div
-    className="main" />
+    className="main"
+  />
 </div>
 `;
 
-exports[`test should render a SlidePanel with a fullscreen state 1`] = `
+exports[`should render a SlidePanel with a fullscreen state 1`] = `
 <div
   className="slide-panel is-fullscreen"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
-  data-slide-panel-panel-size="small">
+  data-slide-panel-panel-size="small"
+>
   <div
     aria-hidden="true"
-    className="panel" />
+    className="panel"
+  />
   <div
-    className="main" />
+    className="main"
+  />
 </div>
 `;
 
-exports[`test should render a SlidePanel with an open state 1`] = `
+exports[`should render a SlidePanel with an open state 1`] = `
 <div
   className="slide-panel is-open"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
-  data-slide-panel-panel-size="small">
+  data-slide-panel-panel-size="small"
+>
   <div
     aria-hidden={null}
-    className="panel" />
+    className="panel"
+  />
   <div
-    className="main" />
+    className="main"
+  />
 </div>
 `;
 
-exports[`test should render a SlidePanel with fill 1`] = `
+exports[`should render a SlidePanel with fill 1`] = `
 <div
   className="slide-panel fill"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
-  data-slide-panel-panel-size="small">
+  data-slide-panel-panel-size="small"
+>
   <div
     aria-hidden="true"
-    className="panel" />
+    className="panel"
+  />
   <div
-    className="main" />
+    className="main"
+  />
 </div>
 `;
 
-exports[`test should render a SlidePanel with main content 1`] = `
+exports[`should render a SlidePanel with main content 1`] = `
 <div
   class="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
-  data-slide-panel-panel-size="small">
+  data-slide-panel-panel-size="small"
+>
   <div
     aria-hidden="true"
-    class="panel" />
+    class="panel"
+  />
   <div
-    class="main">
+    class="main"
+  >
     <p>
       Main Content
     </p>
@@ -73,134 +90,161 @@ exports[`test should render a SlidePanel with main content 1`] = `
 </div>
 `;
 
-exports[`test should render a SlidePanel with panel content 1`] = `
+exports[`should render a SlidePanel with panel content 1`] = `
 <div
   class="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
-  data-slide-panel-panel-size="small">
+  data-slide-panel-panel-size="small"
+>
   <div
     aria-hidden="true"
-    class="panel">
+    class="panel"
+  >
     <p>
       Panel Content
     </p>
   </div>
   <div
-    class="main" />
+    class="main"
+  />
 </div>
 `;
 
-exports[`test should render a SlidePanel with panelBehavior = overlay 1`] = `
+exports[`should render a SlidePanel with panelBehavior = overlay 1`] = `
 <div
   className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
-  data-slide-panel-panel-size="small">
+  data-slide-panel-panel-size="small"
+>
   <div
     aria-hidden="true"
-    className="panel" />
+    className="panel"
+  />
   <div
-    className="main" />
+    className="main"
+  />
 </div>
 `;
 
-exports[`test should render a SlidePanel with panelBehavior = squish 1`] = `
+exports[`should render a SlidePanel with panelBehavior = squish 1`] = `
 <div
   className="slide-panel"
   data-slide-panel-panel-behavior="squish"
   data-slide-panel-panel-position="end"
-  data-slide-panel-panel-size="small">
+  data-slide-panel-panel-size="small"
+>
   <div
     aria-hidden="true"
-    className="panel" />
+    className="panel"
+  />
   <div
-    className="main" />
+    className="main"
+  />
 </div>
 `;
 
-exports[`test should render a SlidePanel with panelPosition = end 1`] = `
+exports[`should render a SlidePanel with panelPosition = end 1`] = `
 <div
   className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
-  data-slide-panel-panel-size="small">
+  data-slide-panel-panel-size="small"
+>
   <div
     aria-hidden="true"
-    className="panel" />
+    className="panel"
+  />
   <div
-    className="main" />
+    className="main"
+  />
 </div>
 `;
 
-exports[`test should render a SlidePanel with panelPosition = start 1`] = `
+exports[`should render a SlidePanel with panelPosition = start 1`] = `
 <div
   className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="start"
-  data-slide-panel-panel-size="small">
+  data-slide-panel-panel-size="small"
+>
   <div
     aria-hidden="true"
-    className="panel" />
+    className="panel"
+  />
   <div
-    className="main" />
+    className="main"
+  />
 </div>
 `;
 
-exports[`test should render a SlidePanel with panelSize = large 1`] = `
+exports[`should render a SlidePanel with panelSize = large 1`] = `
 <div
   className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
-  data-slide-panel-panel-size="large">
+  data-slide-panel-panel-size="large"
+>
   <div
     aria-hidden="true"
-    className="panel" />
+    className="panel"
+  />
   <div
-    className="main" />
+    className="main"
+  />
 </div>
 `;
 
-exports[`test should render a SlidePanel with panelSize = small 1`] = `
+exports[`should render a SlidePanel with panelSize = small 1`] = `
 <div
   className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
-  data-slide-panel-panel-size="small">
+  data-slide-panel-panel-size="small"
+>
   <div
     aria-hidden="true"
-    className="panel" />
+    className="panel"
+  />
   <div
-    className="main" />
+    className="main"
+  />
 </div>
 `;
 
-exports[`test should render a SlidePanel with the given extra attributes 1`] = `
+exports[`should render a SlidePanel with the given extra attributes 1`] = `
 <div
   className="slide-panel pad-this-slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
   data-test-attr="ahoy thar"
-  id="my-slide-panel">
+  id="my-slide-panel"
+>
   <div
     aria-hidden="true"
-    className="panel" />
+    className="panel"
+  />
   <div
-    className="main" />
+    className="main"
+  />
 </div>
 `;
 
-exports[`test should render a default SlidePanel with no props 1`] = `
+exports[`should render a default SlidePanel with no props 1`] = `
 <div
   className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
-  data-slide-panel-panel-size="small">
+  data-slide-panel-panel-size="small"
+>
   <div
     aria-hidden="true"
-    className="panel" />
+    className="panel"
+  />
   <div
-    className="main" />
+    className="main"
+  />
 </div>
 `;

--- a/packages/terra-status/tests/jest/__snapshots__/Status.test.jsx.snap
+++ b/packages/terra-status/tests/jest/__snapshots__/Status.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test should render a arrange with status and customProps 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a arrange with status and customProps 1`] = `
 <div
   className="status"
   id="id"
@@ -6,7 +8,8 @@ exports[`test should render a arrange with status and customProps 1`] = `
     Object {
       "borderColor": "green",
     }
-  }>
+  }
+>
   <Arrange
     fill={
       <div>
@@ -23,19 +26,22 @@ exports[`test should render a arrange with status and customProps 1`] = `
             "display": "block",
           }
         }
-        width="300" />
-    } />
+        width="300"
+      />
+    }
+  />
 </div>
 `;
 
-exports[`test should render a icon with status 1`] = `
+exports[`should render a icon with status 1`] = `
 <div
   className="status"
   style={
     Object {
       "borderColor": "grey",
     }
-  }>
+  }
+>
   <svg
     fill="#8bc34a"
     height="100"
@@ -46,21 +52,24 @@ exports[`test should render a icon with status 1`] = `
     }
     viewBox="0 0 1000 1000"
     width="75"
-    xmlns="http://www.w3.org/2000/svg">
+    xmlns="http://www.w3.org/2000/svg"
+  >
     <path
-      d="M525 841.3c-7.5 " />
+      d="M525 841.3c-7.5 "
+    />
   </svg>
 </div>
 `;
 
-exports[`test should render a image with status 1`] = `
+exports[`should render a image with status 1`] = `
 <div
   className="status"
   style={
     Object {
       "borderColor": "red",
     }
-  }>
+  }
+>
   <img
     alt="placeholder"
     height="150"
@@ -70,27 +79,30 @@ exports[`test should render a image with status 1`] = `
         "display": "block",
       }
     }
-    width="300" />
+    width="300"
+  />
 </div>
 `;
 
-exports[`test should render a simpleText with status 1`] = `
+exports[`should render a simpleText with status 1`] = `
 <div
   className="status"
   style={
     Object {
       "borderColor": "blue",
     }
-  }>
+  }
+>
   <div>
     Lorem labore et dolore magna aliqua.
   </div>
 </div>
 `;
 
-exports[`test should render status with no style 1`] = `
+exports[`should render status with no style 1`] = `
 <div
-  class="status">
+  class="status"
+>
   <div>
     Lorem labore et dolore magna aliqua.
   </div>

--- a/packages/terra-table/tests/jest/__snapshots__/SingleSelectableRows.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/SingleSelectableRows.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test should render SingleSelectableRows one selectable row and one non-selectable row 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render SingleSelectableRows one selectable row and one non-selectable row 1`] = `
 <TableRows>
   <TableRow
     className="PERSON_0"
@@ -6,28 +8,36 @@ exports[`test should render SingleSelectableRows one selectable row and one non-
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
   <TableRow
     isSelectable={false}
-    isSelected={false}>
+    isSelected={false}
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
 </TableRows>
 `;
 
-exports[`test should render SingleSelectableRows tag 1`] = `
+exports[`should render SingleSelectableRows tag 1`] = `
 <TableRows>
   <TableRow
     className="PERSON_0"
@@ -35,13 +45,17 @@ exports[`test should render SingleSelectableRows tag 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
   <TableRow
     className="PERSON_1"
@@ -49,18 +63,22 @@ exports[`test should render SingleSelectableRows tag 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
 </TableRows>
 `;
 
-exports[`test should render SingleSelectableRows with maximum height set 1`] = `
+exports[`should render SingleSelectableRows with maximum height set 1`] = `
 <TableRows>
   <TableRow
     className="PERSON_0"
@@ -68,13 +86,17 @@ exports[`test should render SingleSelectableRows with maximum height set 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
   <TableRow
     className="PERSON_1"
@@ -82,20 +104,24 @@ exports[`test should render SingleSelectableRows with maximum height set 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
 </TableRows>
 `;
 
-exports[`test should render SingleSelectableRows with no rows 1`] = `<TableRows />`;
+exports[`should render SingleSelectableRows with no rows 1`] = `<TableRows />`;
 
-exports[`test should render SingleSelectableRows with one row 1`] = `
+exports[`should render SingleSelectableRows with one row 1`] = `
 <TableRows>
   <TableRow
     className="PERSON_0"
@@ -103,18 +129,22 @@ exports[`test should render SingleSelectableRows with one row 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
 </TableRows>
 `;
 
-exports[`test should select an row 1`] = `
+exports[`should select an row 1`] = `
 <TableRows>
   <TableRow
     className="PERSON_0"
@@ -122,13 +152,17 @@ exports[`test should select an row 1`] = `
     isSelected={true}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
   <TableRow
     className="PERSON_1"
@@ -136,18 +170,22 @@ exports[`test should select an row 1`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
 </TableRows>
 `;
 
-exports[`test should select an row 2`] = `
+exports[`should select an row 2`] = `
 <TableRows>
   <TableRow
     className="PERSON_0"
@@ -155,13 +193,17 @@ exports[`test should select an row 2`] = `
     isSelected={false}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
   <TableRow
     className="PERSON_1"
@@ -169,13 +211,17 @@ exports[`test should select an row 2`] = `
     isSelected={true}
     onClick={[Function]}
     onKeyDown={[Function]}
-    tabIndex="0">
+    tabIndex="0"
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
 </TableRows>
 `;

--- a/packages/terra-table/tests/jest/__snapshots__/Table.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/Table.test.jsx.snap
@@ -1,109 +1,147 @@
-exports[`test should render a default table 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default table 1`] = `
 <table
-  className="table striped padded">
+  className="table striped padded"
+>
   <TableHeader>
     <TableHeaderCell
       content="Name"
-      minWidth="small" />
+      minWidth="small"
+    />
     <TableHeaderCell
       content="Address"
-      minWidth="small" />
+      minWidth="small"
+    />
     <TableHeaderCell
       content="Phone Number"
-      minWidth="small" />
+      minWidth="small"
+    />
   </TableHeader>
   <TableRows>
     <TableRow
-      isSelected={false}>
+      isSelected={false}
+    >
       <TableCell
-        content="John Smith" />
+        content="John Smith"
+      />
       <TableCell
-        content="123 Adams Drive" />
+        content="123 Adams Drive"
+      />
       <TableCell
-        content="111-222-3333" />
+        content="111-222-3333"
+      />
     </TableRow>
     <TableRow
-      isSelected={false}>
+      isSelected={false}
+    >
       <TableCell
-        content="John Smith" />
+        content="John Smith"
+      />
       <TableCell
-        content="123 Adams Drive" />
+        content="123 Adams Drive"
+      />
       <TableCell
-        content="111-222-3333" />
+        content="111-222-3333"
+      />
     </TableRow>
   </TableRows>
 </table>
 `;
 
-exports[`test should render a table without padding 1`] = `
+exports[`should render a table without padding 1`] = `
 <table
-  className="table striped">
+  className="table striped"
+>
   <TableHeader>
     <TableHeaderCell
       content="Name"
-      minWidth="small" />
+      minWidth="small"
+    />
     <TableHeaderCell
       content="Address"
-      minWidth="small" />
+      minWidth="small"
+    />
     <TableHeaderCell
       content="Phone Number"
-      minWidth="small" />
+      minWidth="small"
+    />
   </TableHeader>
   <TableRows>
     <TableRow
-      isSelected={false}>
+      isSelected={false}
+    >
       <TableCell
-        content="John Smith" />
+        content="John Smith"
+      />
       <TableCell
-        content="123 Adams Drive" />
+        content="123 Adams Drive"
+      />
       <TableCell
-        content="111-222-3333" />
+        content="111-222-3333"
+      />
     </TableRow>
     <TableRow
-      isSelected={false}>
+      isSelected={false}
+    >
       <TableCell
-        content="John Smith" />
+        content="John Smith"
+      />
       <TableCell
-        content="123 Adams Drive" />
+        content="123 Adams Drive"
+      />
       <TableCell
-        content="111-222-3333" />
+        content="111-222-3333"
+      />
     </TableRow>
   </TableRows>
 </table>
 `;
 
-exports[`test should render a table without zebra stripes 1`] = `
+exports[`should render a table without zebra stripes 1`] = `
 <table
-  className="table padded">
+  className="table padded"
+>
   <TableHeader>
     <TableHeaderCell
       content="Name"
-      minWidth="small" />
+      minWidth="small"
+    />
     <TableHeaderCell
       content="Address"
-      minWidth="small" />
+      minWidth="small"
+    />
     <TableHeaderCell
       content="Phone Number"
-      minWidth="small" />
+      minWidth="small"
+    />
   </TableHeader>
   <TableRows>
     <TableRow
-      isSelected={false}>
+      isSelected={false}
+    >
       <TableCell
-        content="John Smith" />
+        content="John Smith"
+      />
       <TableCell
-        content="123 Adams Drive" />
+        content="123 Adams Drive"
+      />
       <TableCell
-        content="111-222-3333" />
+        content="111-222-3333"
+      />
     </TableRow>
     <TableRow
-      isSelected={false}>
+      isSelected={false}
+    >
       <TableCell
-        content="John Smith" />
+        content="John Smith"
+      />
       <TableCell
-        content="123 Adams Drive" />
+        content="123 Adams Drive"
+      />
       <TableCell
-        content="111-222-3333" />
+        content="111-222-3333"
+      />
     </TableRow>
   </TableRows>
 </table>

--- a/packages/terra-table/tests/jest/__snapshots__/TableHeader.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableHeader.test.jsx.snap
@@ -1,15 +1,20 @@
-exports[`test should render table header tag 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render table header tag 1`] = `
 <thead>
   <tr>
     <TableHeaderCell
       content="Name"
-      minWidth="small" />
+      minWidth="small"
+    />
     <TableHeaderCell
       content="Address"
-      minWidth="small" />
+      minWidth="small"
+    />
     <TableHeaderCell
       content="Phone Number"
-      minWidth="small" />
+      minWidth="small"
+    />
   </tr>
 </thead>
 `;

--- a/packages/terra-table/tests/jest/__snapshots__/TableHeaderContent.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableHeaderContent.test.jsx.snap
@@ -1,49 +1,59 @@
-exports[`test should render default table header content tag 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render default table header content tag 1`] = `
 <th
   className="min-width-small"
-  data-terra-table-header-cell={true}>
+  data-terra-table-header-cell={true}
+>
   Column Heading
 </th>
 `;
 
-exports[`test should render table header content tag with ascending sort indicator 1`] = `
+exports[`should render table header content tag with ascending sort indicator 1`] = `
 <th
   className="min-width-small"
   data-sort="asc"
-  data-terra-table-header-cell={true}>
+  data-terra-table-header-cell={true}
+>
   Column Heading
   <span
-    className="sort-indicator">
+    className="sort-indicator"
+  >
     <IconCaretUp
       className=""
       isBidi={true}
       viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg" />
+      xmlns="http://www.w3.org/2000/svg"
+    />
   </span>
 </th>
 `;
 
-exports[`test should render table header content tag with descending sort indicator 1`] = `
+exports[`should render table header content tag with descending sort indicator 1`] = `
 <th
   className="min-width-small"
   data-sort="desc"
-  data-terra-table-header-cell={true}>
+  data-terra-table-header-cell={true}
+>
   Column Heading
   <span
-    className="sort-indicator">
+    className="sort-indicator"
+  >
     <IconCaretDown
       className=""
       isBidi={true}
       viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg" />
+      xmlns="http://www.w3.org/2000/svg"
+    />
   </span>
 </th>
 `;
 
-exports[`test should render table header content tag with maximum height fixed 1`] = `
+exports[`should render table header content tag with maximum height fixed 1`] = `
 <th
   className="min-width-small"
-  data-terra-table-header-cell={true}>
+  data-terra-table-header-cell={true}
+>
   Column Heading
 </th>
 `;

--- a/packages/terra-table/tests/jest/__snapshots__/TableRow.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableRow.test.jsx.snap
@@ -1,38 +1,52 @@
-exports[`test should render a default table row 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default table row 1`] = `
 <tr
   aria-selected={false}
-  className="row">
+  className="row"
+>
   <TableCell
-    content="John Smith" />
+    content="John Smith"
+  />
   <TableCell
-    content="123 Adams Drive" />
+    content="123 Adams Drive"
+  />
   <TableCell
-    content="111-222-3333" />
+    content="111-222-3333"
+  />
 </tr>
 `;
 
-exports[`test should render a selectable table row 1`] = `
+exports[`should render a selectable table row 1`] = `
 <tr
   aria-selected={false}
-  className="is-selectable row">
+  className="is-selectable row"
+>
   <TableCell
-    content="John Smith" />
+    content="John Smith"
+  />
   <TableCell
-    content="123 Adams Drive" />
+    content="123 Adams Drive"
+  />
   <TableCell
-    content="111-222-3333" />
+    content="111-222-3333"
+  />
 </tr>
 `;
 
-exports[`test should render a selected table row 1`] = `
+exports[`should render a selected table row 1`] = `
 <tr
   aria-selected={true}
-  className="is-selected row">
+  className="is-selected row"
+>
   <TableCell
-    content="John Smith" />
+    content="John Smith"
+  />
   <TableCell
-    content="123 Adams Drive" />
+    content="123 Adams Drive"
+  />
   <TableCell
-    content="111-222-3333" />
+    content="111-222-3333"
+  />
 </tr>
 `;

--- a/packages/terra-table/tests/jest/__snapshots__/TableRowContent.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableRowContent.test.jsx.snap
@@ -1,13 +1,17 @@
-exports[`test should render a default table row content 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default table row content 1`] = `
 <td
-  data-terra-table-cell={true}>
+  data-terra-table-cell={true}
+>
   Table Data
 </td>
 `;
 
-exports[`test should render a table row content with maximum height 1`] = `
+exports[`should render a table row content with maximum height 1`] = `
 <td
-  data-terra-table-cell={true}>
+  data-terra-table-cell={true}
+>
   Table Data
 </td>
 `;

--- a/packages/terra-table/tests/jest/__snapshots__/TableRows.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableRows.test.jsx.snap
@@ -1,61 +1,83 @@
-exports[`test should render TableRows tag 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render TableRows tag 1`] = `
 <tbody>
   <TableRow
-    isSelected={false}>
+    isSelected={false}
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
   <TableRow
-    isSelected={false}>
+    isSelected={false}
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
 </tbody>
 `;
 
-exports[`test should render TableRows with multiple rows 1`] = `
+exports[`should render TableRows with multiple rows 1`] = `
 <tbody>
   <TableRow
-    isSelected={false}>
+    isSelected={false}
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
   <TableRow
-    isSelected={false}>
+    isSelected={false}
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
 </tbody>
 `;
 
-exports[`test should render TableRows with no rows 1`] = `<tbody />`;
+exports[`should render TableRows with no rows 1`] = `<tbody />`;
 
-exports[`test should render TableRows with one row 1`] = `
+exports[`should render TableRows with one row 1`] = `
 <tbody>
   <TableRow
-    isSelected={false}>
+    isSelected={false}
+  >
     <TableCell
-      content="John Smith" />
+      content="John Smith"
+    />
     <TableCell
-      content="123 Adams Drive" />
+      content="123 Adams Drive"
+    />
     <TableCell
-      content="111-222-3333" />
+      content="111-222-3333"
+    />
   </TableRow>
 </tbody>
 `;

--- a/packages/terra-table/tests/jest/__snapshots__/TableSubheader.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableSubheader.test.jsx.snap
@@ -1,9 +1,13 @@
-exports[`test should render table subheader row 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render table subheader row 1`] = `
 <tr
-  data-terra-table-subheader-row={true}>
+  data-terra-table-subheader-row={true}
+>
   <td
     className="subheader"
-    colSpan={4}>
+    colSpan={4}
+  >
     Subheader
   </td>
 </tr>

--- a/packages/terra-text/tests/jest/__snapshots__/Text.test.jsx.snap
+++ b/packages/terra-text/tests/jest/__snapshots__/Text.test.jsx.snap
@@ -1,3 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`Text should render a text component 1`] = `
 <span
   className="text"
@@ -5,7 +7,8 @@ exports[`Text should render a text component 1`] = `
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   Test
 </span>
 `;
@@ -17,7 +20,8 @@ exports[`Text should render a text component with color prop set 1`] = `
     Object {
       "color": "#f00",
     }
-  }>
+  }
+>
   Test
 </span>
 `;
@@ -29,7 +33,8 @@ exports[`Text should render a text component with fontSize prop set 1`] = `
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   Test
 </span>
 `;
@@ -41,7 +46,8 @@ exports[`Text should render a text component with isItalic prop set 1`] = `
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   Test
 </span>
 `;
@@ -53,7 +59,8 @@ exports[`Text should render a text component with isVisuallyHidden prop set 1`] 
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   Test
 </span>
 `;
@@ -65,7 +72,8 @@ exports[`Text should render a text component with weight prop set 1`] = `
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   Test
 </span>
 `;
@@ -77,7 +85,8 @@ exports[`Text should support rendering a string as children 1`] = `
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   String
 </span>
 `;
@@ -89,7 +98,8 @@ exports[`Text should support rendering an array of elements as a children 1`] = 
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   <span>
     Element 1
   </span>
@@ -109,7 +119,8 @@ exports[`Text should support rendering an element as children 1`] = `
     Object {
       "color": "inherit",
     }
-  }>
+  }
+>
   <span>
     Element
   </span>

--- a/packages/terra-theme-provider/tests/jest/__snapshots__/ThemeProvider.test.jsx.snap
+++ b/packages/terra-theme-provider/tests/jest/__snapshots__/ThemeProvider.test.jsx.snap
@@ -1,6 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`ThemeProvider should render a theme provider component 1`] = `
 <div
-  class="cerner-mock-theme">
+  class="cerner-mock-theme"
+>
   <p>
     Child content
   </p>
@@ -9,7 +12,8 @@ exports[`ThemeProvider should render a theme provider component 1`] = `
 
 exports[`ThemeProvider should shallow render a theme provider component 1`] = `
 <div
-  className="cerner-mock-theme">
+  className="cerner-mock-theme"
+>
   <p>
     Child content
   </p>

--- a/packages/terra-time-input/tests/jest/__snapshots__/TimeInput.test.jsx.snap
+++ b/packages/terra-time-input/tests/jest/__snapshots__/TimeInput.test.jsx.snap
@@ -1,10 +1,14 @@
-exports[`test should render a default time input 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default time input 1`] = `
 <div
-  className="time-input">
+  className="time-input"
+>
   <input
     name="time-input"
     type="hidden"
-    value="" />
+    value=""
+  />
   <Input
     className="time-input-hour"
     maxLength="2"
@@ -13,11 +17,12 @@ exports[`test should render a default time input 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    pattern="\\d*"
+    pattern="\\\\d*"
     placeholder="hh"
     required={false}
     type="text"
-    value="" />
+    value=""
+  />
   <span>
     :
   </span>
@@ -29,21 +34,24 @@ exports[`test should render a default time input 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    pattern="\\d*"
+    pattern="\\\\d*"
     placeholder="mm"
     required={false}
     type="text"
-    value="" />
+    value=""
+  />
 </div>
 `;
 
-exports[`test should render a time input with a default time 1`] = `
+exports[`should render a time input with a default time 1`] = `
 <div
-  className="time-input">
+  className="time-input"
+>
   <input
     name="time-input"
     type="hidden"
-    value="T10:45" />
+    value="T10:45"
+  />
   <Input
     className="time-input-hour"
     maxLength="2"
@@ -52,11 +60,12 @@ exports[`test should render a time input with a default time 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    pattern="\\d*"
+    pattern="\\\\d*"
     placeholder="hh"
     required={false}
     type="text"
-    value="10" />
+    value="10"
+  />
   <span>
     :
   </span>
@@ -68,21 +77,24 @@ exports[`test should render a time input with a default time 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    pattern="\\d*"
+    pattern="\\\\d*"
     placeholder="mm"
     required={false}
     type="text"
-    value="45" />
+    value="45"
+  />
 </div>
 `;
 
-exports[`test should render a time input with custom attributes 1`] = `
+exports[`should render a time input with custom attributes 1`] = `
 <div
-  className="time-input">
+  className="time-input"
+>
   <input
     name="time-input"
     type="hidden"
-    value="" />
+    value=""
+  />
   <Input
     className="time-input-hour"
     id="terra-time-input"
@@ -92,11 +104,12 @@ exports[`test should render a time input with custom attributes 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    pattern="\\d*"
+    pattern="\\\\d*"
     placeholder="hh"
     required={false}
     type="text"
-    value="" />
+    value=""
+  />
   <span>
     :
   </span>
@@ -109,21 +122,24 @@ exports[`test should render a time input with custom attributes 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    pattern="\\d*"
+    pattern="\\\\d*"
     placeholder="mm"
     required={false}
     type="text"
-    value="" />
+    value=""
+  />
 </div>
 `;
 
-exports[`test should render a time input with onChange 1`] = `
+exports[`should render a time input with onChange 1`] = `
 <div
-  className="time-input">
+  className="time-input"
+>
   <input
     name="time-input"
     type="hidden"
-    value="" />
+    value=""
+  />
   <Input
     className="time-input-hour"
     maxLength="2"
@@ -132,11 +148,12 @@ exports[`test should render a time input with onChange 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    pattern="\\d*"
+    pattern="\\\\d*"
     placeholder="hh"
     required={false}
     type="text"
-    value="" />
+    value=""
+  />
   <span>
     :
   </span>
@@ -148,10 +165,11 @@ exports[`test should render a time input with onChange 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    pattern="\\d*"
+    pattern="\\\\d*"
     placeholder="mm"
     required={false}
     type="text"
-    value="" />
+    value=""
+  />
 </div>
 `;

--- a/packages/terra-toggle-button/tests/jest/__snapshots__/ToggleButton.test.jsx.snap
+++ b/packages/terra-toggle-button/tests/jest/__snapshots__/ToggleButton.test.jsx.snap
@@ -1,17 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`ToggleButton should render a default toggle-button 1`] = `
 <div
-  class="button">
+  class="button"
+>
   <button
     aria-disabled="false"
     aria-expanded="false"
     class="button default"
-    type="button">
+    type="button"
+  >
     <div
-      class="arrange">
+      class="arrange"
+    >
       <div
-        class="fit center">
+        class="fit center"
+      >
         <span
-          class="icon">
+          class="icon"
+        >
           <svg
             aria-hidden="true"
             class="icon is-bidi"
@@ -20,43 +27,54 @@ exports[`ToggleButton should render a default toggle-button 1`] = `
             height="1em"
             viewbox="0 0 48 48"
             width="1em"
-            xmlns="http://www.w3.org/2000/svg">
+            xmlns="http://www.w3.org/2000/svg"
+          >
             <path
-              d="M37.7 24L14.2 48l-3.9-3.8L30 24 10.3 3.8 14.2 0z" />
+              d="M37.7 24L14.2 48l-3.9-3.8L30 24 10.3 3.8 14.2 0z"
+            />
           </svg>
         </span>
       </div>
       <div
-        class="fill center">
+        class="fill center"
+      >
         <span
-          class="button-text">
+          class="button-text"
+        >
           Show
         </span>
       </div>
       <div
-        class="fit center" />
+        class="fit center"
+      />
     </div>
   </button>
   <div
     aria-hidden="true"
-    class="toggle" />
+    class="toggle"
+  />
 </div>
 `;
 
 exports[`ToggleButton should render an animated toggle-button 1`] = `
 <div
-  class="button">
+  class="button"
+>
   <button
     aria-disabled="false"
     aria-expanded="false"
     class="button default"
-    type="button">
+    type="button"
+  >
     <div
-      class="arrange">
+      class="arrange"
+    >
       <div
-        class="fit center">
+        class="fit center"
+      >
         <span
-          class="icon">
+          class="icon"
+        >
           <svg
             aria-hidden="true"
             class="icon is-bidi"
@@ -65,30 +83,37 @@ exports[`ToggleButton should render an animated toggle-button 1`] = `
             height="1em"
             viewbox="0 0 48 48"
             width="1em"
-            xmlns="http://www.w3.org/2000/svg">
+            xmlns="http://www.w3.org/2000/svg"
+          >
             <path
-              d="M37.7 24L14.2 48l-3.9-3.8L30 24 10.3 3.8 14.2 0z" />
+              d="M37.7 24L14.2 48l-3.9-3.8L30 24 10.3 3.8 14.2 0z"
+            />
           </svg>
         </span>
       </div>
       <div
-        class="fill center">
+        class="fill center"
+      >
         <span
-          class="button-text">
+          class="button-text"
+        >
           Show
         </span>
       </div>
       <div
-        class="fit center" />
+        class="fit center"
+      />
     </div>
   </button>
   <div
     aria-hidden="true"
-    class="toggle">
+    class="toggle"
+  >
     <div
       aria-hidden="false"
       class="rah-static"
-      style="height:0px;overflow:hidden;">
+      style="height:0px;overflow:hidden;"
+    >
       <div>
         Test
       </div>
@@ -99,15 +124,18 @@ exports[`ToggleButton should render an animated toggle-button 1`] = `
 
 exports[`ToggleButton should render an icon only toggle-button 1`] = `
 <div
-  class="button">
+  class="button"
+>
   <button
     aria-disabled="false"
     aria-expanded="false"
     aria-label="Show"
     class="button default"
-    type="button">
+    type="button"
+  >
     <span
-      class="icon">
+      class="icon"
+    >
       <svg
         aria-hidden="true"
         class="icon is-bidi"
@@ -116,32 +144,40 @@ exports[`ToggleButton should render an icon only toggle-button 1`] = `
         height="1em"
         viewbox="0 0 48 48"
         width="1em"
-        xmlns="http://www.w3.org/2000/svg">
+        xmlns="http://www.w3.org/2000/svg"
+      >
         <path
-          d="M37.7 24L14.2 48l-3.9-3.8L30 24 10.3 3.8 14.2 0z" />
+          d="M37.7 24L14.2 48l-3.9-3.8L30 24 10.3 3.8 14.2 0z"
+        />
       </svg>
     </span>
   </button>
   <div
     aria-hidden="true"
-    class="toggle" />
+    class="toggle"
+  />
 </div>
 `;
 
 exports[`ToggleButton should render an initially open toggle-button 1`] = `
 <div
-  class="button is-open">
+  class="button is-open"
+>
   <button
     aria-disabled="false"
     aria-expanded="true"
     class="button default"
-    type="button">
+    type="button"
+  >
     <div
-      class="arrange">
+      class="arrange"
+    >
       <div
-        class="fit center">
+        class="fit center"
+      >
         <span
-          class="icon">
+          class="icon"
+        >
           <svg
             aria-hidden="true"
             class="icon is-bidi"
@@ -150,26 +186,32 @@ exports[`ToggleButton should render an initially open toggle-button 1`] = `
             height="1em"
             viewbox="0 0 48 48"
             width="1em"
-            xmlns="http://www.w3.org/2000/svg">
+            xmlns="http://www.w3.org/2000/svg"
+          >
             <path
-              d="M37.7 24L14.2 48l-3.9-3.8L30 24 10.3 3.8 14.2 0z" />
+              d="M37.7 24L14.2 48l-3.9-3.8L30 24 10.3 3.8 14.2 0z"
+            />
           </svg>
         </span>
       </div>
       <div
-        class="fill center">
+        class="fill center"
+      >
         <span
-          class="button-text">
+          class="button-text"
+        >
           Show
         </span>
       </div>
       <div
-        class="fit center" />
+        class="fit center"
+      />
     </div>
   </button>
   <div
     aria-hidden="false"
-    class="toggle">
+    class="toggle"
+  >
     Test
   </div>
 </div>
@@ -184,14 +226,17 @@ exports[`ToggleButton should render an open toggle-button when clicked 1`] = `
       data-name="Layer 1"
       isBidi={true}
       viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg" />
+      xmlns="http://www.w3.org/2000/svg"
+    />
   }
   isAnimated={false}
   isIconAnimated={false}
   isIconOnly={false}
-  isInitiallyOpen={false}>
+  isInitiallyOpen={false}
+>
   <div
-    className="button is-open">
+    className="button is-open"
+  >
     <Button
       aria-expanded={true}
       isBlock={false}
@@ -200,45 +245,55 @@ exports[`ToggleButton should render an open toggle-button when clicked 1`] = `
       isReversed={false}
       onClick={[Function]}
       type="button"
-      variant="default">
+      variant="default"
+    >
       <button
         aria-disabled={false}
         aria-expanded={true}
         className="button default"
         disabled={false}
         onClick={[Function]}
-        type="button">
+        type="button"
+      >
         <Arrange
           align="center"
           fill={
             <span
-              className="button-text">
+              className="button-text"
+            >
               Show
             </span>
           }
           fitStart={
             <span
-              className="icon">
+              className="icon"
+            >
               <IconChevronRight
                 className=""
                 data-name="Layer 1"
                 isBidi={true}
                 viewBox="0 0 48 48"
-                xmlns="http://www.w3.org/2000/svg" />
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </span>
-          }>
+          }
+        >
           <div
-            className="arrange">
+            className="arrange"
+          >
             <div
-              className="fit center">
+              className="fit center"
+            >
               <span
-                className="icon">
+                className="icon"
+              >
                 <IconChevronRight
                   className=""
                   data-name="Layer 1"
                   isBidi={true}
                   viewBox="0 0 48 48"
-                  xmlns="http://www.w3.org/2000/svg">
+                  xmlns="http://www.w3.org/2000/svg"
+                >
                   <IconBase
                     ariaLabel={null}
                     className=""
@@ -249,7 +304,8 @@ exports[`ToggleButton should render an open toggle-button when clicked 1`] = `
                     isSpin={false}
                     viewBox="0 0 48 48"
                     width="1em"
-                    xmlns="http://www.w3.org/2000/svg">
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
                     <svg
                       aria-hidden="true"
                       className="icon is-bidi"
@@ -258,33 +314,40 @@ exports[`ToggleButton should render an open toggle-button when clicked 1`] = `
                       height="1em"
                       viewBox="0 0 48 48"
                       width="1em"
-                      xmlns="http://www.w3.org/2000/svg">
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
                       <path
-                        d="M37.7 24L14.2 48l-3.9-3.8L30 24 10.3 3.8 14.2 0z" />
+                        d="M37.7 24L14.2 48l-3.9-3.8L30 24 10.3 3.8 14.2 0z"
+                      />
                     </svg>
                   </IconBase>
                 </IconChevronRight>
               </span>
             </div>
             <div
-              className="fill center">
+              className="fill center"
+            >
               <span
-                className="button-text">
+                className="button-text"
+              >
                 Show
               </span>
             </div>
             <div
-              className="fit center" />
+              className="fit center"
+            />
           </div>
         </Arrange>
       </button>
     </Button>
     <Toggle
       isAnimated={false}
-      isOpen={true}>
+      isOpen={true}
+    >
       <div
         aria-hidden={false}
-        className="toggle">
+        className="toggle"
+      >
         Test
       </div>
     </Toggle>
@@ -294,7 +357,8 @@ exports[`ToggleButton should render an open toggle-button when clicked 1`] = `
 
 exports[`ToggleButton should set icon prop correctly 1`] = `
 <div
-  className="button">
+  className="button"
+>
   <Button
     aria-expanded={false}
     isBlock={false}
@@ -303,30 +367,36 @@ exports[`ToggleButton should set icon prop correctly 1`] = `
     isReversed={false}
     onClick={[Function]}
     type="button"
-    variant="default">
+    variant="default"
+  >
     <Arrange
       align="center"
       fill={
         <span
-          className="button-text">
+          className="button-text"
+        >
           Show
         </span>
       }
       fitStart={
         <span
-          className="icon">
+          className="icon"
+        >
           <IconChevronRight
             className=""
             data-name="Layer 1"
             isBidi={true}
             viewBox="0 0 48 48"
-            xmlns="http://www.w3.org/2000/svg" />
+            xmlns="http://www.w3.org/2000/svg"
+          />
         </span>
-      } />
+      }
+    />
   </Button>
   <Toggle
     isAnimated={false}
-    isOpen={false}>
+    isOpen={false}
+  >
     Test
   </Toggle>
 </div>
@@ -334,7 +404,8 @@ exports[`ToggleButton should set icon prop correctly 1`] = `
 
 exports[`ToggleButton should set icon prop correctly with custom icon 1`] = `
 <div
-  className="button">
+  className="button"
+>
   <Button
     aria-expanded={false}
     isBlock={false}
@@ -343,29 +414,35 @@ exports[`ToggleButton should set icon prop correctly with custom icon 1`] = `
     isReversed={false}
     onClick={[Function]}
     type="button"
-    variant="default">
+    variant="default"
+  >
     <Arrange
       align="center"
       fill={
         <span
-          className="button-text">
+          className="button-text"
+        >
           Show
         </span>
       }
       fitStart={
         <span
-          className="icon">
+          className="icon"
+        >
           <IconCaretRight
             className=""
             isBidi={true}
             viewBox="0 0 48 48"
-            xmlns="http://www.w3.org/2000/svg" />
+            xmlns="http://www.w3.org/2000/svg"
+          />
         </span>
-      } />
+      }
+    />
   </Button>
   <Toggle
     isAnimated={false}
-    isOpen={false}>
+    isOpen={false}
+  >
     Test
   </Toggle>
 </div>

--- a/packages/terra-toggle/tests/jest/__snapshots__/Toggle.test.jsx.snap
+++ b/packages/terra-toggle/tests/jest/__snapshots__/Toggle.test.jsx.snap
@@ -1,17 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`Toggle should render a default toggle 1`] = `
 <div
   aria-hidden="true"
-  class="toggle" />
+  class="toggle"
+/>
 `;
 
 exports[`Toggle should render an animated toggle 1`] = `
 <div
   aria-hidden="true"
-  class="toggle">
+  class="toggle"
+>
   <div
     aria-hidden="false"
     class="rah-static"
-    style="height:0px;overflow:hidden;">
+    style="height:0px;overflow:hidden;"
+  >
     <div>
       Test
     </div>
@@ -22,7 +27,8 @@ exports[`Toggle should render an animated toggle 1`] = `
 exports[`Toggle should render an open toggle 1`] = `
 <div
   aria-hidden="false"
-  class="toggle">
+  class="toggle"
+>
   Test
 </div>
 `;


### PR DESCRIPTION
### Summary
Resolves #323 

With Jest v21, compared to Jest v18, snapshots have some changes in how they are rendering.

Closing angle brackets are rendered on their own line.

```diff
<div>
-  className="arrange">
+   className="arrange"
+ >
```

```diff
- variant="default" />
+   variant="default" 
+ />
```

```diff
- }>
+  }
+ >
```

The word `test` is no longer included in export in snapshot

```diff
- exports[`test should render a badge component in the order, icon and text with medium size 1`] = `
+ exports[`should render a badge component in the order, icon and text with medium size 1`] = `
```

Snapshots include version number in snapshot

```diff
+ // Jest Snapshot v1, https://goo.gl/fbAQLP
```

DOM elements / React Components which were empty now render differently

```diff
- <div />
+ <div>
+ 
+ </div>
```

This is the majority of the diffs in this PR.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
