### PR TITLE
Package Level Updates for Jest v21.0.2

### DIFF
--- a/jestconfig.json
+++ b/jestconfig.json
@@ -1,9 +1,9 @@
 {
   "setupFiles": [
-    "../../jestsetup.js"
+    "./jestsetup.js"
   ],
   "snapshotSerializers": [
-    "../../node_modules/enzyme-to-json/serializer"
+    "./node_modules/enzyme-to-json/serializer"
   ],
   "moduleNameMapper": {
     "\\.(css|scss|svg)$": "identity-obj-proxy"

--- a/packages/terra-alert/package.json
+++ b/packages/terra-alert/package.json
@@ -49,7 +49,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Alert.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-app-delegate/package.json
+++ b/packages/terra-app-delegate/package.json
@@ -30,7 +30,7 @@
     "lint": "npm run lint:js",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "echo \"No Nightwath tests written.\" && exit 0"
   }
 }

--- a/packages/terra-arrange/package.json
+++ b/packages/terra-arrange/package.json
@@ -29,7 +29,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Arrange.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   },
   "peerDependencies": {

--- a/packages/terra-badge/package.json
+++ b/packages/terra-badge/package.json
@@ -29,7 +29,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Badge.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   },
   "peerDependencies": {

--- a/packages/terra-base/package.json
+++ b/packages/terra-base/package.json
@@ -41,7 +41,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Base.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-button-group/package.json
+++ b/packages/terra-button-group/package.json
@@ -44,7 +44,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/ButtonGroup.jsx ./src/ButtonGroupButton.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-button/package.json
+++ b/packages/terra-button/package.json
@@ -29,7 +29,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Button.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   },
   "devDependencies": {

--- a/packages/terra-card/package.json
+++ b/packages/terra-card/package.json
@@ -44,7 +44,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Card.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-content-container/package.json
+++ b/packages/terra-content-container/package.json
@@ -42,7 +42,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/ContentContainer.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-date-picker/package.json
+++ b/packages/terra-date-picker/package.json
@@ -56,7 +56,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/DatePicker.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-demographics-banner/package.json
+++ b/packages/terra-demographics-banner/package.json
@@ -44,7 +44,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/DemographicsBanner.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-dynamic-grid/package.json
+++ b/packages/terra-dynamic-grid/package.json
@@ -43,7 +43,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/DynamicGrid.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-embedded-content-consumer/package.json
+++ b/packages/terra-embedded-content-consumer/package.json
@@ -44,7 +44,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/EmbeddedContentConsumer.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-form/package.json
+++ b/packages/terra-form/package.json
@@ -42,7 +42,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Control.jsx ./src/Field.jsx ./src/Fieldset.jsx ./src/Input.jsx ./src/NumberField.jsx ./src/Textarea.jsx ./src/TextareaField.jsx ./src/TextField.jsx ./src/Select.jsx ./src/SelectField.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-grid/package.json
+++ b/packages/terra-grid/package.json
@@ -29,7 +29,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Grid.jsx ./src/GridColumn.jsx ./src/GridRow.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   },
   "devDependencies": {

--- a/packages/terra-heading/package.json
+++ b/packages/terra-heading/package.json
@@ -43,7 +43,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Heading.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-i18n/package.json
+++ b/packages/terra-i18n/package.json
@@ -42,7 +42,7 @@
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "props-table": "props-table ./src/I18nProvider.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-icon/package.json
+++ b/packages/terra-icon/package.json
@@ -53,7 +53,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/IconBase.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-image/package.json
+++ b/packages/terra-image/package.json
@@ -29,7 +29,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Image.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   },
   "devDependencies": {

--- a/packages/terra-list/package.json
+++ b/packages/terra-list/package.json
@@ -45,7 +45,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/List.jsx ./src/SingleSelectList.jsx ./src/MultiSelectList.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-markdown/package.json
+++ b/packages/terra-markdown/package.json
@@ -38,7 +38,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "echo \"props-table is not used here to avoid cyclical package dependencies\"",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-menu/package.json
+++ b/packages/terra-menu/package.json
@@ -54,7 +54,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Menu.jsx ./src/MenuItem.jsx ./src/MenuItemGroup.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-modal-manager/package.json
+++ b/packages/terra-modal-manager/package.json
@@ -51,7 +51,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/ModalManager.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-modal/package.json
+++ b/packages/terra-modal/package.json
@@ -44,7 +44,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Modal.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-overlay/package.json
+++ b/packages/terra-overlay/package.json
@@ -46,7 +46,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Overlay.jsx ./src/OverlayContainer.jsx ./src/LoadingOverlay.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-popup/package.json
+++ b/packages/terra-popup/package.json
@@ -53,7 +53,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Popup.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-profile-image/package.json
+++ b/packages/terra-profile-image/package.json
@@ -29,7 +29,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/ProfileImage.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   },
   "devDependencies": {

--- a/packages/terra-progress-bar/package.json
+++ b/packages/terra-progress-bar/package.json
@@ -29,7 +29,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/ProgressBar.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   },
   "devDependencies": {

--- a/packages/terra-props-table/package.json
+++ b/packages/terra-props-table/package.json
@@ -42,7 +42,7 @@
     "lint": "npm run lint:js",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-responsive-element/package.json
+++ b/packages/terra-responsive-element/package.json
@@ -42,7 +42,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/ResponsiveElement.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-search-field/package.json
+++ b/packages/terra-search-field/package.json
@@ -48,7 +48,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/SearchField.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -24,7 +24,7 @@
     "lint": "npm run lint:js",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "test": "npm run test:spec",
-    "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json"
+    "test:spec": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json"
   },
   "dependencies": {
     "moment": "^2.17.1",

--- a/packages/terra-slide-panel/package.json
+++ b/packages/terra-slide-panel/package.json
@@ -42,7 +42,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/SlidePanel.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-status/package.json
+++ b/packages/terra-status/package.json
@@ -29,7 +29,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Status.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   },
   "devDependencies": {

--- a/packages/terra-table/package.json
+++ b/packages/terra-table/package.json
@@ -44,7 +44,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Table.jsx ./src/TableCell.jsx ./src/TableHeader.jsx ./src/TableRow.jsx ./src/TableRows.jsx ./src/TableSubheader.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-text/package.json
+++ b/packages/terra-text/package.json
@@ -43,7 +43,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Text.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-theme-provider/package.json
+++ b/packages/terra-theme-provider/package.json
@@ -44,7 +44,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/ThemeProvider.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-time-input/package.json
+++ b/packages/terra-time-input/package.json
@@ -45,7 +45,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/TimeInput.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-toggle-button/package.json
+++ b/packages/terra-toggle-button/package.json
@@ -50,7 +50,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/ToggleButton.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-toggle/package.json
+++ b/packages/terra-toggle/package.json
@@ -43,7 +43,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "props-table ./src/Toggle.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }


### PR DESCRIPTION
### Summary
In PR #798, the jest dependency version was updated from v18 to v21.0.2. With this change, package level jest testing was broken. This PR updates the package-level jest configuration and test script to allow for jest testing in each package. 