### PR TITLE
Use uniqueIds for ids on terra-arrange examples

### DIFF
--- a/packages/terra-site/CHANGELOG.md
+++ b/packages/terra-site/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* Fixed title mispelling.
+* Fixed title misspelling.
+* Updated ArrangeAlignment to generate Ids with `_.uniqueId()`.
 
 1.10.0 - (September 12, 2017)
 ------------------

--- a/packages/terra-site/docs/DEPENDENCIES.md
+++ b/packages/terra-site/docs/DEPENDENCIES.md
@@ -3,6 +3,7 @@
 ## dependencies
 | Dependency | Version | React Version | Description |
 |-|-|-|-|
+| lodash | ^4.17.4 | -- | Lodash modular utilities. |
 | moment | ^2.17.1 | -- | Parse, validate, manipulate, and display dates |
 | postcss | ^6.0.9 | -- | Tool for transforming styles with JS plugins |
 | prop-types | ^15.5.8 | -- | Runtime type checking for React props and similar objects. |

--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -27,6 +27,7 @@
     "test:spec": "lerna exec --scope terra-site -- jest ./tests/jest/* --config ../../jestconfig.json"
   },
   "dependencies": {
+    "lodash": "^4.17.4",
     "moment": "^2.17.1",
     "postcss": "^6.0.9",
     "prop-types": "^15.5.8",

--- a/packages/terra-site/src/examples/arrange/ArrangeAlignment.jsx
+++ b/packages/terra-site/src/examples/arrange/ArrangeAlignment.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Arrange from 'terra-arrange';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import _ from 'lodash';
 import { ArrangeWrapper, alignLabels, alignOptions } from './examplesetup';
 
 const alignmentTypes = ['all', 'individual'];
@@ -32,10 +34,14 @@ class ArrangeAlignment extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      id: Math.floor(Math.random() * 0xFFFF),
+      id: undefined,
     };
-    this.getId = this.getId.bind(this);
+
     this.handleSelectChange = this.handleSelectChange.bind(this);
+  }
+
+  componentWillMount() {
+    this.state.id = _.uniqueId();
   }
 
   getId(name) {

--- a/packages/terra-site/src/examples/arrange/ArrangeAlignment.jsx
+++ b/packages/terra-site/src/examples/arrange/ArrangeAlignment.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Arrange from 'terra-arrange';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import _ from 'lodash';
 import { ArrangeWrapper, alignLabels, alignOptions } from './examplesetup';
 


### PR DESCRIPTION
### Summary
This PR
- Closes #389 - Use uniqueIds for ids on terra-arrange examples. 