### PR TITLE
Add OCS clinical background image to terra-base

### DIFF
--- a/packages/terra-base/CHANGELOG.md
+++ b/packages/terra-base/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added OCS clinical background image theme
 
 2.4.0 - (September 19, 2017)
 ------------------

--- a/packages/terra-base/docs/DEPENDENCIES.md
+++ b/packages/terra-base/docs/DEPENDENCIES.md
@@ -6,6 +6,7 @@
 | classnames | ^2.2.5 | -- | A simple utility for conditionally joining classNames together |
 | prop-types | ^15.5.8 | -- | Runtime type checking for React props and similar objects. |
 | terra-i18n | ^1.8.0 | ^15.4.2 | The terra-i18n component provides the internationalization to the React component. Terra supports the following locales: 'de' 'es' 'en' 'en-US' 'en-GB', 'fi-FI', 'fr', 'pt'. All locales related files are loading on demand. |
+| terra-mixins | ^1.10.0 | -- | terra-mixins |
 
 ## devDependencies
 | Dependency | Version | React Version | Description |
@@ -17,3 +18,4 @@
 |-|-|-|-|
 | react | ^15.4.2 | -- | React is a JavaScript library for building user interfaces. |
 | react-dom | ^15.4.2 | ^15.6.1 | React package for working with the DOM. |
+| terra-mixins | ^1.10.0 | -- | terra-mixins |

--- a/packages/terra-base/package.json
+++ b/packages/terra-base/package.json
@@ -25,12 +25,14 @@
   },
   "peerDependencies": {
     "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react-dom": "^15.4.2",
+    "terra-mixins": "^1.10.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-i18n": "^1.8.0"
+    "terra-i18n": "^1.8.0",
+    "terra-mixins": "^1.10.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-base/src/Base.scss
+++ b/packages/terra-base/src/Base.scss
@@ -1,3 +1,6 @@
+@import '~terra-mixins';
+@import './themes';
+
 // Normalize box-sizing.
 // More info: https://css-tricks.com/box-sizing/#article-header-id-6
 html {
@@ -10,7 +13,10 @@ html {
 }
 
 body {
+  // stylelint-disable order/properties-alphabetical-order
+  background-image: var(--terra-base-background-image, none);
   background-color: var(--terra-base-background-color, #fff);
+  // stylelint-enable order/properties-alphabetical-order
   color: var(--terra-base-color, #1c1f21);
   font-size: 1rem;
   height: var(--terra-base-body-height, auto);

--- a/packages/terra-base/src/_themes.scss
+++ b/packages/terra-base/src/_themes.scss
@@ -1,0 +1,14 @@
+@import '~terra-mixins';
+
+@include cerner-clinical-theme {
+  --terra-base-background-image: radial-gradient(50% 50% at 50% 0%, rgba(90, 231, 253, 0.7), rgba(90, 231, 253, 0)),
+    radial-gradient(60% 60% at 50% 50%, rgba(157, 202, 253, 1), rgba(157, 202, 253, 0)),
+    radial-gradient(50% 50% at 50% 100%, rgba(55, 105, 190, 0.7), rgba(55, 105, 190, 0)),
+    radial-gradient(100% 100% at 0% 0%, rgba(29, 175, 236, 0.7), rgba(29, 175, 236, 0)),
+    radial-gradient(100% 100% at 0% 50%, rgba(35, 119, 186, 0.7), rgba(35, 119, 186, 0)),
+    radial-gradient(100% 100% at 0% 100%, rgba(41, 77, 211, 0.7), rgba(41, 77, 211, 0)),
+    radial-gradient(100% 100% at 100% 0%, rgba(148, 179, 252, 0.7), rgba(148, 179, 252, 0.7)),
+    radial-gradient(100% 100% at 100% 50%, rgba(123, 91, 200, 0.7), rgba(123, 91, 200, 0)),
+    radial-gradient(100% 100% at 100% 100%, rgba(32, 79, 185, 0.7), rgba(32, 79, 185, 0)),
+    linear-gradient(rgba(154, 208, 255, 0.7), rgba(154, 208, 255, 0.7));
+}

--- a/packages/terra-card/CHANGELOG.md
+++ b/packages/terra-card/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 -----------------
+### Added
+* Added import for terra-mixins to themes.scss file
 
 1.4.0 - (September 19, 2017)
 ------------------

--- a/packages/terra-card/src/_themes.scss
+++ b/packages/terra-card/src/_themes.scss
@@ -1,3 +1,5 @@
+@import '~terra-mixins';
+
 @include cerner-consumer-theme {
   --terra-card-box-shadow: 0 1px 1px 0 rgba(28, 31, 33, 0.35);
   --terra-card-border: none;

--- a/packages/terra-mixins/CHANGELOG.md
+++ b/packages/terra-mixins/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added cerner-clinical-theme mixin
 
 1.4.0 - (September 19, 2017)
 ------------------

--- a/packages/terra-mixins/src/Mixins.scss
+++ b/packages/terra-mixins/src/Mixins.scss
@@ -43,6 +43,24 @@ $bundled-themes: false !default;
   }
 }
 
+@mixin cerner-clinical-theme {
+  @if index($bundled-themes, 'clinical') {
+    @if $default-theme == 'clinical' {
+      :global {
+        :root {
+          @content;
+        }
+      }
+    } @else {
+      :global {
+        .cerner-clinical-theme {
+          @content;
+        }
+      }
+    }
+  }
+}
+
 /* stylelint-enable selector-class-pattern, scss/at-mixin-pattern  */
 
 

--- a/packages/terra-site/CHANGELOG.md
+++ b/packages/terra-site/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added cerner-clinical-theme
 
 1.11.0 - (September 19, 2017)
 ------------------

--- a/packages/terra-site/src/App.jsx
+++ b/packages/terra-site/src/App.jsx
@@ -102,6 +102,7 @@ class App extends React.Component {
           <label htmlFor="theme"> Theme: </label>
           <select value={this.state.theme} onChange={this.handleThemeChange}>
             <option value="">Default Theme</option>
+            <option value="cerner-clinical-theme">Clinical Theme</option>
             <option value="cerner-consumer-theme">Consumer Theme</option>
             <option value="cerner-mock-theme">Mock Theme</option>
           </select>

--- a/packages/terra-site/themeable-variables.json
+++ b/packages/terra-site/themeable-variables.json
@@ -50,6 +50,7 @@
     "--terra-base-font-size": "87.5%",
     "--terra-base-html-height": "100%",
     "--terra-base-html-margin": "0",
+    "--terra-base-background-image": "none",
     "--terra-base-background-color": "#fff",
     "--terra-base-color": "#1c1f21",
     "--terra-base-body-height": "auto",

--- a/packages/terra-site/webpack.config.js
+++ b/packages/terra-site/webpack.config.js
@@ -63,7 +63,7 @@ module.exports = {
         {
           loader: 'sass-loader',
           options: {
-            data: '$bundled-themes: mock, consumer;',
+            data: '$bundled-themes: mock, clinical, consumer;',
           },
         }],
       }),

--- a/packages/terra-slide-panel/CHANGELOG.md
+++ b/packages/terra-slide-panel/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed background color from main container in slide-panel
 
 1.9.0 - (September 19, 2017)
 ------------------

--- a/packages/terra-slide-panel/src/SlidePanel.scss
+++ b/packages/terra-slide-panel/src/SlidePanel.scss
@@ -7,7 +7,6 @@
 
   .main,
   .panel {
-    background-color: #fff;
     box-sizing: border-box;
 
     height: 100%;
@@ -27,6 +26,7 @@
   }
 
   .panel {
+    background-color: #fff;
     position: absolute;
     z-index: 500; // z-index used to set master above detail in visual stacking context.
   }

--- a/packages/terra-theme-provider/CHANGELOG.md
+++ b/packages/terra-theme-provider/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 -----------------
 ### Added
 * Added isGlobalTheme prop to apply theme to root DOM node
+* Added CLINICAL key to ThemeProvider.opts.ThemeProviderThemes
 
 1.4.0 - (September 19, 2017)
 ------------------

--- a/packages/terra-theme-provider/src/ThemeProvider.jsx
+++ b/packages/terra-theme-provider/src/ThemeProvider.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ThemeProviderThemes = {
+  CLINICAL: 'cerner-clinical-theme',
   CONSUMER: 'cerner-consumer-theme',
   MOCK: 'cerner-mock-theme',
 };


### PR DESCRIPTION
### Summary
Resolves #825 
* Addes cerner-clinical-theme mixin
* Adds background-image style to terra base
* Adds cerner-clinical-theme to terra-base
* Removes background color on slide-panel main container
* Adds `CLINICAL` key to ThemeProvider.opts.ThemeProviderThemes object

### Deployment Link
https://terra-core-deployed-pr-844.herokuapp.com/

To test the clinical theme, go to the deployment link, and switch to the clinical theme using the theme switcher in the top right of the site.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
