### PR TITLE
Update Toggle Docs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,6 +35,7 @@ Cerner Corporation
 - Sai Kaushik Mallela [@msaikaushik1992]
 - Kevin Schuster [@kschuste]
 - Sai Gorantla [@saigorantla]
+- Derek Yu [@yuderekyu]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -73,3 +74,4 @@ Cerner Corporation
 [@msaikaushik1992]: https://github.com/msaikaushik1992
 [@kschuste]: https://github.com/kschuste
 [@saigorantla]: https://github.com/saigorantla
+[@yuderekyu]: https://github.com/yuderekyu

--- a/packages/terra-site/CHANGELOG.md
+++ b/packages/terra-site/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
 ------------------
 ### Changed
 * Minor version bump
+* Updated toggle docs
 
 1.12.0 - (September 26, 2017)
 ------------------

--- a/packages/terra-site/CHANGELOG.md
+++ b/packages/terra-site/CHANGELOG.md
@@ -8,7 +8,7 @@ Unreleased
 ------------------
 ### Changed
 * Minor version bump
-* Updated toggle docs
+* Updated terra-toggle examples
 
 1.12.0 - (September 26, 2017)
 ------------------

--- a/packages/terra-site/src/examples/toggle/AnimatedToggle.jsx
+++ b/packages/terra-site/src/examples/toggle/AnimatedToggle.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Toggle from 'terra-toggle/lib/Toggle';
-import Button from 'terra-button';
+import IconInformation from 'terra-icon/lib/icon/IconInformation';
 
 class ToggleDefault extends React.Component {
   constructor() {
@@ -17,7 +17,7 @@ class ToggleDefault extends React.Component {
   render() {
     return (
       <div>
-        <Button onClick={this.handleOnClick}>Animated Toggle</Button>
+        <IconInformation onClick={this.handleOnClick} />
         <Toggle isOpen={this.state.isOpen} isAnimated>
           <p>Lorem ipsum dolor sit amet, <a href="#test">consectetur</a> adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </Toggle>

--- a/packages/terra-site/src/examples/toggle/DefaultToggle.jsx
+++ b/packages/terra-site/src/examples/toggle/DefaultToggle.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Toggle from 'terra-toggle/lib/Toggle';
-import Button from 'terra-button';
+import IconInformation from 'terra-icon/lib/icon/IconInformation';
 
 class ToggleDefault extends React.Component {
   constructor() {
@@ -17,7 +17,7 @@ class ToggleDefault extends React.Component {
   render() {
     return (
       <div>
-        <Button onClick={this.handleOnClick}>Toggle</Button>
+        <IconInformation onClick={this.handleOnClick} />
         <Toggle isOpen={this.state.isOpen}>
           <p>Lorem ipsum dolor sit amet, <a href="#test">consectetur</a> adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </Toggle>

--- a/packages/terra-toggle/docs/README.md
+++ b/packages/terra-toggle/docs/README.md
@@ -1,6 +1,6 @@
 # Terra Toggle
 
-Toggle component that transitions content in and out.
+Toggle component that transitions content in and out. For toggle button functionality, see [terra-toggle-button](#/site/toggle-button).
 
 ## Getting Started
 
@@ -11,10 +11,10 @@ Toggle component that transitions content in and out.
 
 ```jsx
 import React from 'react';
-import Toggle from 'terra-toggle';
-import Button from 'terra-button';
+import Toggle from 'terra-toggle/lib/Toggle';
+import IconInformation from 'terra-icon/lib/icon/IconInformation';
 
-class MyCustomToggle extends React.Component {
+class ToggleDefault extends React.Component {
   constructor() {
     super();
     this.state = ({ isOpen: false });
@@ -29,7 +29,7 @@ class MyCustomToggle extends React.Component {
   render() {
     return (
       <div>
-        <Button onClick={this.handleOnClick}>Click Me!</Button>
+        <IconInformation onClick={this.handleOnClick} />
         <Toggle isOpen={this.state.isOpen} isAnimated>
           Hello World
         </Toggle>
@@ -38,7 +38,8 @@ class MyCustomToggle extends React.Component {
   }
 }
 
-export default MyCustomToggle;
+
+export default ToggleDefault;
 ```
 
 ## Component Features


### PR DESCRIPTION
### Summary
Resolves #676.
* Button examples have been refactored to icons - doesn't make much sense to provide toggle examples with buttons when we have a specific toggle-button component.

