### PR TITLE
Set webpack dev server at 2.7.1 for IE10 compatibility

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -38,4 +38,4 @@
 | stylelint-suitcss | ^1.0.0 | -- | A collection of stylelint plugins for SUIT CSS |
 | terra-toolkit | ^2.1.0 | ^15.4.2 | Utilities to help when developing terra modules. |
 | webpack | ^3.6.0 | -- | Packs CommonJs/AMD modules for the browser. Allows to split your codebase into multiple bundles, which can be loaded on demand. Support loaders to preprocess files, i.e. json, jsx, es7, css, less, ... and your custom stuff. |
-| webpack-dev-server | ^2.9.1 | -- | Serves a webpack app. Updates the browser on changes. |
+| webpack-dev-server | 2.7.1 | -- | Serves a webpack app. Updates the browser on changes. |

--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
     "stylelint-suitcss": "^1.0.0",
     "terra-toolkit": "^2.1.0",
     "webpack": "^3.6.0",
-    "webpack-dev-server": "^2.9.1"
+    "webpack-dev-server": "2.7.1"
   }
 }

--- a/packages/terra-modal/docs/DEPENDENCIES.md
+++ b/packages/terra-modal/docs/DEPENDENCIES.md
@@ -4,7 +4,7 @@
 | Dependency | Version | React Version | Description |
 |-|-|-|-|
 | classnames | ^2.2.5 | -- | A simple utility for conditionally joining classNames together |
-| focus-trap-react | ^3.0.2 | 0.14.x \|\| ^15.0.0 \|\| ^16.0.0 | A React component that traps focus. |
+| focus-trap-react | ^3.0.2 | 0.14.x \|\| ^15.0.0 | A React component that traps focus. |
 | prop-types | ^15.5.8 | -- | Runtime type checking for React props and similar objects. |
 | react-portal | ^3.0.0 | -- | React component for transportation of modals, lightboxes, loading bars... to document.body |
 | terra-base | ^2.6.0 | ^15.4.2 | The base component sets minimal global styles for an application. |

--- a/packages/terra-overlay/docs/DEPENDENCIES.md
+++ b/packages/terra-overlay/docs/DEPENDENCIES.md
@@ -4,7 +4,7 @@
 | Dependency | Version | React Version | Description |
 |-|-|-|-|
 | classnames | ^2.2.5 | -- | A simple utility for conditionally joining classNames together |
-| focus-trap-react | ^3.0.2 | 0.14.x \|\| ^15.0.0 \|\| ^16.0.0 | A React component that traps focus. |
+| focus-trap-react | ^3.0.2 | 0.14.x \|\| ^15.0.0 | A React component that traps focus. |
 | prop-types | ^15.5.8 | -- | Runtime type checking for React props and similar objects. |
 | terra-base | ^2.6.0 | ^15.4.2 | The base component sets minimal global styles for an application. |
 | terra-icon | ^1.12.0 | ^15.4.2 | terra-icon |

--- a/packages/terra-popup/docs/DEPENDENCIES.md
+++ b/packages/terra-popup/docs/DEPENDENCIES.md
@@ -4,7 +4,7 @@
 | Dependency | Version | React Version | Description |
 |-|-|-|-|
 | classnames | ^2.2.5 | -- | A simple utility for conditionally joining classNames together |
-| focus-trap-react | ^3.0.2 | 0.14.x \|\| ^15.0.0 \|\| ^16.0.0 | A React component that traps focus. |
+| focus-trap-react | ^3.0.2 | 0.14.x \|\| ^15.0.0 | A React component that traps focus. |
 | prop-types | ^15.5.8 | -- | Runtime type checking for React props and similar objects. |
 | react-onclickoutside | ^5.11.1 | -- | An onClickOutside wrapper for React components |
 | react-portal | ^3.0.0 | -- | React component for transportation of modals, lightboxes, loading bars... to document.body |

--- a/packages/terra-site/CHANGELOG.md
+++ b/packages/terra-site/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* Lock wepback-dev-server at last version supporting IE10 (1.7.1)
+* Lock webpack-dev-server at last version supporting IE10 (1.7.1)
 
 1.13.0 - (October 6, 2017)
 ------------------

--- a/packages/terra-site/CHANGELOG.md
+++ b/packages/terra-site/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Lock wepback-dev-server at last version supporting IE10 (1.7.1)
 
 1.13.0 - (October 6, 2017)
 ------------------

--- a/packages/terra-site/docs/DEPENDENCIES.md
+++ b/packages/terra-site/docs/DEPENDENCIES.md
@@ -81,7 +81,7 @@
 | sass-loader | ^6.0.6 | -- | Sass loader for webpack |
 | style-loader | ^0.19.0 | -- | style loader module for webpack |
 | webpack | ^3.6.0 | -- | Packs CommonJs/AMD modules for the browser. Allows to split your codebase into multiple bundles, which can be loaded on demand. Support loaders to preprocess files, i.e. json, jsx, es7, css, less, ... and your custom stuff. |
-| webpack-dev-server | ^2.9.1 | -- | Serves a webpack app. Updates the browser on changes. |
+| webpack-dev-server | 2.7.1 | -- | Serves a webpack app. Updates the browser on changes. |
 
 ## peerDependencies
 | Dependency | Version | React Version | Description |

--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -107,6 +107,6 @@
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",
     "webpack": "^3.6.0",
-    "webpack-dev-server": "^2.9.1"
+    "webpack-dev-server": "2.7.1"
   }
 }

--- a/packages/terra-slide-group/docs/DEPENDENCIES.md
+++ b/packages/terra-slide-group/docs/DEPENDENCIES.md
@@ -5,7 +5,7 @@
 |-|-|-|-|
 | classnames | ^2.2.5 | -- | A simple utility for conditionally joining classNames together |
 | prop-types | ^15.5.8 | -- | Runtime type checking for React props and similar objects. |
-| react-transition-group | ^2.2.0 | >=15.0.0 | A react component toolset for managing animations |
+| react-transition-group | ^2.2.0 | ^15.0.0 | A react component toolset for managing animations |
 | terra-base | ^2.6.0 | ^15.4.2 | The base component sets minimal global styles for an application. |
 
 ## devDependencies


### PR DESCRIPTION
### Summary
Set webpack dev server at 2.7.1 for IE10 compatability. see https://github.com/webpack/webpack-dev-server#caveats

This should fix https://github.com/cerner/terra-core/pull/899