### PR TITLE
Update I18n plugin to generate ES6 modules. Fixes #914

### DIFF
--- a/packages/terra-i18n-plugin/CHANGELOG.md
+++ b/packages/terra-i18n-plugin/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Generated translations are now ES6 modules.
 
 1.6.0 - (October 6, 2017)
 ------------------

--- a/packages/terra-i18n-plugin/src/I18nAggregatorPlugin.js
+++ b/packages/terra-i18n-plugin/src/I18nAggregatorPlugin.js
@@ -10,11 +10,12 @@ import localeData from 'react-intl/locale-data/${language.split('-')[0]}';
 addLocaleData(localeData);
 
 const messages = ${JSON.stringify(messages, null, 2)};
-
-module.exports = {
-  areTranslationsLoaded: true,
-  locale: '${language}',
-  messages: messages
+const areTranslationsLoaded = true;
+const locale = '${language}'
+export {
+  areTranslationsLoaded,
+  locale,
+  messages
 };`;
 }
 

--- a/packages/terra-modal/docs/DEPENDENCIES.md
+++ b/packages/terra-modal/docs/DEPENDENCIES.md
@@ -4,7 +4,7 @@
 | Dependency | Version | React Version | Description |
 |-|-|-|-|
 | classnames | ^2.2.5 | -- | A simple utility for conditionally joining classNames together |
-| focus-trap-react | ^3.0.2 | 0.14.x \|\| ^15.0.0 \|\| ^16.0.0 | A React component that traps focus. |
+| focus-trap-react | ^3.0.2 | 0.14.x \|\| ^15.0.0 | A React component that traps focus. |
 | prop-types | ^15.5.8 | -- | Runtime type checking for React props and similar objects. |
 | react-portal | ^3.0.0 | -- | React component for transportation of modals, lightboxes, loading bars... to document.body |
 | terra-base | ^2.6.0 | ^15.4.2 | The base component sets minimal global styles for an application. |


### PR DESCRIPTION
### Summary
Updates i18n plugin to generate pure ES6 modules. This is required for anyone wanting to use webpack to optimizations such as tree shaking that has turned module transpiling off on babel.

### Additional Details
This should address https://github.com/cerner/terra-core/issues/914