### PR TITLE
Add semi-colon to generated translations.

### DIFF
--- a/packages/terra-i18n-plugin/src/I18nAggregatorPlugin.js
+++ b/packages/terra-i18n-plugin/src/I18nAggregatorPlugin.js
@@ -11,7 +11,7 @@ addLocaleData(localeData);
 
 const messages = ${JSON.stringify(messages, null, 2)};
 const areTranslationsLoaded = true;
-const locale = '${language}'
+const locale = '${language}';
 export {
   areTranslationsLoaded,
   locale,


### PR DESCRIPTION
Forgot to add a semi-colon to the locale variable on the generated syntax.
