### PR TITLE
Revert "List Item Selection shows 100% height (#923)"

### DIFF
--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -8,7 +8,6 @@ Unreleased
 ------------------
 ### Changed
 * Update table test links to be 'Table Tests' and 'Single Select Table Links'
-* Update list to use flex and column directional to update selection height
 
 1.11.0 - (September 26, 2017)
 ------------------

--- a/packages/terra-list/src/List.scss
+++ b/packages/terra-list/src/List.scss
@@ -3,8 +3,6 @@
 /* stylelint-disable selector-max-compound-selectors */
 :local {
   .list {
-    display: flex;
-    flex-direction: column;
     list-style: none;
     margin: 0;
     padding: 0;
@@ -27,6 +25,7 @@
   // ========================================================
 
   .chevron {
+    display: flex;
     padding-left: 10px;
     padding-right: 10px;
 


### PR DESCRIPTION
This reverts commit 01b611a79a5d6f3728ac1f10f71114a11225aeaa.

### Summary
Trying this out to see if the master build is fixed by reverting @kschuste changes.
