### PR TITLE
Fix Build: Stop checking against the computed value for font weight.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ addons:
       - google-chrome
     packages:
       - google-chrome-stable
+      - oracle-java8-set-default
 before_script:
   - export TZ=America/Chicago
-  - sudo apt-get update && sudo apt-get install oracle-java8-installer
 script:
   - npm test
   - npm run danger

--- a/packages/terra-heading/CHANGELOG.md
+++ b/packages/terra-heading/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 Unreleased
 ----------
+* Update nightwatch tests to stop checking the computed value for bold and normal font weights.
 
 1.12.0 - (October 6, 2017)
 ------------------

--- a/packages/terra-heading/tests/nightwatch/heading-spec.js
+++ b/packages/terra-heading/tests/nightwatch/heading-spec.js
@@ -42,8 +42,8 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
 
   'Displays a heading component with a set weight': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/heading-tests/weight`);
-    browser.assert.cssProperty('#heading-weight-700', 'font-weight', '700'); // Browser computes 700 as bold
-    browser.assert.cssProperty('#heading-weight-400', 'font-weight', '400'); // Browser computes 400 as normal
+    browser.assert.cssProperty('#heading-weight-700', 'font-weight', '700');
+    browser.assert.cssProperty('#heading-weight-400', 'font-weight', '400');
     browser.assert.cssProperty('#heading-weight-200', 'font-weight', '200');
   },
 

--- a/packages/terra-heading/tests/nightwatch/heading-spec.js
+++ b/packages/terra-heading/tests/nightwatch/heading-spec.js
@@ -42,8 +42,8 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
 
   'Displays a heading component with a set weight': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/heading-tests/weight`);
-    browser.assert.cssProperty('#heading-weight-700', 'font-weight', 'bold'); // Browser computes 700 as bold
-    browser.assert.cssProperty('#heading-weight-400', 'font-weight', 'normal'); // Browser computes 400 as normal
+    browser.assert.cssProperty('#heading-weight-700', 'font-weight', '700'); // Browser computes 700 as bold
+    browser.assert.cssProperty('#heading-weight-400', 'font-weight', '400'); // Browser computes 400 as normal
     browser.assert.cssProperty('#heading-weight-200', 'font-weight', '200');
   },
 

--- a/packages/terra-text/CHANGELOG.md
+++ b/packages/terra-text/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 Unreleased
 ----------
+* Update nightwatch tests to stop checking the computed value for bold and normal font weights.
 
 1.11.0 - (October 6, 2017)
 ------------------

--- a/packages/terra-text/tests/nightwatch/text-spec.js
+++ b/packages/terra-text/tests/nightwatch/text-spec.js
@@ -34,8 +34,8 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
 
   'Displays a text component with a set weight': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/text-tests/weight`);
-    browser.assert.cssProperty('#textFontWeight700', 'font-weight', 'bold'); // Browser computes 700 as bold
-    browser.assert.cssProperty('#textFontWeight400', 'font-weight', 'normal'); // Browser computes 400 as normal
+    browser.assert.cssProperty('#textFontWeight700', 'font-weight', '700'); // Browser computes 700 as bold
+    browser.assert.cssProperty('#textFontWeight400', 'font-weight', '400'); // Browser computes 400 as normal
     browser.assert.cssProperty('#textFontWeight200', 'font-weight', '200');
   },
 

--- a/packages/terra-text/tests/nightwatch/text-spec.js
+++ b/packages/terra-text/tests/nightwatch/text-spec.js
@@ -34,8 +34,8 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
 
   'Displays a text component with a set weight': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/text-tests/weight`);
-    browser.assert.cssProperty('#textFontWeight700', 'font-weight', '700'); // Browser computes 700 as bold
-    browser.assert.cssProperty('#textFontWeight400', 'font-weight', '400'); // Browser computes 400 as normal
+    browser.assert.cssProperty('#textFontWeight700', 'font-weight', '700');
+    browser.assert.cssProperty('#textFontWeight400', 'font-weight', '400');
     browser.assert.cssProperty('#textFontWeight200', 'font-weight', '200');
   },
 


### PR DESCRIPTION
### Summary
For an unknown as of now reason, normal and bold font weights are not returning the computed value but the default value (ie 700 instead of bold). I'm assuming this is a change in the chrome driver we've pulled in, but I'm not sure yet.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
