### PR TITLE
Added line ending in gitattributes for consistency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,5 @@
 *.gitattributes text
 .gitignore text
 *.md text
+*.js text eol=lf
+*.jsx text eol=lf

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,6 +36,7 @@ Cerner Corporation
 - Kevin Schuster [@kschuste]
 - Sai Gorantla [@saigorantla]
 - Derek Yu [@yuderekyu]
+- Dustin Singleton [@singleton06]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -75,3 +76,4 @@ Cerner Corporation
 [@kschuste]: https://github.com/kschuste
 [@saigorantla]: https://github.com/saigorantla
 [@yuderekyu]: https://github.com/yuderekyu
+[@singleton06]: https://github.com/Singleton06


### PR DESCRIPTION
### Summary
This fixes the issue where line endings were failing linting for js and jsx files.  I ran the check against terra-badge with [this](https://gist.github.com/Singleton06/dde43c349cec599a7cf01e5f0273d484) output and then again after the fix with [this](https://gist.github.com/Singleton06/89f92f404bded72b53048441d3c8985a).   All I had to do was change the gitattributes to indicate the correct line endings for .js and .jsx files and re-clone the project after the fix was uploaded remotely.

Addresses: #816 

### Additional Details
If you were to do a pull on an existing repository on a windows machine after this fix is merged, I do not think that it would work.  I believe that you would need to clone the project again because when it clones the files, it applies the correct line endings then, thus a pull wouldn't do this.  I could be wrong, however.
