### PR TITLE
Fix hookshot blurring

### DIFF
--- a/packages/terra-hookshot/CHANGELOG.md
+++ b/packages/terra-hookshot/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog
 =========
 ### Fixed
 * Mobile zoom on safari
+* Half px value causing blurriness
 
 Unreleased
 ----------

--- a/packages/terra-hookshot/src/_HookshotUtils.js
+++ b/packages/terra-hookshot/src/_HookshotUtils.js
@@ -543,8 +543,8 @@ const positionStyleFromBounds = (boundingRect, content, target, margin, behavior
   return {
     style: {
       position: 'absolute',
-      left: `${positions.content.x + pageXOffset}px`,
-      top: `${positions.content.y + pageYOffset}px`,
+      left: `${Math.round(positions.content.x + pageXOffset)}px`,
+      top: `${Math.round(positions.content.y + pageYOffset)}px`,
     },
     positions,
   };


### PR DESCRIPTION
### Summary
When passing content that is an odd number of px in size, calculations result in .5px being applied, this can cause blurriness. Round the final positioning value to ensure this doesn't occur.

Thanks for contributing to Terra. 
@cerner/terra
