### PR TITLE
use path.join in place of hard coded paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .nyc_output
 .repl_history
 .rvmrc
+.idea
 .sass-cache/
 /.bundle/
 /.config

--- a/packages/terra-i18n-plugin/tests/i18n-plugin-spec.test.js
+++ b/packages/terra-i18n-plugin/tests/i18n-plugin-spec.test.js
@@ -2,6 +2,7 @@
 /* eslint-disable global-require */
 /* eslint no-underscore-dangle: ["error", { "allow": ["_plugins"] }] */
 import fs from 'fs';
+import path from 'path';
 import I18nAggregatorPlugin from '../src/I18nAggregatorPlugin';
 
 const Compiler = require('webpack/lib/Compiler');
@@ -17,7 +18,7 @@ function createCompiler() {
 
 describe('i18n-aggregator-plugin', () => {
   const supportedLocales = ['en', 'es', 'pt'];
-  const baseDirectory = 'packages/terra-i18n-plugin/tests/fixtures';
+  const baseDirectory = path.join('packages', 'terra-i18n-plugin', 'tests', 'fixtures');
 
   describe('when throwing errors when plugin options are not provided', () => {
     const compiler = createCompiler();
@@ -81,13 +82,13 @@ describe('i18n-aggregator-plugin', () => {
 
     it('should log console warning for missing tranlsation files', () => {
       expect(consoleMessage).toContain('Translation file en.json not found for');
-      expect(consoleMessage).toContain('/tests/fixtures/node_modules/fixtures2/translations');
+      expect(consoleMessage).toContain(path.join('tests', 'fixtures', 'node_modules', 'fixtures2', 'translations'));
       expect(SpyOnConsoleWarn).toHaveBeenCalled();
     });
 
     it('should fill the tranlsation files with the expected information for each locales', () => {
       supportedLocales.forEach((locale, index) => {
-        expect(outputtedFileName[index]).toContain(`aggregated-translations/${locale}.js`);
+        expect(outputtedFileName[index]).toContain(path.join('aggregated-translations', `${locale}.js`));
         expect(outputtedFileContent[index]).toContain(`react-intl/locale-data/${locale}`);
         if (locale === 'en') {
           const missingTranslationMessages = Object.assign({}, expectedMessages);
@@ -142,13 +143,13 @@ describe('i18n-aggregator-plugin', () => {
 
     it('should log console warning for missing tranlsation files', () => {
       expect(consoleMessage).toContain('Translation file en.json not found for');
-      expect(consoleMessage).toContain('/tests/fixtures/node_modules/fixtures2/translations');
+      expect(consoleMessage).toContain(path.join('tests', 'fixtures', 'node_modules', 'fixtures2', 'translations'));
       expect(SpyOnConsoleWarn).toHaveBeenCalled();
     });
 
     it('should fill the tranlsation files with the expected information for each locales', () => {
       supportedLocales.forEach((locale, index) => {
-        expect(outputtedFileName[index]).toContain(`aggregated-translations/${locale}.js`);
+        expect(outputtedFileName[index]).toContain(path.join('aggregated-translations', `${locale}.js`));
         expect(outputtedFileContent[index]).toContain(`react-intl/locale-data/${locale}`);
         if (locale === 'en') {
           const missingTranslationMessages = Object.assign({}, expectedMessages);

--- a/packages/terra-site/tests/jest/theming-plugin-spec.test.jsx
+++ b/packages/terra-site/tests/jest/theming-plugin-spec.test.jsx
@@ -3,6 +3,7 @@
 
 import postcss from 'postcss';
 import fs from 'fs';
+import path from 'path';
 
 describe('theming-plugin', () => {
   let expectedHash;
@@ -61,7 +62,7 @@ describe('theming-plugin', () => {
       const rootNode = postcss.parse(mockStyles);
       rootNode.source = { input: { file: 'TestingComponent.scss' } };
       expect(JSON.parse(testingFunction(rootNode))).toEqual(JSON.parse(expectedHash));
-      expect(outputtedFileName.slice(outputtedFileName.length - 55)).toEqual('terra-core/packages/terra-site/themeable-variables.json');
+      expect(outputtedFileName.slice(outputtedFileName.length - 55)).toEqual(path.join('terra-core', 'packages', 'terra-site', 'themeable-variables.json'));
       expect(outputtedEncoding).toEqual('utf8');
     });
   });
@@ -80,7 +81,7 @@ describe('theming-plugin', () => {
       }`;
 
       expect(JSON.parse(testingFunction(rootNode))).toEqual(JSON.parse(expectedHash));
-      expect(outputtedFileName.slice(outputtedFileName.length - 55)).toEqual('terra-core/packages/terra-site/themeable-variables.json');
+      expect(outputtedFileName.slice(outputtedFileName.length - 55)).toEqual(path.join('terra-core', 'packages', 'terra-site', 'themeable-variables.json'));
       expect(outputtedEncoding).toEqual('utf8');
     });
   });
@@ -106,7 +107,7 @@ describe('theming-plugin', () => {
       rootNode.source = { input: { file: 'TestingComponent.scss' } };
 
       expect(JSON.parse(testingFunction(rootNode))).toEqual(JSON.parse(expectedHash));
-      expect(outputtedFileName.slice(outputtedFileName.length - 55)).toEqual('terra-core/packages/terra-site/themeable-variables.json');
+      expect(outputtedFileName.slice(outputtedFileName.length - 55)).toEqual(path.join('terra-core', 'packages', 'terra-site', 'themeable-variables.json'));
       expect(outputtedEncoding).toEqual('utf8');
     });
   });


### PR DESCRIPTION
### Summary
Tests were failing on windows because paths were being used for comparisons that were hard coded with the forward slash.  Using node's path.join, it is now able to handle builds on windows.  

I was able to build nightwatch and jest tests both from the root directory.

### Additional Details
One important note (marked [here](https://github.com/cerner/terra-core/pull/949/files#r145879687)) is that any paths that show up in the import statements in generated files do not seem to get converted to the backslash, so the path.join is not required (and actually would break the build on windows if it is used)

### Unrelated Config Change
Just a warning, I added the .idea folder to the .gitignore file.  If that's an issue, I can remove it, just figured that I would call it out as it is not technically related to the issue this PR addresses.

### Addresses
#945 #839