### PR TITLE
Update depenency docs setup

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,12 @@
 {
   "lerna": "2.1.2",
-  "packages": [
-    "packages/*"
-  ],
-  "version": "independent"
-}
+  "version": "independent",
+  "commands": {
+    "publish": {
+      "ignore": [
+        "DEPENDENCIES.md"
+      ]
+    }
+  },
+  "packages": ["packages/*"]
+  }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "props-table": "lerna run props-table",
     "postinstall": "link-parent-bin && npm run compile && npm run bootstrap",
     "publish": "npm whoami && check-installed-dependencies && npm run compile && npm test && npm run props-table && lerna publish",
-    "z": "npm run dependency-markdown && git add --all && git commit -m 'Updated DEPENDENCIES.md files'",
+    "postpublish": "npm run dependency-markdown && git add --all && git commit -m 'Updated DEPENDENCIES.md files'",
     "start": "cd packages/terra-site && npm run start",
     "start:express": "node scripts/express/app.js",
     "test": "jest && nightwatch"

--- a/package.json
+++ b/package.json
@@ -57,8 +57,9 @@
     "nightwatch": "nightwatch",
     "pretest": "npm run lint",
     "props-table": "lerna run props-table",
-    "postinstall": "link-parent-bin && npm run compile && npm run bootstrap && npm run dependency-markdown",
+    "postinstall": "link-parent-bin && npm run compile && npm run bootstrap",
     "publish": "npm whoami && check-installed-dependencies && npm run compile && npm test && npm run props-table && lerna publish",
+    "z": "npm run dependency-markdown && git add --all && git commit -m 'Updated DEPENDENCIES.md files'",
     "start": "cd packages/terra-site && npm run start",
     "start:express": "node scripts/express/app.js",
     "test": "jest && nightwatch"


### PR DESCRIPTION
### Summary
* Adds `DEPENDENCIES.md` files to lerna ignore. When we go to publish, lerna will not view changes to these files as a change to package that needs to be released. This cuts down on version increase we've been seeing on all packages.
* Moved generation of these docs to a `postpublish` script instead of `postinstall`. This means no more modified files after running `npm install`. Now we can update these files as part of a release.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
