### PR TITLE
Delete stats.json file from terra-site

### DIFF
--- a/packages/terra-site/.gitignore
+++ b/packages/terra-site/.gitignore
@@ -1,0 +1,1 @@
+/stats.json

--- a/packages/terra-site/CHANGELOG.md
+++ b/packages/terra-site/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 ### Changed
 * Lock webpack-dev-server at last version supporting IE10 (1.7.1)
 * Uplift site header to use collapsible menu view
+* Removing verbose build scripts and related files
 
 1.14.0 - (October 12, 2017)
 ------------------

--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -19,7 +19,6 @@
     "compile:build": "babel src --out-dir lib --copy-files",
     "compile:heroku": "webpack --config webpack.prod.config --progress",
     "compile:prod": "webpack --config webpack.prod.config -p",
-    "compile:prod-stats": "webpack --config webpack.prod.config -p --json > stats.json",
     "deploy": "npm run compile:prod && gh-pages -d build",
     "lint": "npm run lint:js",
     "lint:js": "eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",


### PR DESCRIPTION
### Summary
This 23 MB file doesn't seem to be doing much. We could add it to the .gitignore too.

It's being generated by one of our scripts:
`"compile:prod-stats": "webpack --config webpack.prod.config -p --json > stats.json"`
