### PR TITLE
I18n input file system

### DIFF
--- a/packages/terra-i18n-plugin/CHANGELOG.md
+++ b/packages/terra-i18n-plugin/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 Unreleased
 ----------
+* Updated to allow an inputFileSystem to be passed in through the options
 
 1.7.0 - (October 12, 2017)
 ------------------


### PR DESCRIPTION
### Summary
This resolves issue #956.  Can pass in an inputFileSystem through the options rather than use the compiler's inputFileSystem to read the translations.

### Additional Details
In the options given to the i18nPlugin, can pass in an inputFileSystem to be used instead of the compiler's inputFileSystem.  Updated the tests as well.