### PR TITLE
Added search field disabling and stretch sizing

### DIFF
--- a/packages/terra-search-field/CHANGELOG.md
+++ b/packages/terra-search-field/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added the ability to disable
+* Added the ability to expand to its parent container through sizing prop
 
 1.13.0 - (October 24, 2017)
 ------------------

--- a/packages/terra-search-field/src/SearchField.jsx
+++ b/packages/terra-search-field/src/SearchField.jsx
@@ -34,12 +34,24 @@ const propTypes = {
    * A callback to indicate an invalid search. Sends parameter {String} searchText.
    */
   onInvalidSearch: PropTypes.func,
+
+  /**
+   * Indicates whether or not the search control should be disabled.
+   */
+  isDisabled: PropTypes.bool,
+
+  /**
+   * Indicates what sizing style should be used. Should be `fixed` or `stretch`.
+   */
+  sizing: PropTypes.oneOf(['fixed', 'stretch']),
 };
 
 const defaultProps = {
   placeholder: '',
   minimumSearchTextLength: 2,
   searchDelay: 250,
+  isDisabled: false,
+  sizing: 'fixed',
 };
 
 class SearchField extends React.Component {
@@ -86,10 +98,21 @@ class SearchField extends React.Component {
   }
 
   render() {
-    const { placeholder, searchDelay, minimumSearchTextLength, onSearch, onInvalidSearch, ...customProps } = this.props;
+    const {
+      placeholder,
+      searchDelay,
+      minimumSearchTextLength,
+      onSearch,
+      onInvalidSearch,
+      isDisabled,
+      sizing,
+      ...customProps
+    } = this.props;
+
     const searchFieldClassNames = cx([
       'searchfield',
       customProps.className,
+      { stretch: sizing === 'stretch' },
     ]);
 
     return (
@@ -100,18 +123,19 @@ class SearchField extends React.Component {
           placeholder={placeholder}
           value={this.state.searchText}
           onChange={this.handleTextChange}
+          disabled={isDisabled}
         />
         <Button
           className={cx('button')}
           onClick={this.handleSearch}
           isCompact
+          isDisabled={isDisabled}
         >
           <IconSearch />
         </Button>
       </div>
     );
   }
-
 }
 
 SearchField.propTypes = propTypes;

--- a/packages/terra-search-field/src/SearchField.scss
+++ b/packages/terra-search-field/src/SearchField.scss
@@ -25,6 +25,10 @@
     }
   }
 
+  .stretch {
+    width: 100%;
+  }
+
   .input::-webkit-search-cancel-button {
     appearance: searchfield-cancel-button;
   }

--- a/packages/terra-search-field/tests/jest/SearchField.test.jsx
+++ b/packages/terra-search-field/tests/jest/SearchField.test.jsx
@@ -19,6 +19,24 @@ describe('Snapshots', () => {
 
     expect(searchField).toMatchSnapshot();
   });
+
+  it('renders a disabled search field', () => {
+    const searchField = shallow(<SearchField isDisabled />);
+
+    expect(searchField).toMatchSnapshot();
+  });
+
+  it('renders a search field with a stretched container', () => {
+    const searchField = shallow(<SearchField sizing={'stretch'} />);
+
+    expect(searchField).toMatchSnapshot();
+  });
+
+  it('renders a search field with no stretch class specified if sizing is fixed', () => {
+    const searchField = shallow(<SearchField sizing={'fixed'} />);
+
+    expect(searchField).toMatchSnapshot();
+  });
 });
 
 describe('Manual Search', () => {

--- a/packages/terra-search-field/tests/jest/__snapshots__/SearchField.test.jsx.snap
+++ b/packages/terra-search-field/tests/jest/__snapshots__/SearchField.test.jsx.snap
@@ -6,6 +6,7 @@ exports[`Snapshots renders a basic search field 1`] = `
 >
   <Input
     className="input"
+    disabled={false}
     name={null}
     onChange={[Function]}
     placeholder=""
@@ -32,15 +33,82 @@ exports[`Snapshots renders a basic search field 1`] = `
 </div>
 `;
 
+exports[`Snapshots renders a disabled search field 1`] = `
+<div
+  className="searchfield"
+>
+  <Input
+    className="input"
+    disabled={true}
+    name={null}
+    onChange={[Function]}
+    placeholder=""
+    required={false}
+    type="search"
+    value=""
+  />
+  <Button
+    className="button"
+    isBlock={false}
+    isCompact={true}
+    isDisabled={true}
+    isReversed={false}
+    onClick={[Function]}
+    type="button"
+    variant="default"
+  >
+    <IconSearch
+      data-name="Layer 1"
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </Button>
+</div>
+`;
+
 exports[`Snapshots renders a search field with a placeholder 1`] = `
 <div
   className="searchfield"
 >
   <Input
     className="input"
+    disabled={false}
     name={null}
     onChange={[Function]}
     placeholder="Test"
+    required={false}
+    type="search"
+    value=""
+  />
+  <Button
+    className="button"
+    isBlock={false}
+    isCompact={true}
+    isDisabled={false}
+    isReversed={false}
+    onClick={[Function]}
+    type="button"
+    variant="default"
+  >
+    <IconSearch
+      data-name="Layer 1"
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </Button>
+</div>
+`;
+
+exports[`Snapshots renders a search field with a stretched container 1`] = `
+<div
+  className="searchfield stretch"
+>
+  <Input
+    className="input"
+    disabled={false}
+    name={null}
+    onChange={[Function]}
+    placeholder=""
     required={false}
     type="search"
     value=""
@@ -70,12 +138,46 @@ exports[`Snapshots renders a search field with a value 1`] = `
 >
   <Input
     className="input"
+    disabled={false}
     name={null}
     onChange={[Function]}
     placeholder=""
     required={false}
     type="search"
     value="Test"
+  />
+  <Button
+    className="button"
+    isBlock={false}
+    isCompact={true}
+    isDisabled={false}
+    isReversed={false}
+    onClick={[Function]}
+    type="button"
+    variant="default"
+  >
+    <IconSearch
+      data-name="Layer 1"
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </Button>
+</div>
+`;
+
+exports[`Snapshots renders a search field with no stretch class specified if sizing is fixed 1`] = `
+<div
+  className="searchfield"
+>
+  <Input
+    className="input"
+    disabled={false}
+    name={null}
+    onChange={[Function]}
+    placeholder=""
+    required={false}
+    type="search"
+    value=""
   />
   <Button
     className="button"

--- a/packages/terra-search-field/tests/nightwatch/DisabledSearchField.jsx
+++ b/packages/terra-search-field/tests/nightwatch/DisabledSearchField.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+import SearchField from '../../src/SearchField';
+
+export default () => <SearchField id="disabledsearchfield" isDisabled />;

--- a/packages/terra-search-field/tests/nightwatch/SearchFieldTestRoutes.jsx
+++ b/packages/terra-search-field/tests/nightwatch/SearchFieldTestRoutes.jsx
@@ -8,6 +8,7 @@ import PlaceholderSearchField from './PlaceholderSearchField';
 import CallbackSearchField from './CallbackSearchField';
 import DelayedSearchField from './DelayedSearchField';
 import MinimumLengthSearchField from './MinimumLengthSearchField';
+import DisabledSearchField from './DisabledSearchField';
 
 const routes = (
   <div>
@@ -17,6 +18,7 @@ const routes = (
     <Route path="/tests/search-field-tests/callback" component={CallbackSearchField} />
     <Route path="/tests/search-field-tests/delayed" component={DelayedSearchField} />
     <Route path="/tests/search-field-tests/minimum-length" component={MinimumLengthSearchField} />
+    <Route path="/tests/search-field-tests/disabled" component={DisabledSearchField} />
   </div>
 );
 

--- a/packages/terra-search-field/tests/nightwatch/search-field-spec.js
+++ b/packages/terra-search-field/tests/nightwatch/search-field-spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
@@ -73,5 +74,16 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
         browser.assert.equal(Math.round(parseFloat(inputResult.value)), Math.round(parseFloat(buttonResult.value)));
       });
     });
+  },
+
+  'Displays the search button disabled': (browser) => {
+    browser.url(`${browser.launchUrl}/#/tests/search-field-tests/disabled`);
+
+    browser.assert.expect.element('#disabledsearchfield').to.be.present;
+    browser.assert.expect.element('#disabledsearchfield button').to.be.present;
+    browser.assert.expect.element('#disabledsearchfield input').to.be.present;
+
+    browser.expect.element('#disabledsearchfield button').to.not.be.enabled;
+    browser.expect.element('#disabledsearchfield input').to.not.be.enabled;
   },
 });

--- a/packages/terra-site/CHANGELOG.md
+++ b/packages/terra-site/CHANGELOG.md
@@ -11,6 +11,10 @@ Unreleased
 * Uplift site header to use collapsible menu view
 * Removing verbose build scripts and related files
 
+### Added
+* Example for search-field being disabled
+* Example for search-field expanding to fit its parent
+
 1.14.0 - (October 12, 2017)
 ------------------
 ### Updated

--- a/packages/terra-site/src/examples/search-field/Index.jsx
+++ b/packages/terra-site/src/examples/search-field/Index.jsx
@@ -14,6 +14,8 @@ import SearchFieldBasic from './SearchFieldBasic';
 import SearchFieldPlaceholder from './SearchFieldPlaceholder';
 import SearchFieldMinimumLength from './SearchFieldMinimumLength';
 import SearchFieldDelayed from './SearchFieldDelayed';
+import SearchFieldDisabled from './SearchFieldDisabled';
+import SearchFieldStretched from './SearchFieldStretched';
 
 const SearchFieldExamples = () => (
   <div>
@@ -31,6 +33,10 @@ const SearchFieldExamples = () => (
     <br />
     <h2 id="searchFieldDelayed">Search Field with delay of 2000ms</h2>
     <SearchFieldDelayed />
+    <h2 id="searchFieldDisabled">Search Field Disabled</h2>
+    <SearchFieldDisabled />
+    <h2 id="searchFieldStretched">Search Field Stretched</h2>
+    <SearchFieldStretched />
   </div>
 );
 

--- a/packages/terra-site/src/examples/search-field/SearchFieldDisabled.jsx
+++ b/packages/terra-site/src/examples/search-field/SearchFieldDisabled.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import SearchFieldExampleTemplate from './SearchFieldExampleTemplate';
+
+const SearchFieldExample = () => (
+  <SearchFieldExampleTemplate
+    isDisabled
+  />
+);
+
+export default SearchFieldExample;

--- a/packages/terra-site/src/examples/search-field/SearchFieldStretched.jsx
+++ b/packages/terra-site/src/examples/search-field/SearchFieldStretched.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import SearchFieldExampleTemplate from './SearchFieldExampleTemplate';
+
+const SearchFieldExample = () => (
+  <SearchFieldExampleTemplate
+    sizing={'stretch'}
+  />
+);
+
+export default SearchFieldExample;


### PR DESCRIPTION
### Summary
Added code changes that allow for the terra-search-field to be disabled and to be stretched to fit its parent container. 

Addresses #953 

Below is a screenshot of the new functionality:

![image](https://user-images.githubusercontent.com/2235110/32003894-23baa3e8-b966-11e7-9ad4-06f483478457.png)
