### PR TITLE
Add postcssassets-plugin

### DIFF
--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -99,6 +99,7 @@
     "html-webpack-plugin": "^2.30.0",
     "json-loader": "^0.5.7",
     "node-sass": "^4.5.2",
+    "postcss-assets-webpack-plugin": "^1.1.0",
     "postcss-custom-properties": "^6.0.1",
     "postcss-loader": "^2.0.6",
     "postcss-rtl": "^1.1.2",

--- a/packages/terra-site/postcss.config.js
+++ b/packages/terra-site/postcss.config.js
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
 const Autoprefixer = require('autoprefixer');
-const CustomProperties = require('postcss-custom-properties');
 const rtl = require('postcss-rtl');
 const ThemingPlugin = require('./theming-plugin');
 
@@ -16,7 +15,6 @@ module.exports = {
           'iOS >= 10',
         ],
       }),
-      CustomProperties({ preserve: true, warnings: false }),
       ThemingPlugin,
       rtl(),
     ];

--- a/packages/terra-site/webpack.config.js
+++ b/packages/terra-site/webpack.config.js
@@ -3,6 +3,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
 const webpack = require('webpack');
 const postCssConfig = require('./postcss.config');
+const PostCSSAssetsPlugin = require('postcss-assets-webpack-plugin');
+const PostCSSCustomProperties = require('postcss-custom-properties');
 const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -62,6 +64,13 @@ module.exports = {
     new I18nAggregatorPlugin({
       baseDirectory: __dirname,
       supportedLocales: i18nSupportedLocales,
+    }),
+    new PostCSSAssetsPlugin({
+      test: /\.css$/,
+      log: false,
+      plugins: [
+        PostCSSCustomProperties({ preserve: true }),
+      ],
     }),
     new webpack.NamedChunksPlugin(),
   ],


### PR DESCRIPTION
### Summary
* add postcssassets-plugin

This enables us to compile themes using the `:root` selector to static values for testing theming in browsers that lack support for CSS custom properties.

Thanks for contributing to Terra. 
@cerner/terra
