### PR TITLE
Round height and width values to prevent arrow blur.

### DIFF
--- a/packages/terra-hookshot/CHANGELOG.md
+++ b/packages/terra-hookshot/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Height and Width rounding
 
 1.1.0 - (October 24, 2017)
 ------------------

--- a/packages/terra-hookshot/src/_HookshotUtils.js
+++ b/packages/terra-hookshot/src/_HookshotUtils.js
@@ -125,6 +125,8 @@ const getBounds = (element) => {
   box.right = Math.round(box.right);
   box.bottom = Math.round(box.bottom);
   box.left = Math.round(box.left);
+  box.height = Math.round(box.height);
+  box.width = Math.round(box.width);
 
   return box;
 };


### PR DESCRIPTION
### Summary
Height and Width values for computed size had been missed in the first pass of value rounding.

Thanks for contributing to Terra. 
@cerner/terra
