### PR TITLE
Fix issues with rtl plugin and css-custom-properties

### DIFF
--- a/packages/terra-site/postcss.config.js
+++ b/packages/terra-site/postcss.config.js
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
 const Autoprefixer = require('autoprefixer');
-const rtl = require('postcss-rtl');
 const ThemingPlugin = require('./theming-plugin');
 
 module.exports = {
@@ -16,7 +15,6 @@ module.exports = {
         ],
       }),
       ThemingPlugin,
-      rtl(),
     ];
   },
 };

--- a/packages/terra-site/webpack.config.js
+++ b/packages/terra-site/webpack.config.js
@@ -5,6 +5,7 @@ const webpack = require('webpack');
 const postCssConfig = require('./postcss.config');
 const PostCSSAssetsPlugin = require('postcss-assets-webpack-plugin');
 const PostCSSCustomProperties = require('postcss-custom-properties');
+const rtl = require('postcss-rtl');
 const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -70,6 +71,7 @@ module.exports = {
       log: false,
       plugins: [
         PostCSSCustomProperties({ preserve: true }),
+        rtl(),
       ],
     }),
     new webpack.NamedChunksPlugin(),


### PR DESCRIPTION
### Summary
Resolves #986 

The rtl and postcss-custom-properties are conflicting with each other, and causing issues with producing the correct styles. To resolve this, we run rtl before we run postcss-custom-properties.

### Additional Details
This is the first part of the long term solution. We will need to eventually create better mixins for left and right functionality, as styles such as box-shadow, and background-position causes issue. If you need these styles themed, you need to wrap them individually in your components with the proper [dir=ltr] & [dir=rtl] attribute selectors.