### PR TITLE
Fix font-family defect in terra-button

### DIFF
--- a/packages/terra-button/CHANGELOG.md
+++ b/packages/terra-button/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ----------
 
+1.13.0 - (November 8, 2017)
+------------------
+### Changed
+* Removed unnecessary `font-family` rule.
+
 1.12.0 - (October 31, 2017)
 ------------------
 ### Changed

--- a/packages/terra-button/src/Button.scss
+++ b/packages/terra-button/src/Button.scss
@@ -33,7 +33,6 @@
     border-width: var(--terra-button-border-width, 1px);
     cursor: pointer;
     display: inline-block;
-    font-family: inherit;
     font-size: map-get($terra-button-font-sizes, medium);
     font-weight: var(--terra-button-font-weight, 400);
     line-height: 1.429; // 20px when html font size is computed to 14px

--- a/packages/terra-button/src/Button.scss
+++ b/packages/terra-button/src/Button.scss
@@ -33,7 +33,7 @@
     border-width: var(--terra-button-border-width, 1px);
     cursor: pointer;
     display: inline-block;
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-family: inherit;
     font-size: map-get($terra-button-font-sizes, medium);
     font-weight: var(--terra-button-font-weight, 400);
     line-height: 1.429; // 20px when html font size is computed to 14px


### PR DESCRIPTION
### Summary
Prior to this change, the terra-button component had it’s own font-family set explicitly within its stylesheet. Now, the font-family being applied to terra-button can be set using the ‘--terra-base-font-family’ CSS custom prop. Fixes issue #997.

### Additional Details
This fix is needed for the new Healthe@Cerner site themed-buttons.