### PR TITLE
Remove flickering initial header background.

### DIFF
--- a/packages/terra-site/CHANGELOG.md
+++ b/packages/terra-site/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Place site header background on a parent div, instead of collapsible.
 
 1.19.0 - (November 28, 2017)
 ------------------

--- a/packages/terra-site/src/App.jsx
+++ b/packages/terra-site/src/App.jsx
@@ -205,13 +205,15 @@ class App extends React.Component {
     );
 
     const applicationHeader = (
-      <CollapsibleMenuView className={styles['site-header']}>
-        {toggleContent}
-        {themeSwitcher}
-        {localeContent}
-        <CollapsibleMenuView.Divider />
-        {bidiContent}
-      </CollapsibleMenuView>
+      <div className={styles['site-header']}>
+        <CollapsibleMenuView className={styles['site-collapsible']}>
+          {toggleContent}
+          {themeSwitcher}
+          {localeContent}
+          <CollapsibleMenuView.Divider />
+          {bidiContent}
+        </CollapsibleMenuView>
+      </div>
     );
 
     return (

--- a/packages/terra-site/src/site.scss
+++ b/packages/terra-site/src/site.scss
@@ -66,9 +66,10 @@
     background-color: #80c7ee;
     border-bottom: 3px solid #047cc0;
     padding: 0.5rem 1.25rem;
+    width: 100%;
   }
 
-  .site-header > div:first-child {
+  .site-collapsible > div:first-child {
     flex: 3 0 auto;
   }
 


### PR DESCRIPTION
### Summary
Remove sites flickering header background on initial page load, by placing the background on a parent div.

Thanks for contributing to Terra. 
@cerner/terra
