### PR TITLE
Remove react-bps from spacer component

### DIFF
--- a/packages/terra-site/src/examples/spacer/Index.jsx
+++ b/packages/terra-site/src/examples/spacer/Index.jsx
@@ -11,7 +11,6 @@ import SpacerSrc from '!raw-loader!terra-spacer/src/Spacer';
 
 // Example Files
 import Spacer from './SpacerExample';
-import SpacerResponsive from './SpacerResponsiveExample';
 
 const SpacerExamples = () => (
   <div>
@@ -23,12 +22,6 @@ const SpacerExamples = () => (
     <p>Spacing default button with a padding value of large+4 and primary button with padding value of large+2</p>
     <br />
     <Spacer />
-    <br />
-    <h2 id="default">Spacer Responsive Example</h2>
-    <br />
-    <p>Resize the browser to see responsiveness</p>
-    <br />
-    <SpacerResponsive />
   </div>
 );
 

--- a/packages/terra-spacer/CHANGELOG.md
+++ b/packages/terra-spacer/CHANGELOG.md
@@ -2,5 +2,6 @@ ChangeLog
 =========
 
 Unreleased - (<!--- Insert date using June 28, 2017 format. --->)
+
 -----------------
 Initial stable release

--- a/packages/terra-spacer/docs/README.md
+++ b/packages/terra-spacer/docs/README.md
@@ -1,6 +1,6 @@
 # Terra Spacer
 
-This component is used to provide margin and/or padding space between two components based on the given values. This component uses **react-bps package mobile first strategy** for **responsiveness**. Find more information on how it is used [here](https://www.npmjs.com/package/react-bps).
+This component is used to provide margin and/or padding space between two components based on the given values.
 
 ## Getting Started
 
@@ -46,22 +46,9 @@ import Spacer from 'terra-spacer';
 <Spacer paddingTop="large" paddingBottom="large+1" paddingLeft="large+2" marginLeft="large+4" marginRight="large+3">
   <Image src="someImageSource" alt="example image" />
 <Spacer/>
-
-// Responsive spacing
-
-// sets margin-top to 50px for view port sizes >= 768px, for view port sizes < 768px sets margin-top to 5px
-
-<Spacer marginTop="small-1" bps={{ 768: { marginTop: 'large+4' } }} >
-  <Image src="someImageSource" alt="example image" />
-</Spacer>
 ```
-
 
 ## Component Features
 
  * [Cross-Browser Support](https://github.com/cerner/terra-core/wiki/Component-Features#cross-browser-support)
- * [Responsive Support](https://github.com/cerner/terra-core/wiki/Component-Features#responsive-support)
- * [Mobile Support](https://github.com/cerner/terra-core/wiki/Component-Features#mobile-support)
- * [Internationalization Support](https://github.com/cerner/terra-core/wiki/Component-Features#internationalization-i18n-support)
- * [Localization Support](https://github.com/cerner/terra-core/wiki/Component-Features#localization-support)
  * [LTR/RTL Support](https://github.com/cerner/terra-core/wiki/Component-Features#ltr--rtl-support)

--- a/packages/terra-spacer/package.json
+++ b/packages/terra-spacer/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "react-bps": "0.0.4",
     "terra-base": "^2.6.1",
     "terra-toolkit": "^2.1.0"
   },

--- a/packages/terra-spacer/src/Spacer.jsx
+++ b/packages/terra-spacer/src/Spacer.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import { withBps } from 'react-bps';
 import 'terra-base/lib/baseStyles';
 import styles from './Spacer.scss';
 

--- a/packages/terra-spacer/src/Spacer.jsx
+++ b/packages/terra-spacer/src/Spacer.jsx
@@ -49,10 +49,6 @@ const propTypes = {
    * Sets the display to be inline-block.
    */
   isInlineBlock: PropTypes.bool,
-  /**
-   * Object used to determine at what window size props should be active. e.g { 768: { marginBottom: 'small-2' }}
-   */
-  bps: PropTypes.object,
 };
 
 const defaultProps = {
@@ -65,7 +61,6 @@ const defaultProps = {
   paddingLeft: 'none',
   paddingRight: 'none',
   isInlineBlock: false,
-  bps: null,
 };
 
 const Spacer = ({
@@ -79,7 +74,6 @@ const Spacer = ({
   paddingRight,
   isInlineBlock,
   children,
-  bps,
   ...customProps
  }) => {
   const spacingSizes = {
@@ -115,4 +109,4 @@ const Spacer = ({
 Spacer.propTypes = propTypes;
 Spacer.defaultProps = defaultProps;
 
-export default withBps({ mobileFirst: true })(Spacer);
+export default Spacer;

--- a/packages/terra-spacer/tests/jest/Spacer.test.jsx
+++ b/packages/terra-spacer/tests/jest/Spacer.test.jsx
@@ -29,11 +29,6 @@ describe('Spacer', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should render a spacer component with right padding set to the given value at the given viewport size', () => {
-    const wrapper = render(<Spacer bps={{ 768: { paddingRight: 'large+3' } }}><p>Test</p></Spacer>);
-    expect(wrapper).toMatchSnapshot();
-  });
-
   it('should render a spacer component with all margin props set to the given values', () => {
     const wrapper =
     render(

--- a/packages/terra-spacer/tests/jest/__snapshots__/Spacer.test.jsx.snap
+++ b/packages/terra-spacer/tests/jest/__snapshots__/Spacer.test.jsx.snap
@@ -70,16 +70,6 @@ exports[`Spacer should render a spacer component with medium bottom margin 1`] =
 </div>
 `;
 
-exports[`Spacer should render a spacer component with right padding set to the given value at the given viewport size 1`] = `
-<div
-  class="spacer margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-none padding-bottom-none padding-left-none padding-right-large-plus-3"
->
-  <p>
-    Test
-  </p>
-</div>
-`;
-
 exports[`Spacer should render a spacer component with small top margin 1`] = `
 <div
   class="spacer margin-top-small margin-bottom-none margin-left-none margin-right-none padding-top-none padding-bottom-none padding-left-none padding-right-none"


### PR DESCRIPTION
### Summary
* Removed react-bps (This should resolve travis build errors we are seeing once merged)

### Additional Details
* Use the responsive element if you need responsive spacing going forward
* Will evaluate creating a util similar to react-bps within terra-ui in the future.