### PR TITLE
Pushed demo content in for modal site examples

### DIFF
--- a/packages/terra-site/CHANGELOG.md
+++ b/packages/terra-site/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added styles for terra-modal content displaying div.
+
 ### Changed
 * Place site header background on a parent div, instead of collapsible.
 

--- a/packages/terra-site/src/examples/modal/ModalCloseOnOutsideClick.jsx
+++ b/packages/terra-site/src/examples/modal/ModalCloseOnOutsideClick.jsx
@@ -31,7 +31,7 @@ class ModalCloseOnOutsideClick extends React.Component {
           closeOnOutsideClick={false}
           onRequestClose={this.handleCloseModal}
         >
-          <div className={styles['modal-closed-content']}>
+          <div className={styles['demo-modal-content']}>
             <h1>Modal disable close on outside click</h1>
             <br />
             <p>You can close the modal by:</p>

--- a/packages/terra-site/src/examples/modal/ModalCloseOnOutsideClick.jsx
+++ b/packages/terra-site/src/examples/modal/ModalCloseOnOutsideClick.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Modal from 'terra-modal';
+import styles from '../../site.scss';
 
 class ModalCloseOnOutsideClick extends React.Component {
   constructor() {
@@ -30,7 +31,7 @@ class ModalCloseOnOutsideClick extends React.Component {
           closeOnOutsideClick={false}
           onRequestClose={this.handleCloseModal}
         >
-          <div>
+          <div className={styles['modal-closed-content']}>
             <h1>Modal disable close on outside click</h1>
             <br />
             <p>You can close the modal by:</p>

--- a/packages/terra-site/src/examples/modal/ModalIsFullscreen.jsx
+++ b/packages/terra-site/src/examples/modal/ModalIsFullscreen.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Modal from 'terra-modal';
+import styles from '../../site.scss';
 
 class ModalIsFullscreen extends React.Component {
   constructor() {
@@ -30,7 +31,7 @@ class ModalIsFullscreen extends React.Component {
           isFullscreen
           onRequestClose={this.handleCloseModal}
         >
-          <div>
+          <div className={styles['modal-full-screen-content']}>
             <h1>Fullscreen Modal</h1>
             <br />
             <p>This modal will always take up the full screen.</p>

--- a/packages/terra-site/src/examples/modal/ModalIsFullscreen.jsx
+++ b/packages/terra-site/src/examples/modal/ModalIsFullscreen.jsx
@@ -31,7 +31,7 @@ class ModalIsFullscreen extends React.Component {
           isFullscreen
           onRequestClose={this.handleCloseModal}
         >
-          <div className={styles['modal-full-screen-content']}>
+          <div className={styles['demo-modal-content']}>
             <h1>Fullscreen Modal</h1>
             <br />
             <p>This modal will always take up the full screen.</p>

--- a/packages/terra-site/src/examples/modal/ModalIsOpened.jsx
+++ b/packages/terra-site/src/examples/modal/ModalIsOpened.jsx
@@ -30,7 +30,7 @@ class ModalIsOpen extends React.Component {
           isOpen={this.state.isOpen}
           onRequestClose={this.handleCloseModal}
         >
-          <div className={styles['modal-opened-content']}>
+          <div className={styles['demo-modal-content']}>
             <h1>Default Modal</h1>
             <br />
             <p>You can close the modal by:</p>

--- a/packages/terra-site/src/examples/modal/ModalIsOpened.jsx
+++ b/packages/terra-site/src/examples/modal/ModalIsOpened.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Modal from 'terra-modal';
+import styles from '../../site.scss';
 
 class ModalIsOpen extends React.Component {
   constructor() {
@@ -29,7 +30,7 @@ class ModalIsOpen extends React.Component {
           isOpen={this.state.isOpen}
           onRequestClose={this.handleCloseModal}
         >
-          <div>
+          <div className={styles['modal-opened-content']}>
             <h1>Default Modal</h1>
             <br />
             <p>You can close the modal by:</p>

--- a/packages/terra-site/src/site.scss
+++ b/packages/terra-site/src/site.scss
@@ -76,6 +76,18 @@
   .site-input-display {
     display: inline-block;
   }
+
+  .modal-opened-content{
+    padding: 15px;
+  }
+
+  .modal-closed-content{
+    padding: 15px;
+  }
+
+  .modal-full-screen-content{
+    padding: 15px;
+  }
 }
 
 #site-body {

--- a/packages/terra-site/src/site.scss
+++ b/packages/terra-site/src/site.scss
@@ -77,15 +77,7 @@
     display: inline-block;
   }
 
-  .modal-opened-content{
-    padding: 15px;
-  }
-
-  .modal-closed-content{
-    padding: 15px;
-  }
-
-  .modal-full-screen-content{
+  .demo-modal-content{
     padding: 15px;
   }
 }


### PR DESCRIPTION
### Summary

Added padding to push content of a modal a little into it to make sure button outline (outline of the close button in the modal) is visible when tab key is hit. Focuses more on fixing bug in Safari.

Fixes https://github.com/cerner/terra-core/issues/351

### Deployment Links
https://terra-core-deployed-pr-1048.herokuapp.com/static/#/site/modal
### Note
Added new class styles to site.scss because they are specific to only, demo on the terra site .