### PR TITLE
Optimize webpack by using thread-loader

### DIFF
--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -115,6 +115,6 @@
     "terra-divider": "^1.2.0",
     "thread-loader": "^1.1.2",
     "webpack": "^3.10.0",
-    "webpack-dev-server": "2.9.6"
+    "webpack-dev-server": "2.7.1"
   }
 }

--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -113,7 +113,8 @@
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",
     "terra-divider": "^1.2.0",
-    "webpack": "^3.6.0",
-    "webpack-dev-server": "2.7.1"
+    "thread-loader": "^1.1.2",
+    "webpack": "^3.10.0",
+    "webpack-dev-server": "2.9.6"
   }
 }

--- a/packages/terra-site/webpack.config.js
+++ b/packages/terra-site/webpack.config.js
@@ -12,6 +12,14 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const I18nAggregatorPlugin = require('terra-i18n-plugin');
 const i18nSupportedLocales = require('terra-i18n/lib/i18nSupportedLocales');
 
+const threadLoaderRule = {
+  loader: 'thread-loader',
+  options: {
+    workerParallelJobs: 50,
+    poolParallelJobs: 50,
+    poolTimeout: 2000,
+  },
+};
 
 module.exports = {
   entry: {
@@ -23,16 +31,16 @@ module.exports = {
       test: /\.(jsx|js)$/,
       exclude: /node_modules/,
       use: [
-        'thread-loader',
+        !process.env.CI && threadLoaderRule,
         'babel-loader',
-      ],
+      ].filter(Boolean),
     },
     {
       test: /\.(scss|css)$/,
       use: ExtractTextPlugin.extract({
         fallback: 'style-loader',
         use: [
-          'thread-loader',
+          !process.env.CI && threadLoaderRule,
           {
             loader: 'css-loader',
             options: {
@@ -49,15 +57,15 @@ module.exports = {
             options: {
               data: '$bundled-themes: mock, consumer;',
             },
-          }],
+          }].filter(Boolean),
       }),
     },
     {
       test: /\.md$/,
       use: [
-        'thread-loader',
+        !process.env.CI && threadLoaderRule,
         'raw-loader',
-      ],
+      ].filter(Boolean),
     },
     {
       test: /\.(png|svg|jpg|gif)$/,

--- a/packages/terra-site/webpack.config.js
+++ b/packages/terra-site/webpack.config.js
@@ -11,26 +11,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const I18nAggregatorPlugin = require('terra-i18n-plugin');
 const i18nSupportedLocales = require('terra-i18n/lib/i18nSupportedLocales');
-const threadLoader = require('thread-loader');
 
-const threadLoaderRule = {
-  loader: 'thread-loader',
-  options: {
-    workerParallelJobs: 50,
-    poolParallelJobs: 50,
-    poolTimeout: 2000,
-  },
-};
-
-threadLoader.warmup(threadLoaderRule.options, [
-  // modules to load
-  // can be any module, i. e.
-  'babel-loader',
-  'css-loader',
-  'sass-loader',
-  'postcss-loader',
-  'raw-loader',
-]);
 
 module.exports = {
   entry: {
@@ -42,7 +23,7 @@ module.exports = {
       test: /\.(jsx|js)$/,
       exclude: /node_modules/,
       use: [
-        threadLoaderRule,
+        'thread-loader',
         'babel-loader',
       ],
     },
@@ -51,7 +32,7 @@ module.exports = {
       use: ExtractTextPlugin.extract({
         fallback: 'style-loader',
         use: [
-          threadLoaderRule,
+          'thread-loader',
           {
             loader: 'css-loader',
             options: {
@@ -74,7 +55,7 @@ module.exports = {
     {
       test: /\.md$/,
       use: [
-        threadLoaderRule,
+        'thread-loader',
         'raw-loader',
       ],
     },

--- a/packages/terra-site/webpack.config.js
+++ b/packages/terra-site/webpack.config.js
@@ -11,6 +11,26 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const I18nAggregatorPlugin = require('terra-i18n-plugin');
 const i18nSupportedLocales = require('terra-i18n/lib/i18nSupportedLocales');
+const threadLoader = require('thread-loader');
+
+const threadLoaderRule = {
+  loader: 'thread-loader',
+  options: {
+    workerParallelJobs: 50,
+    poolParallelJobs: 50,
+    poolTimeout: 2000,
+  },
+};
+
+threadLoader.warmup(threadLoaderRule.options, [
+  // modules to load
+  // can be any module, i. e.
+  'babel-loader',
+  'css-loader',
+  'sass-loader',
+  'postcss-loader',
+  'raw-loader',
+]);
 
 module.exports = {
   entry: {
@@ -21,34 +41,42 @@ module.exports = {
     rules: [{
       test: /\.(jsx|js)$/,
       exclude: /node_modules/,
-      use: 'babel-loader',
+      use: [
+        threadLoaderRule,
+        'babel-loader',
+      ],
     },
     {
       test: /\.(scss|css)$/,
       use: ExtractTextPlugin.extract({
         fallback: 'style-loader',
-        use: [{
-          loader: 'css-loader',
-          options: {
-            sourceMap: true,
-            importLoaders: 2,
-            localIdentName: '[name]__[local]___[hash:base64:5]',
+        use: [
+          threadLoaderRule,
+          {
+            loader: 'css-loader',
+            options: {
+              sourceMap: true,
+              importLoaders: 2,
+              localIdentName: '[name]__[local]___[hash:base64:5]',
+            },
+          }, {
+            loader: 'postcss-loader',
+            options: postCssConfig,
           },
-        }, {
-          loader: 'postcss-loader',
-          options: postCssConfig,
-        },
-        {
-          loader: 'sass-loader',
-          options: {
-            data: '$bundled-themes: mock, consumer;',
-          },
-        }],
+          {
+            loader: 'sass-loader',
+            options: {
+              data: '$bundled-themes: mock, consumer;',
+            },
+          }],
       }),
     },
     {
       test: /\.md$/,
-      use: 'raw-loader',
+      use: [
+        threadLoaderRule,
+        'raw-loader',
+      ],
     },
     {
       test: /\.(png|svg|jpg|gif)$/,


### PR DESCRIPTION
### Summary
Updated webpack to use the [thread-loader](https://github.com/webpack-contrib/thread-loader) and also updated webpack to 3.10 which includes performance optimizations from versions between our current (3.6). On my local machine this speeds up the initial webpack compilation from 40s to ~22s. 
