### PR TITLE
Revert "Optimize webpack by using thread-loader (#1060)"

### DIFF
--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -114,8 +114,7 @@
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",
     "terra-divider": "^1.2.0",
-    "thread-loader": "^1.1.2",
-    "webpack": "^3.10.0",
+    "webpack": "^3.6.0",
     "webpack-dev-server": "2.7.1"
   }
 }

--- a/packages/terra-site/webpack.config.js
+++ b/packages/terra-site/webpack.config.js
@@ -12,15 +12,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const I18nAggregatorPlugin = require('terra-i18n-plugin');
 const i18nSupportedLocales = require('terra-i18n/lib/i18nSupportedLocales');
 
-const threadLoaderRule = {
-  loader: 'thread-loader',
-  options: {
-    workerParallelJobs: 50,
-    poolParallelJobs: 50,
-    poolTimeout: 2000,
-  },
-};
-
 module.exports = {
   entry: {
     'babel-polyfill': 'babel-polyfill',
@@ -30,42 +21,34 @@ module.exports = {
     rules: [{
       test: /\.(jsx|js)$/,
       exclude: /node_modules/,
-      use: [
-        !process.env.CI && threadLoaderRule,
-        'babel-loader',
-      ].filter(Boolean),
+      use: 'babel-loader',
     },
     {
       test: /\.(scss|css)$/,
       use: ExtractTextPlugin.extract({
         fallback: 'style-loader',
-        use: [
-          !process.env.CI && threadLoaderRule,
-          {
-            loader: 'css-loader',
-            options: {
-              sourceMap: true,
-              importLoaders: 2,
-              localIdentName: '[name]__[local]___[hash:base64:5]',
-            },
-          }, {
-            loader: 'postcss-loader',
-            options: postCssConfig,
+        use: [{
+          loader: 'css-loader',
+          options: {
+            sourceMap: true,
+            importLoaders: 2,
+            localIdentName: '[name]__[local]___[hash:base64:5]',
           },
-          {
-            loader: 'sass-loader',
-            options: {
-              data: '$bundled-themes: mock, consumer;',
-            },
-          }].filter(Boolean),
+        }, {
+          loader: 'postcss-loader',
+          options: postCssConfig,
+        },
+        {
+          loader: 'sass-loader',
+          options: {
+            data: '$bundled-themes: mock, consumer;',
+          },
+        }],
       }),
     },
     {
       test: /\.md$/,
-      use: [
-        !process.env.CI && threadLoaderRule,
-        'raw-loader',
-      ].filter(Boolean),
+      use: 'raw-loader',
     },
     {
       test: /\.(png|svg|jpg|gif)$/,


### PR DESCRIPTION
This reverts commit 5d302ede8f0ca3fdefddd321ddf8138527c3d524.

### Summary
Heroku deployments have started timing out when running webpack. The only changes we've made recently to our webpack config was adding the thread-loader. Gonna test reverting this change to see if it helps resolve time out issue we see in heroku.

More info: https://github.com/cerner/terra-core/issues/1071