### PR TITLE
Add HEROKU env var to heroku review app

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,6 +13,10 @@
       "description": "development environment",
       "value": "development"
     },
+    "CI": {
+      "description": "Continuous integration environment",
+      "value": "true"
+    },
     "NPM_CONFIG_PRODUCTION": {
       "description": "development environment",
       "value": "false"

--- a/app.json
+++ b/app.json
@@ -13,8 +13,8 @@
       "description": "development environment",
       "value": "development"
     },
-    "CI": {
-      "description": "Continuous integration environment",
+    "HEROKU": {
+      "description": "Heroku environment",
       "value": "true"
     },
     "NPM_CONFIG_PRODUCTION": {

--- a/packages/terra-site/webpack.config.js
+++ b/packages/terra-site/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = {
       test: /\.(jsx|js)$/,
       exclude: /node_modules/,
       use: [
-        !process.env.CI && threadLoaderRule,
+        !process.env.CI && !process.env.HEROKU && threadLoaderRule,
         'babel-loader',
       ].filter(Boolean),
     },
@@ -40,7 +40,7 @@ module.exports = {
       use: ExtractTextPlugin.extract({
         fallback: 'style-loader',
         use: [
-          !process.env.CI && threadLoaderRule,
+          !process.env.CI && !process.env.HEROKU && threadLoaderRule,
           {
             loader: 'css-loader',
             options: {
@@ -63,7 +63,7 @@ module.exports = {
     {
       test: /\.md$/,
       use: [
-        !process.env.CI && threadLoaderRule,
+        !process.env.CI && !process.env.HEROKU && threadLoaderRule,
         'raw-loader',
       ].filter(Boolean),
     },


### PR DESCRIPTION
Summary

Heroku deployments have started timing out when running webpack. The only changes we've made recently to our webpack config was adding the thread-loader. Gonna test setting env var we use to disable the thread-loader in the heroku app.json and see if this resolves #1071