### PR TITLE
Set max instances to 1 on travis'

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -19,6 +19,8 @@ const config = {
   baseUrl: `http://${localIP.address()}:${webpackPort}`,
   specs,
 
+  // Travis only has 1 browser instace, set maxInstances to 1 to prevent timeouts
+  maxInstances: process.env.CI ? 1 : wdioConf.config.maxInstances,
   seleniumDocker: {
     enabled: !process.env.TRAVIS,
   },
@@ -36,7 +38,6 @@ const config = {
     global.browser.refresh();
   },
 };
-
 
 config.services = wdioConf.config.services.concat([WebpackDevService]);
 exports.config = config;


### PR DESCRIPTION
Travis only has the ability to run a single selenium node. This means that we should only run 1 test instances at a time as they will either time out or conflict with each other.This PR checks for the travis env variable and dynamically sets maxInstances accordingly.

Hoping this resolves #1085 