### PR TITLE
Import terra-mixins for checkbox

### DIFF
--- a/packages/terra-form-checkbox/CHANGELOG.md
+++ b/packages/terra-form-checkbox/CHANGELOG.md
@@ -3,4 +3,6 @@ ChangeLog
 
 (Unreleased)
 -----------------
-Initial stable release
+### Added
+* Import terra-mixins into style sheet
+* Initial stable release

--- a/packages/terra-form-checkbox/src/Checkbox.scss
+++ b/packages/terra-form-checkbox/src/Checkbox.scss
@@ -1,3 +1,5 @@
+@import '~terra-mixins';
+
 :local {
   .checkbox {
     color: var(--terra-form-checkbox-font-color, rgb(0, 0, 0));


### PR DESCRIPTION
### Summary
Import terra-mixins in order for the checkbox stylesheet to use `inline-svg`, a mixins function which will be passed by custom themes to display their custom checkmark symbol.