### PR TITLE
Moved mock theme from component package to site

### DIFF
--- a/packages/terra-badge/CHANGELOG.md
+++ b/packages/terra-badge/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed mock theme from package
 
 1.14.0 - (December 5, 2017)
 ------------------

--- a/packages/terra-badge/src/Badge.scss
+++ b/packages/terra-badge/src/Badge.scss
@@ -2,23 +2,6 @@
 @import './variables';
 @import './mixins';
 
-@include cerner-mock-theme {
-  --terra-badge-background-color-default: #2c3e50;
-  --terra-badge-color-default: #fff;
-  --terra-badge-background-color-primary: #3498db;
-  --terra-badge-color-primary: #fff;
-  --terra-badge-background-color-secondary: #1abc9c;
-  --terra-badge-color-secondary: #fff;
-  --terra-badge-background-color-positive: #27ae60;
-  --terra-badge-color-positive: #fff;
-  --terra-badge-background-color-negative: #c0392b;
-  --terra-badge-color-negative: #fff;
-  --terra-badge-background-color-warning: #e67e22;
-  --terra-badge-color-warning: #fff;
-  --terra-badge-background-color-info: #bdc3c7;
-  --terra-badge-color-info: #333;
-}
-
 :local {
   .badge {
     border-radius: var(--terra-badge-border-radius, 0.25em);

--- a/packages/terra-site/CHANGELOG.md
+++ b/packages/terra-site/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added badge mock theme
+
 ### Changed
 * Fixed broken image in arrange example
 

--- a/packages/terra-site/src/cerner-mock-theme.scss
+++ b/packages/terra-site/src/cerner-mock-theme.scss
@@ -3,6 +3,22 @@
 @import '~terra-mixins';
 
 @include cerner-mock-theme {
+  // terra-badge
+  --terra-badge-background-color-default: #2c3e50;
+  --terra-badge-color-default: #fff;
+  --terra-badge-background-color-primary: #3498db;
+  --terra-badge-color-primary: #fff;
+  --terra-badge-background-color-secondary: #1abc9c;
+  --terra-badge-color-secondary: #fff;
+  --terra-badge-background-color-positive: #27ae60;
+  --terra-badge-color-positive: #fff;
+  --terra-badge-background-color-negative: #c0392b;
+  --terra-badge-color-negative: #fff;
+  --terra-badge-background-color-warning: #e67e22;
+  --terra-badge-color-warning: #fff;
+  --terra-badge-background-color-info: #bdc3c7;
+  --terra-badge-color-info: #333;
+
   // terra-form-checkbox
   --terra-form-checkbox-font-color: rgb(255, 192, 203);
   --terra-form-checkbox-container-margin-left: 0.643rem;


### PR DESCRIPTION
### Summary
Fixes #995 
Moved mock theme from component package to site. It looked like badge was the only place we still had this. 

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
