### PR TITLE
Fix button group accessibility issue.

### DIFF
--- a/packages/terra-button-group/CHANGELOG.md
+++ b/packages/terra-button-group/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* aria-selected attribute to aria-pressed
 
 1.15.0 - (November 28, 2017)
 ------------------

--- a/packages/terra-button-group/src/ButtonGroupButton.jsx
+++ b/packages/terra-button-group/src/ButtonGroupButton.jsx
@@ -48,7 +48,7 @@ const ButtonGroupButton = ({ isSelected, ...customProps }) => {
     { 'is-active': isSelected },
     attributes.className,
   ]);
-  attributes['aria-selected'] = isSelected;
+  attributes['aria-pressed'] = isSelected;
 
   return (
     <Button

--- a/packages/terra-button-group/tests/jest/__snapshots__/ButtonGroupButton.test.jsx.snap
+++ b/packages/terra-button-group/tests/jest/__snapshots__/ButtonGroupButton.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`should render a default component 1`] = `
 <Button
-  aria-selected={false}
+  aria-pressed={false}
   className="button-group-button"
   isBlock={false}
   isCompact={false}
@@ -15,7 +15,7 @@ exports[`should render a default component 1`] = `
 
 exports[`should render as selected 1`] = `
 <Button
-  aria-selected={true}
+  aria-pressed={true}
   className="button-group-button is-active"
   isBlock={false}
   isCompact={false}
@@ -28,7 +28,7 @@ exports[`should render as selected 1`] = `
 
 exports[`should render with icon and text 1`] = `
 <Button
-  aria-selected={false}
+  aria-pressed={false}
   className="button-group-button"
   icon={
     <img
@@ -47,7 +47,7 @@ exports[`should render with icon and text 1`] = `
 
 exports[`should render with icon and text reversed 1`] = `
 <Button
-  aria-selected={false}
+  aria-pressed={false}
   className="button-group-button"
   icon={
     <img
@@ -66,7 +66,7 @@ exports[`should render with icon and text reversed 1`] = `
 
 exports[`should render with icon only 1`] = `
 <Button
-  aria-selected={false}
+  aria-pressed={false}
   className="button-group-button"
   icon={
     <img
@@ -84,7 +84,7 @@ exports[`should render with icon only 1`] = `
 
 exports[`should render with text 1`] = `
 <Button
-  aria-selected={false}
+  aria-pressed={false}
   className="button-group-button"
   isBlock={false}
   isCompact={false}

--- a/packages/terra-button-group/tests/wdio/button-group-spec.js
+++ b/packages/terra-button-group/tests/wdio/button-group-spec.js
@@ -1,56 +1,51 @@
 /* global before, browser, Terra */
 
-// TODO: remove once https://github.com/cerner/terra-core/issues/1061 is resolved
-const ignoreAria = {
-  'aria-allowed-attr': { enabled: false },
-};
-
 describe('Button Group', () => {
   describe('Tiny', () => {
     beforeEach(() => browser.url('/#/tests/button-group-tests/tiny-button-group'));
-    Terra.should.beAccessible({ rules: ignoreAria });
+    Terra.should.beAccessible();
     Terra.should.matchScreenshot();
   });
 
   describe('Small', () => {
     beforeEach(() => browser.url('/#/tests/button-group-tests/small-button-group'));
-    Terra.should.beAccessible({ rules: ignoreAria });
+    Terra.should.beAccessible();
     Terra.should.matchScreenshot();
   });
 
   describe('Medium', () => {
     beforeEach(() => browser.url('/#/tests/button-group-tests/medium-button-group'));
-    Terra.should.beAccessible({ rules: ignoreAria });
+    Terra.should.beAccessible();
     Terra.should.matchScreenshot();
   });
 
   describe('Large', () => {
     beforeEach(() => browser.url('/#/tests/button-group-tests/large-button-group'));
-    Terra.should.beAccessible({ rules: ignoreAria });
+    Terra.should.beAccessible();
     Terra.should.matchScreenshot();
   });
 
   describe('Huge', () => {
     beforeEach(() => browser.url('/#/tests/button-group-tests/huge-button-group'));
-    Terra.should.beAccessible({ rules: ignoreAria });
+    Terra.should.beAccessible();
     Terra.should.matchScreenshot();
   });
 
   describe('Compact', () => {
     beforeEach(() => browser.url('/#/tests/button-group-tests/compact-button-group'));
-    Terra.should.beAccessible({ rules: ignoreAria });
+    Terra.should.beAccessible();
     Terra.should.matchScreenshot();
   });
 
   describe('Icon Default', () => {
     beforeEach(() => browser.url('/#/tests/button-group-tests/icon-default-button-group'));
-    Terra.should.beAccessible({ rules: ignoreAria });
+    Terra.should.beAccessible();
     Terra.should.matchScreenshot();
   });
 
   describe('Icon Reversed', () => {
     beforeEach(() => browser.url('/#/tests/button-group-tests/icon-reversed-button-group'));
-    Terra.should.beAccessible({ rules: ignoreAria });
+    Terra.should.beAccessible();
     Terra.should.matchScreenshot();
   });
 
@@ -58,26 +53,26 @@ describe('Button Group', () => {
     beforeEach(() => browser.url('/#/tests/button-group-tests/icon-only-button-group'));
     // TODO: remove button-name exception once https://github.com/cerner/terra-core/issues/1058 is closed
     Terra.should.beAccessible({
-      rules: { 'button-name': { enabled: false }, ...ignoreAria },
+      rules: { 'button-name': { enabled: false } },
     });
     Terra.should.matchScreenshot();
   });
 
   describe('Default Variant', () => {
     beforeEach(() => browser.url('/#/tests/button-group-tests/default-variant-button-group'));
-    Terra.should.beAccessible({ rules: ignoreAria });
+    Terra.should.beAccessible();
     Terra.should.matchScreenshot();
   });
 
   describe('Secondary Variant', () => {
     beforeEach(() => browser.url('/#/tests/button-group-tests/secondary-variant-button-group'));
-    Terra.should.beAccessible({ rules: ignoreAria });
+    Terra.should.beAccessible();
     Terra.should.matchScreenshot();
   });
 
   describe('Selectable', () => {
     beforeEach(() => browser.url('/#/tests/button-group-tests/selectable-button-group'));
-    Terra.should.beAccessible({ rules: ignoreAria });
+    Terra.should.beAccessible();
     Terra.should.matchScreenshot();
   });
 
@@ -89,7 +84,7 @@ describe('Button Group', () => {
       expect(browser.getText('#selected-index')).to.equal('0');
     });
 
-    Terra.should.beAccessible({ rules: ignoreAria });
+    Terra.should.beAccessible();
     Terra.should.matchScreenshot('0');
 
     it('should select the second button', () => {
@@ -98,7 +93,7 @@ describe('Button Group', () => {
       expect(browser.getText('#selected-index')).to.equal('1');
     });
 
-    Terra.should.beAccessible({ rules: ignoreAria });
+    Terra.should.beAccessible();
     Terra.should.matchScreenshot('1');
 
     it('should select the fourth button', () => {
@@ -108,7 +103,7 @@ describe('Button Group', () => {
       expect(browser.getText('#selected-index')).to.equal('3');
     });
 
-    Terra.should.beAccessible({ rules: ignoreAria });
+    Terra.should.beAccessible();
     Terra.should.matchScreenshot('3');
   });
 });

--- a/packages/terra-time-input/CHANGELOG.md
+++ b/packages/terra-time-input/CHANGELOG.md
@@ -8,6 +8,9 @@ Unreleased
 * Added support for theming.
 * Added mobile only time input.
 
+### Changed
+* Updated tests to use aria-pressed instead of aria-selected for button group
+
 
 1.15.0 - (November 28, 2017)
 ------------------

--- a/packages/terra-time-input/tests/jest/__snapshots__/TimeInput.test.jsx.snap
+++ b/packages/terra-time-input/tests/jest/__snapshots__/TimeInput.test.jsx.snap
@@ -106,7 +106,7 @@ exports[`should render a 12 hour timepicker meridiem with buttons when viewed on
   >
     <button
       aria-disabled="false"
-      aria-selected="true"
+      aria-pressed="true"
       class="button default button-group-button is-active meridiem-button"
       type="button"
     >
@@ -118,7 +118,7 @@ exports[`should render a 12 hour timepicker meridiem with buttons when viewed on
     </button>
     <button
       aria-disabled="false"
-      aria-selected="false"
+      aria-pressed="false"
       class="button default button-group-button meridiem-button"
       type="button"
     >

--- a/packages/terra-time-input/tests/nightwatch/time-input-twelve-hour-mobile-spec.js
+++ b/packages/terra-time-input/tests/nightwatch/time-input-twelve-hour-mobile-spec.js
@@ -8,7 +8,7 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large'], {
 
     browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('value').equals('');
     browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('');
-    browser.expect.element('#timeInput button[aria-selected="true"]').text.to.equal('a.m.');
+    browser.expect.element('#timeInput button[aria-pressed="true"]').text.to.equal('a.m.');
     browser.expect.element('#timeInput label[for="terra-time-hour-time-input"]').text.to.equal('Hours');
     browser.expect.element('#timeInput label[for="terra-time-minute-time-input"]').text.to.equal('Minutes');
   },
@@ -17,7 +17,7 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large'], {
 
     browser.expect.element('#timeInput input[name="terra-time-hour-time-input"]').to.have.attribute('value').equals('03');
     browser.expect.element('#timeInput input[name="terra-time-minute-time-input"]').to.have.attribute('value').equals('23');
-    browser.expect.element('#timeInput button[aria-selected="true"]').text.to.equal('p.m.');
+    browser.expect.element('#timeInput button[aria-pressed="true"]').text.to.equal('p.m.');
     browser.expect.element('label[for="terra-time-hour-time-input"]').text.to.equal('Hours');
     browser.expect.element('label[for="terra-time-minute-time-input"]').text.to.equal('Minutes');
   },
@@ -30,12 +30,12 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large'], {
   'Clicking the meridiem inputs updates the time': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/time-input-tests/twelve-hour-mobile-time-provided`);
 
-    browser.click('#timeInput button[aria-selected="false"]');
-    browser.expect.element('#timeInput button[aria-selected="true"]').text.to.equal('a.m.');
+    browser.click('#timeInput button[aria-pressed="false"]');
+    browser.expect.element('#timeInput button[aria-pressed="true"]').text.to.equal('a.m.');
     browser.expect.element('#time-input-value').text.to.contain('03:23');
 
-    browser.click('#timeInput button[aria-selected="false"]');
-    browser.expect.element('#timeInput button[aria-selected="true"]').text.to.equal('p.m.');
+    browser.click('#timeInput button[aria-pressed="false"]');
+    browser.expect.element('#timeInput button[aria-pressed="true"]').text.to.equal('p.m.');
     browser.expect.element('#time-input-value').text.to.contain('15:23');
   },
 });


### PR DESCRIPTION
### Summary
Fixes #1061 Updated button group to use `aria-pressed` instead of `aria-selected`. Removed rule disabling `aria-allowed-attr` on axe accessibility tests and those tests now pass. 

### Additional Details
If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process.

Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
