### PR TITLE
Removing commas from button group doc

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -43,6 +43,7 @@ Cerner Corporation
 - Victor Nava [@vikonava]
 - Chase Sinclair [@ChaseSinclair]
 - Gerard Isdell [@gerard-isdell]
+- Andy Nleson [@anelson425]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -89,3 +90,4 @@ Cerner Corporation
 [@vikonava]: https://github.com/vikonava
 [@ChaseSinclair]: https://github.com/ChaseSinclair
 [@gerard-isdell]: https://github.com/gerard-isdell
+[@anelson425]: https://github.com/anelson425

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -43,7 +43,7 @@ Cerner Corporation
 - Victor Nava [@vikonava]
 - Chase Sinclair [@ChaseSinclair]
 - Gerard Isdell [@gerard-isdell]
-- Andy Nleson [@anelson425]
+- Andy Nelson [@anelson425]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler

--- a/packages/terra-button-group/docs/README.md
+++ b/packages/terra-button-group/docs/README.md
@@ -16,13 +16,13 @@ import ButtonGroup from 'terra-button-group';
 
 // Default button group
   <ButtonGroup>
-    <ButtonGroup.Button text="Button 1" key="button1" />,
+    <ButtonGroup.Button text="Button 1" key="button1" />
     <ButtonGroup.Button text="Button 2" key="button2" />
   </ButtonGroup>
 
 // Selectable (toggle style) button group with second button pre-selected
   <ButtonGroup isSelectable>
-    <ButtonGroup.Button text="Button 1" key="button1" />,
+    <ButtonGroup.Button text="Button 1" key="button1" />
     <ButtonGroup.Button isSelected text="Button 2" key="button2" />
   </ButtonGroup>
 ```


### PR DESCRIPTION
### Summary
This isn't a code change, just an update to the documentation. I was trying to use a button group and while copying and pasting the documented usage, I kept getting an error. The commas were the source of far too much pain. This change removes them.

### Additional Details
N/A, I will more than happily add my name to the contributors if you would like me too but this contribution seems not so worthy.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
