### PR TITLE
Menu arrow navigation issue.

### DIFF
--- a/packages/terra-menu/CHANGELOG.md
+++ b/packages/terra-menu/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Fixed issue with left arrow presses on first layer.
 
 1.10.0 - (December 5, 2017)
 ------------------

--- a/packages/terra-menu/src/Menu.jsx
+++ b/packages/terra-menu/src/Menu.jsx
@@ -91,9 +91,11 @@ class Menu extends React.Component {
   }
 
   pop() {
-    const newStack = this.state.stack.slice();
-    newStack.pop();
-    this.setState({ stack: newStack });
+    if (this.state.stack.length > 1) {
+      const newStack = this.state.stack.slice();
+      newStack.pop();
+      this.setState({ stack: newStack });
+    }
   }
 
   push(item) {

--- a/packages/terra-menu/tests/nightwatch/menu/menu-spec.js
+++ b/packages/terra-menu/tests/nightwatch/menu/menu-spec.js
@@ -76,6 +76,13 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
     browser.sendKeys('.TestNestedMenuContent', [browser.Keys.ARROW_LEFT]);
     browser.expect.element('.TestInitialMenuContent').to.be.visible;
   },
+  'Menu should not do anything when left arrow is pressed on the first layer': (browser) => {
+    browser.url(`${browser.launchUrl}/#/tests/menu-tests/submenu`);
+    browser.click('#sub-menu-button');
+    browser.expect.element('.TestInitialMenuContent').to.be.present;
+    browser.sendKeys('.TestNestedMenu', [browser.Keys.LEFT_RIGHT]);
+    browser.expect.element('.TestInitialMenuContent').to.be.present;
+  },
   'Displays a selectable menu when there is one child': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/menu-tests/selectable`);
     browser.click('#selectable-menu-button');


### PR DESCRIPTION
### Summary
Fixes #1094 
Fixed issue where pressing the left arrow key on the first menu layer would remove the menu contents. 

### Steps to verify
1) Open menu
2) Tab into menu
3) Press left arrow key
4) Verify that the menu content remains. 

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
