### PR TITLE
Clarify Selectable List Examples

### DIFF
--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Add context to selectable list nightwatch example
 
 1.18.0 - (January 3, 2018)
 ------------------

--- a/packages/terra-list/tests/nightwatch/selectable-list/OnChangeSelectableList.jsx
+++ b/packages/terra-list/tests/nightwatch/selectable-list/OnChangeSelectableList.jsx
@@ -18,6 +18,7 @@ class listExample extends React.Component {
       <div>
         <div id="current-index">
           <h3>Triggered Item: {this.state.selectedIndex}</h3>
+          <p><strong>Note:</strong> Marking an item as selected is an implemention detail of the consumer.</p>
         </div>
         <SelectableList onChange={this.handleSelection}>
           <SelectableList.Item content={<p>test 1</p>} key="123" />

--- a/packages/terra-list/tests/nightwatch/selectable-list/OnChangeSelectableList.jsx
+++ b/packages/terra-list/tests/nightwatch/selectable-list/OnChangeSelectableList.jsx
@@ -18,7 +18,7 @@ class listExample extends React.Component {
       <div>
         <div id="current-index">
           <h3>Triggered Item: {this.state.selectedIndex}</h3>
-          <p><strong>Note:</strong> Marking an item as selected is an implemention detail of the consumer.</p>
+          <p><strong>Note:</strong> Marking an item as selected is an implementation detail of the consumer.</p>
         </div>
         <SelectableList onChange={this.handleSelection}>
           <SelectableList.Item content={<p>test 1</p>} key="123" />

--- a/packages/terra-site/CHANGELOG.md
+++ b/packages/terra-site/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Add context to selectable list example
 
 1.21.0 - (January 3, 2018)
 ------------------

--- a/packages/terra-site/src/examples/list/examples/Selectable.jsx
+++ b/packages/terra-site/src/examples/list/examples/Selectable.jsx
@@ -18,7 +18,7 @@ class listExample extends React.Component {
       <div>
         <div id="current-index">
           <h3>Last Triggered Index: {this.state.selectedIndex}</h3>
-          <p><strong>Note:</strong> Marking an item as selected is an implemention detail of the consumer. This example shows a single-selectable list implementation.</p>
+          <p><strong>Note:</strong> Marking an item as selected is an implementation detail of the consumer. This example shows a single-selectable list implementation.</p>
         </div>
         <SelectableList onChange={this.handleSelection} selectedIndexes={[this.state.selectedIndex]}>
           <SelectableList.Item content={<p>Item 1</p>} key="123" />

--- a/packages/terra-site/src/examples/list/examples/Selectable.jsx
+++ b/packages/terra-site/src/examples/list/examples/Selectable.jsx
@@ -18,8 +18,9 @@ class listExample extends React.Component {
       <div>
         <div id="current-index">
           <h3>Last Triggered Index: {this.state.selectedIndex}</h3>
+          <p><strong>Note:</strong> Marking an item as selected is an implemention detail of the consumer. This example shows a single-selectable list implementation.</p>
         </div>
-        <SelectableList onChange={this.handleSelection}>
+        <SelectableList onChange={this.handleSelection} selectedIndexes={[this.state.selectedIndex]}>
           <SelectableList.Item content={<p>Item 1</p>} key="123" />
           <SelectableList.Item content={<p>Item 2</p>} key="124" />
           <SelectableList.Item content={<p>Item 3</p>} key="125" />


### PR DESCRIPTION
### Summary
The Selectable List examples appear broken because item selection is an implementation detail of the consumer. 
