### PR TITLE
Status View: Support single child

### DIFF
--- a/packages/terra-status-view/src/StatusView.jsx
+++ b/packages/terra-status-view/src/StatusView.jsx
@@ -183,7 +183,7 @@ class StatusView extends React.Component {
     }
 
     let actionSection;
-    if (children.length || !Array.isArray(children)) { // Single children are objects, not arrays
+    if (React.Children.count(children) > 0) {
       actionSection = (
         <div className={cx('actions')} ref={(element) => { this.actionsNode = element; }}>
           {children}

--- a/packages/terra-status-view/src/StatusView.jsx
+++ b/packages/terra-status-view/src/StatusView.jsx
@@ -183,7 +183,7 @@ class StatusView extends React.Component {
     }
 
     let actionSection;
-    if (children.length) {
+    if (children.length || !Array.isArray(children)) { // Single children are objects, not arrays
       actionSection = (
         <div className={cx('actions')} ref={(element) => { this.actionsNode = element; }}>
           {children}

--- a/packages/terra-status-view/tests/jest/StatusView.test.jsx
+++ b/packages/terra-status-view/tests/jest/StatusView.test.jsx
@@ -12,6 +12,15 @@ it('should render an image with a default status view', () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+it('should render a single child element', () => {
+  const statusView = (<StatusView>
+    <Button text="OK" key="1" />
+  </StatusView>);
+
+  const wrapper = mount(statusView, intlContexts.mountContext);
+  expect(wrapper).toMatchSnapshot();
+});
+
 it('should render an image with a no-data status view with all message props given', () => {
   const statusView = (<StatusView variant={StatusView.Opts.variants.NODATA} title="Test Title" message="Test Message">
     <Button text="OK" key="1" />

--- a/packages/terra-status-view/tests/jest/__snapshots__/StatusView.test.jsx.snap
+++ b/packages/terra-status-view/tests/jest/__snapshots__/StatusView.test.jsx.snap
@@ -1,5 +1,80 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should render a single child element 1`] = `
+<StatusView
+  isAlignedTop={false}
+  isGlyphHidden={false}
+  variant="error"
+>
+  <div
+    className="status-view"
+  >
+    <div
+      className="status-view-inner"
+      style={
+        Object {
+          "paddingBottom": "0px",
+          "paddingTop": "0px",
+        }
+      }
+    >
+      <div
+        className="glyph"
+      >
+        <svg
+          className="error"
+        />
+      </div>
+      <div
+        className="message-content-group"
+      >
+        <div
+          className="title"
+        >
+          Error
+        </div>
+        <div
+          className="divider"
+        >
+          <Divider>
+            <hr
+              className="divider"
+            />
+          </Divider>
+        </div>
+      </div>
+      <div
+        className="actions"
+      >
+        <Button
+          isBlock={false}
+          isCompact={false}
+          isDisabled={false}
+          isReversed={false}
+          key="1"
+          text="OK"
+          type="button"
+          variant="default"
+        >
+          <button
+            aria-disabled={false}
+            className="button default"
+            disabled={false}
+            type="button"
+          >
+            <span
+              className="text"
+            >
+              OK
+            </span>
+          </button>
+        </Button>
+      </div>
+    </div>
+  </div>
+</StatusView>
+`;
+
 exports[`should render an image with a custom status-view 1`] = `
 <StatusView
   customGlyph={


### PR DESCRIPTION
### Summary
This allows `terra-status-view` to display a single child element. Current behavior only allows multiple.

### Additional Details
~We might be able to leverage [React.Children.toArray()](https://reactjs.org/docs/react-api.html#reactchildrentoarray) as an alternative, if preferred.~

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
