### PR TITLE
adding missing end quote in translation file

### DIFF
--- a/packages/terra-status-view/translations/es-US.json
+++ b/packages/terra-status-view/translations/es-US.json
@@ -2,5 +2,5 @@
   "Terra.status-view.no-data": "Sin resultados",
   "Terra.status-view.no-matching-results": "Sin resultados coincidentes",
   "Terra.status-view.not-authorized": "No autorizado",
-  "Terra.status-view.error": "Error
+  "Terra.status-view.error": "Error"
 }


### PR DESCRIPTION
### Summary
A missing end quote was found in the es-US translation file.  This add that missing end quote back in.