### PR TITLE
Reduce test screen sizes

### DIFF
--- a/packages/terra-content-container/tests/nightwatch/content-container-spec.js
+++ b/packages/terra-content-container/tests/nightwatch/content-container-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'enormous'], {
   'Displays a content container with default props': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/content-container-tests/default`);
     browser.expect.element('#content-container').to.be.present;

--- a/packages/terra-date-picker/tests/nightwatch/date-picker-spec.js
+++ b/packages/terra-date-picker/tests/nightwatch/date-picker-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays the DatePicker with defaulted props': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/date-picker-tests/default`);
     browser.click('[class*="button"]');

--- a/packages/terra-date-picker/tests/nightwatch/date-picker-spec.js
+++ b/packages/terra-date-picker/tests/nightwatch/date-picker-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays the DatePicker with defaulted props': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/date-picker-tests/default`);
     browser.click('[class*="button"]');

--- a/packages/terra-date-time-picker/tests/nightwatch/date-time-picker-spec.js
+++ b/packages/terra-date-time-picker/tests/nightwatch/date-time-picker-spec.js
@@ -7,7 +7,7 @@ const timeZones = ['America/Chicago', 'America/Denver', 'America/Detroit', 'Amer
   'America/Los_Angeles', 'America/New_York', 'America/Phoenix'];
 const includesTZ = timeZones.includes(moment.tz.guess());
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays the DateTimePicker with default props': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/date-time-picker-tests/default`);
 

--- a/packages/terra-date-time-picker/tests/nightwatch/date-time-picker-spec.js
+++ b/packages/terra-date-time-picker/tests/nightwatch/date-time-picker-spec.js
@@ -7,7 +7,7 @@ const timeZones = ['America/Chicago', 'America/Denver', 'America/Detroit', 'Amer
   'America/Los_Angeles', 'America/New_York', 'America/Phoenix'];
 const includesTZ = timeZones.includes(moment.tz.guess());
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays the DateTimePicker with default props': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/date-time-picker-tests/default`);
 

--- a/packages/terra-demographics-banner/tests/nightwatch/demographics-banner-spec.js
+++ b/packages/terra-demographics-banner/tests/nightwatch/demographics-banner-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a blank demographics banner with the empty text identifier': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/demographics-banner-tests/blank`)

--- a/packages/terra-demographics-banner/tests/nightwatch/demographics-banner-spec.js
+++ b/packages/terra-demographics-banner/tests/nightwatch/demographics-banner-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a blank demographics banner with the empty text identifier': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/demographics-banner-tests/blank`)

--- a/packages/terra-divider/tests/nightwatch/divider-spec.js
+++ b/packages/terra-divider/tests/nightwatch/divider-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'enormous'], {
   'Displays a default divider': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/divider-tests/default`)

--- a/packages/terra-dynamic-grid/tests/nightwatch/dynamic-grid-spec.js
+++ b/packages/terra-dynamic-grid/tests/nightwatch/dynamic-grid-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default dynamic-grid': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/dynamic-grid-tests/default`)

--- a/packages/terra-dynamic-grid/tests/nightwatch/dynamic-grid-spec.js
+++ b/packages/terra-dynamic-grid/tests/nightwatch/dynamic-grid-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default dynamic-grid': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/dynamic-grid-tests/default`)

--- a/packages/terra-embedded-content-consumer/tests/nightwatch/embedded-content-consumer-spec.js
+++ b/packages/terra-embedded-content-consumer/tests/nightwatch/embedded-content-consumer-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a provider embedded in the consumer that contains title text.': (browser) => {
     const consumerSrc = '#/tests/embedded-content-consumer-tests/basic-consumer';
     const providerSrc = '#/tests/embedded-content-consumer-tests/basic-provider';

--- a/packages/terra-embedded-content-consumer/tests/nightwatch/embedded-content-consumer-spec.js
+++ b/packages/terra-embedded-content-consumer/tests/nightwatch/embedded-content-consumer-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'huge'], {
+module.exports = resizeTo(['medium'], {
   'Displays a provider embedded in the consumer that contains title text.': (browser) => {
     const consumerSrc = '#/tests/embedded-content-consumer-tests/basic-consumer';
     const providerSrc = '#/tests/embedded-content-consumer-tests/basic-provider';

--- a/packages/terra-embedded-content-consumer/tests/nightwatch/embedded-content-consumer-spec.js
+++ b/packages/terra-embedded-content-consumer/tests/nightwatch/embedded-content-consumer-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a provider embedded in the consumer that contains title text.': (browser) => {
     const consumerSrc = '#/tests/embedded-content-consumer-tests/basic-consumer';
     const providerSrc = '#/tests/embedded-content-consumer-tests/basic-provider';

--- a/packages/terra-form-checkbox/tests/nightwatch/checkbox-spec.js
+++ b/packages/terra-form-checkbox/tests/nightwatch/checkbox-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default Checkbox': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/form-checkbox-tests/default`);
     browser.expect.element('#default').to.be.present;

--- a/packages/terra-form-checkbox/tests/nightwatch/checkbox-spec.js
+++ b/packages/terra-form-checkbox/tests/nightwatch/checkbox-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default Checkbox': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/form-checkbox-tests/default`);
     browser.expect.element('#default').to.be.present;

--- a/packages/terra-form-field/tests/nightwatch/form-field-spec.js
+++ b/packages/terra-form-field/tests/nightwatch/form-field-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a field with a label': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/form-field-tests/combinations`);
     browser.expect.element('#label').to.be.present.before(10000);

--- a/packages/terra-form-field/tests/nightwatch/form-field-spec.js
+++ b/packages/terra-form-field/tests/nightwatch/form-field-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a field with a label': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/form-field-tests/combinations`);
     browser.expect.element('#label').to.be.present.before(10000);

--- a/packages/terra-form-select/tests/nightwatch/select-option/select-option-spec.js
+++ b/packages/terra-form-select/tests/nightwatch/select-option/select-option-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays default option': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/select-option-tests/default`);
     browser.expect.element('#defaultOption').text.to.equal('Default');

--- a/packages/terra-form-select/tests/nightwatch/select-option/select-option-spec.js
+++ b/packages/terra-form-select/tests/nightwatch/select-option/select-option-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays default option': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/select-option-tests/default`);
     browser.expect.element('#defaultOption').text.to.equal('Default');

--- a/packages/terra-form-select/tests/nightwatch/select/select-spec.js
+++ b/packages/terra-form-select/tests/nightwatch/select/select-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default select': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/select-tests/default`);
     browser.expect.element('#defaultSelect').to.be.present;

--- a/packages/terra-form-select/tests/nightwatch/select/select-spec.js
+++ b/packages/terra-form-select/tests/nightwatch/select/select-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default select': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/select-tests/default`);
     browser.expect.element('#defaultSelect').to.be.present;

--- a/packages/terra-form-textarea/tests/nightwatch/textarea-spec.js
+++ b/packages/terra-form-textarea/tests/nightwatch/textarea-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default Textarea': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/form-textarea-tests/default`);
     browser.expect.element('textarea').to.be.present;

--- a/packages/terra-form-textarea/tests/nightwatch/textarea-spec.js
+++ b/packages/terra-form-textarea/tests/nightwatch/textarea-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default Textarea': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/form-textarea-tests/default`);
     browser.expect.element('textarea').to.be.present;

--- a/packages/terra-form/tests/nightwatch/control/control-spec.js
+++ b/packages/terra-form/tests/nightwatch/control/control-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default Control': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/control/default`)

--- a/packages/terra-form/tests/nightwatch/control/control-spec.js
+++ b/packages/terra-form/tests/nightwatch/control/control-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default Control': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/control/default`)

--- a/packages/terra-form/tests/nightwatch/field/field-spec.js
+++ b/packages/terra-form/tests/nightwatch/field/field-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default Field': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/field/default`)

--- a/packages/terra-form/tests/nightwatch/field/field-spec.js
+++ b/packages/terra-form/tests/nightwatch/field/field-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default Field': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/field/default`)

--- a/packages/terra-form/tests/nightwatch/fieldset/fieldset-spec.js
+++ b/packages/terra-form/tests/nightwatch/fieldset/fieldset-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default Fieldset': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/fieldset/default`)

--- a/packages/terra-form/tests/nightwatch/fieldset/fieldset-spec.js
+++ b/packages/terra-form/tests/nightwatch/fieldset/fieldset-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default Fieldset': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/fieldset/default`)

--- a/packages/terra-form/tests/nightwatch/input/input-spec.js
+++ b/packages/terra-form/tests/nightwatch/input/input-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default Input': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/input/default`)

--- a/packages/terra-form/tests/nightwatch/input/input-spec.js
+++ b/packages/terra-form/tests/nightwatch/input/input-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default Input': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/input/default`)

--- a/packages/terra-form/tests/nightwatch/number-field/number-field-spec.js
+++ b/packages/terra-form/tests/nightwatch/number-field/number-field-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default NumberField with a number input': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/number-field/default`)

--- a/packages/terra-form/tests/nightwatch/number-field/number-field-spec.js
+++ b/packages/terra-form/tests/nightwatch/number-field/number-field-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default NumberField with a number input': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/number-field/default`)

--- a/packages/terra-form/tests/nightwatch/select-field/select-field-spec.js
+++ b/packages/terra-form/tests/nightwatch/select-field/select-field-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default SelectField with a single option': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/select-field/default`)

--- a/packages/terra-form/tests/nightwatch/select-field/select-field-spec.js
+++ b/packages/terra-form/tests/nightwatch/select-field/select-field-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default SelectField with a single option': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/select-field/default`)

--- a/packages/terra-form/tests/nightwatch/select/select-spec.js
+++ b/packages/terra-form/tests/nightwatch/select/select-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default Select with a single option': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/select/default`)

--- a/packages/terra-form/tests/nightwatch/select/select-spec.js
+++ b/packages/terra-form/tests/nightwatch/select/select-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default Select with a single option': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/select/default`)

--- a/packages/terra-form/tests/nightwatch/text-field/text-field-spec.js
+++ b/packages/terra-form/tests/nightwatch/text-field/text-field-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default TextField with a text input': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/text-field/default`)

--- a/packages/terra-form/tests/nightwatch/text-field/text-field-spec.js
+++ b/packages/terra-form/tests/nightwatch/text-field/text-field-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default TextField with a text input': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/text-field/default`)

--- a/packages/terra-form/tests/nightwatch/textarea-field/textarea-field-spec.js
+++ b/packages/terra-form/tests/nightwatch/textarea-field/textarea-field-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default TextareaField with a number input': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/textarea-field/default`)

--- a/packages/terra-form/tests/nightwatch/textarea-field/textarea-field-spec.js
+++ b/packages/terra-form/tests/nightwatch/textarea-field/textarea-field-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default TextareaField with a number input': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/textarea-field/default`)

--- a/packages/terra-form/tests/nightwatch/textarea/textarea-spec.js
+++ b/packages/terra-form/tests/nightwatch/textarea/textarea-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default Textarea with a number input': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/textarea/default`)

--- a/packages/terra-form/tests/nightwatch/textarea/textarea-spec.js
+++ b/packages/terra-form/tests/nightwatch/textarea/textarea-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default Textarea with a number input': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/form-tests/textarea/default`)

--- a/packages/terra-grid/tests/nightwatch/grid-spec.js
+++ b/packages/terra-grid/tests/nightwatch/grid-spec.js
@@ -2,7 +2,7 @@
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
 /* eslint-disable no-unused-expressions */
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default grid': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/grid-tests/default`)

--- a/packages/terra-grid/tests/nightwatch/grid-spec.js
+++ b/packages/terra-grid/tests/nightwatch/grid-spec.js
@@ -2,7 +2,7 @@
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
 /* eslint-disable no-unused-expressions */
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default grid': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/grid-tests/default`)

--- a/packages/terra-heading/tests/nightwatch/heading-spec.js
+++ b/packages/terra-heading/tests/nightwatch/heading-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default heading component': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/heading-tests/default`);
     browser.expect.element('#heading-default').text.to.equal('Default');

--- a/packages/terra-heading/tests/nightwatch/heading-spec.js
+++ b/packages/terra-heading/tests/nightwatch/heading-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default heading component': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/heading-tests/default`);
     browser.expect.element('#heading-default').text.to.equal('Default');

--- a/packages/terra-hookshot/tests/nightwatch/hookshot-spec.js
+++ b/packages/terra-hookshot/tests/nightwatch/hookshot-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { resizeTo, screenWidth } = require('terra-toolkit/lib/nightwatch/responsive-helpers');
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   // minimum props
   'Displays default hookshot': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/hookshot-tests/default`);

--- a/packages/terra-hookshot/tests/nightwatch/hookshot-spec.js
+++ b/packages/terra-hookshot/tests/nightwatch/hookshot-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { resizeTo, screenWidth } = require('terra-toolkit/lib/nightwatch/responsive-helpers');
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   // minimum props
   'Displays default hookshot': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/hookshot-tests/default`);

--- a/packages/terra-i18n/tests/nightwatch/i18n-spec.js
+++ b/packages/terra-i18n/tests/nightwatch/i18n-spec.js
@@ -20,7 +20,7 @@ const defaultTranslations = enTranslations;
 
 const waitInms = 3000;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['medium'], {
   'Displays ajax error message in default': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/i18n-tests/default`)

--- a/packages/terra-icon/tests/nightwatch/icon-spec.js
+++ b/packages/terra-icon/tests/nightwatch/icon-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default icon with aria-hidden equal to true': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/icon-tests/default`)

--- a/packages/terra-image/tests/nightwatch/image-spec.js
+++ b/packages/terra-image/tests/nightwatch/image-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays an image with default options': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/image-tests/default`);
   },

--- a/packages/terra-image/tests/nightwatch/image-spec.js
+++ b/packages/terra-image/tests/nightwatch/image-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays an image with default options': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/image-tests/default`);
   },

--- a/packages/terra-list/tests/nightwatch/list-item/list-item-spec.js
+++ b/packages/terra-list/tests/nightwatch/list-item/list-item-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default list item': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/list-item-tests/default`)

--- a/packages/terra-list/tests/nightwatch/list-item/list-item-spec.js
+++ b/packages/terra-list/tests/nightwatch/list-item/list-item-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default list item': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/list-item-tests/default`)

--- a/packages/terra-list/tests/nightwatch/list/list-spec.js
+++ b/packages/terra-list/tests/nightwatch/list/list-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default list': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/list-tests/default`)

--- a/packages/terra-list/tests/nightwatch/list/list-spec.js
+++ b/packages/terra-list/tests/nightwatch/list/list-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default list': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/list-tests/default`)

--- a/packages/terra-list/tests/nightwatch/multi-select-list/multi-select-list-spec.js
+++ b/packages/terra-list/tests/nightwatch/multi-select-list/multi-select-list-spec.js
@@ -6,7 +6,7 @@ const { checkElementsClass } = require('../common.js');
 const listItemSelectors = ['ul li:nth-child(1)', 'ul li:nth-child(2)', 'ul li:nth-child(3)'];
 const selectedClasses = ['selected', 'selected', 'selected'];
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a multi select list': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/multi-select-list-tests/default`)

--- a/packages/terra-list/tests/nightwatch/multi-select-list/multi-select-list-spec.js
+++ b/packages/terra-list/tests/nightwatch/multi-select-list/multi-select-list-spec.js
@@ -6,7 +6,7 @@ const { checkElementsClass } = require('../common.js');
 const listItemSelectors = ['ul li:nth-child(1)', 'ul li:nth-child(2)', 'ul li:nth-child(3)'];
 const selectedClasses = ['selected', 'selected', 'selected'];
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a multi select list': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/multi-select-list-tests/default`)

--- a/packages/terra-list/tests/nightwatch/selectable-list/selectable-list-spec.js
+++ b/packages/terra-list/tests/nightwatch/selectable-list/selectable-list-spec.js
@@ -5,7 +5,7 @@ const { checkElementsClass } = require('../common.js');
 const listItemSelectors = ['ul li:nth-child(1)', 'ul li:nth-child(2)', 'ul li:nth-child(3)'];
 const selectedClasses = ['selected', 'selected', 'selected'];
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a selectable list': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/selectable-list-tests/default`)

--- a/packages/terra-list/tests/nightwatch/selectable-list/selectable-list-spec.js
+++ b/packages/terra-list/tests/nightwatch/selectable-list/selectable-list-spec.js
@@ -5,7 +5,7 @@ const { checkElementsClass } = require('../common.js');
 const listItemSelectors = ['ul li:nth-child(1)', 'ul li:nth-child(2)', 'ul li:nth-child(3)'];
 const selectedClasses = ['selected', 'selected', 'selected'];
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a selectable list': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/selectable-list-tests/default`)

--- a/packages/terra-list/tests/nightwatch/single-select-list/single-select-list-spec.js
+++ b/packages/terra-list/tests/nightwatch/single-select-list/single-select-list-spec.js
@@ -5,7 +5,7 @@ const { checkElementsClass } = require('../common.js');
 const listItemSelectors = ['ul li:nth-child(1)', 'ul li:nth-child(2)', 'ul li:nth-child(3)'];
 const selectedClasses = ['selected', 'selected', 'selected'];
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a single select list': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/single-select-list-tests/default`)

--- a/packages/terra-list/tests/nightwatch/single-select-list/single-select-list-spec.js
+++ b/packages/terra-list/tests/nightwatch/single-select-list/single-select-list-spec.js
@@ -5,7 +5,7 @@ const { checkElementsClass } = require('../common.js');
 const listItemSelectors = ['ul li:nth-child(1)', 'ul li:nth-child(2)', 'ul li:nth-child(3)'];
 const selectedClasses = ['selected', 'selected', 'selected'];
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a single select list': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/single-select-list-tests/default`)

--- a/packages/terra-markdown/tests/nightwatch/markdown-spec.js
+++ b/packages/terra-markdown/tests/nightwatch/markdown-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['medium'], {
   'Displays a props table': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/markdown/default`)
       .assert.elementPresent('[class*="markdown-body"]');

--- a/packages/terra-menu/tests/nightwatch/menu-item-group/menu-item-group-spec.js
+++ b/packages/terra-menu/tests/nightwatch/menu-item-group/menu-item-group-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default item group': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/menu-item-group-tests/default`)

--- a/packages/terra-menu/tests/nightwatch/menu-item-group/menu-item-group-spec.js
+++ b/packages/terra-menu/tests/nightwatch/menu-item-group/menu-item-group-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default item group': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/menu-item-group-tests/default`)

--- a/packages/terra-menu/tests/nightwatch/menu-item/menu-item-spec.js
+++ b/packages/terra-menu/tests/nightwatch/menu-item/menu-item-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default Menu.item': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/menu-item-tests/default`)

--- a/packages/terra-menu/tests/nightwatch/menu-item/menu-item-spec.js
+++ b/packages/terra-menu/tests/nightwatch/menu-item/menu-item-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default Menu.item': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/menu-item-tests/default`)

--- a/packages/terra-menu/tests/nightwatch/menu/menu-spec.js
+++ b/packages/terra-menu/tests/nightwatch/menu/menu-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default menu with expected content': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/menu-tests/default`);
     browser.click('#default-button');

--- a/packages/terra-menu/tests/nightwatch/menu/menu-spec.js
+++ b/packages/terra-menu/tests/nightwatch/menu/menu-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default menu with expected content': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/menu-tests/default`);
     browser.click('#default-button');

--- a/packages/terra-modal-manager/tests/nightwatch/modal-manager-spec.js
+++ b/packages/terra-modal-manager/tests/nightwatch/modal-manager-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Renders the ModalManager': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/modal-manager-tests/demo`);
     browser.expect.element('[class*="container"]').to.be.present;

--- a/packages/terra-modal-manager/tests/nightwatch/modal-manager-spec.js
+++ b/packages/terra-modal-manager/tests/nightwatch/modal-manager-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Renders the ModalManager': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/modal-manager-tests/demo`);
     browser.expect.element('[class*="container"]').to.be.present;

--- a/packages/terra-modal/tests/nightwatch/modal-spec.js
+++ b/packages/terra-modal/tests/nightwatch/modal-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Opens and closes a modal correctly': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/modal-tests/is-open`);
     browser.waitForElementPresent('.button-open-modal', 5000);

--- a/packages/terra-modal/tests/nightwatch/modal-spec.js
+++ b/packages/terra-modal/tests/nightwatch/modal-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Opens and closes a modal correctly': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/modal-tests/is-open`);
     browser.waitForElementPresent('.button-open-modal', 5000);

--- a/packages/terra-overlay/tests/nightwatch/LoadingOverlay/loading-overlay-spec.js
+++ b/packages/terra-overlay/tests/nightwatch/LoadingOverlay/loading-overlay-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default LoadingOverlay': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/loading-overlay-tests/default`);
 

--- a/packages/terra-overlay/tests/nightwatch/LoadingOverlay/loading-overlay-spec.js
+++ b/packages/terra-overlay/tests/nightwatch/LoadingOverlay/loading-overlay-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default LoadingOverlay': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/loading-overlay-tests/default`);
 

--- a/packages/terra-overlay/tests/nightwatch/Overlay/overlay-spec.js
+++ b/packages/terra-overlay/tests/nightwatch/Overlay/overlay-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default overlay': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/overlay-tests/default`);
 

--- a/packages/terra-overlay/tests/nightwatch/Overlay/overlay-spec.js
+++ b/packages/terra-overlay/tests/nightwatch/Overlay/overlay-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default overlay': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/overlay-tests/default`);
 

--- a/packages/terra-overlay/tests/nightwatch/OverlayContainer/overlay-container-spec.js
+++ b/packages/terra-overlay/tests/nightwatch/OverlayContainer/overlay-container-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default OverlayContainer': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/overlay-container-tests/default`);
     browser.assert.attributeEquals('#terra-OverlayContainer', 'tabIndex', '-1');

--- a/packages/terra-overlay/tests/nightwatch/OverlayContainer/overlay-container-spec.js
+++ b/packages/terra-overlay/tests/nightwatch/OverlayContainer/overlay-container-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default OverlayContainer': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/overlay-container-tests/default`);
     browser.assert.attributeEquals('#terra-OverlayContainer', 'tabIndex', '-1');

--- a/packages/terra-popup/tests/nightwatch/popup-spec.js
+++ b/packages/terra-popup/tests/nightwatch/popup-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { resizeTo, screenWidth } = require('terra-toolkit/lib/nightwatch/responsive-helpers');
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default popup & closes on width resize': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/popup-tests/default`);
     browser.expect.element('.test-content').to.be.present;

--- a/packages/terra-popup/tests/nightwatch/popup-spec.js
+++ b/packages/terra-popup/tests/nightwatch/popup-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { resizeTo, screenWidth } = require('terra-toolkit/lib/nightwatch/responsive-helpers');
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default popup & closes on width resize': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/popup-tests/default`);
     browser.expect.element('.test-content').to.be.present;

--- a/packages/terra-profile-image/tests/nightwatch/profile-image-spec.js
+++ b/packages/terra-profile-image/tests/nightwatch/profile-image-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a profile image': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/profile-image-tests/default`)

--- a/packages/terra-profile-image/tests/nightwatch/profile-image-spec.js
+++ b/packages/terra-profile-image/tests/nightwatch/profile-image-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a profile image': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/profile-image-tests/default`)

--- a/packages/terra-progress-bar/tests/nightwatch/progress-bar-spec.js
+++ b/packages/terra-progress-bar/tests/nightwatch/progress-bar-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default progress bar': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/progress-bar-tests/default`); // Browser computes #304FFE to rgba(48, 79, 254, 1);
   },

--- a/packages/terra-progress-bar/tests/nightwatch/progress-bar-spec.js
+++ b/packages/terra-progress-bar/tests/nightwatch/progress-bar-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default progress bar': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/progress-bar-tests/default`); // Browser computes #304FFE to rgba(48, 79, 254, 1);
   },

--- a/packages/terra-props-table/tests/nightwatch/props-table-spec.js
+++ b/packages/terra-props-table/tests/nightwatch/props-table-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['medium'], {
   'Displays a props table': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/props-table-tests/default`)
       .assert.elementPresent('[class*="markdown-body"]');

--- a/packages/terra-responsive-element/tests/nightwatch/responsive-element-spec.js
+++ b/packages/terra-responsive-element/tests/nightwatch/responsive-element-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { resizeTo, screenWidth } = require('terra-toolkit/lib/nightwatch/responsive-helpers');
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays the default element when contained within a parent of default size': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/responsive-element-tests/default`)

--- a/packages/terra-responsive-element/tests/nightwatch/responsive-element-spec.js
+++ b/packages/terra-responsive-element/tests/nightwatch/responsive-element-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { resizeTo, screenWidth } = require('terra-toolkit/lib/nightwatch/responsive-helpers');
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays the default element when contained within a parent of default size': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/responsive-element-tests/default`)

--- a/packages/terra-search-field/tests/nightwatch/search-field-spec.js
+++ b/packages/terra-search-field/tests/nightwatch/search-field-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a search field with search button': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/search-field-tests/default`);
 

--- a/packages/terra-search-field/tests/nightwatch/search-field-spec.js
+++ b/packages/terra-search-field/tests/nightwatch/search-field-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a search field with search button': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/search-field-tests/default`);
 

--- a/packages/terra-signature/tests/nightwatch/signature-spec.js
+++ b/packages/terra-signature/tests/nightwatch/signature-spec.js
@@ -5,7 +5,7 @@
 const { resizeTo } = require('terra-toolkit/lib/nightwatch/responsive-helpers');
 const constants = require('./SignatureConstants');
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default signature': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/signature-tests/default`);
     browser.expect.element('canvas[class*="signature"]').to.be.present;

--- a/packages/terra-signature/tests/nightwatch/signature-spec.js
+++ b/packages/terra-signature/tests/nightwatch/signature-spec.js
@@ -5,7 +5,7 @@
 const { resizeTo } = require('terra-toolkit/lib/nightwatch/responsive-helpers');
 const constants = require('./SignatureConstants');
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default signature': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/signature-tests/default`);
     browser.expect.element('canvas[class*="signature"]').to.be.present;

--- a/packages/terra-slide-group/tests/nightwatch/slide-group-spec.js
+++ b/packages/terra-slide-group/tests/nightwatch/slide-group-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default SlideGroup with the a few items': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/slide-group-tests/default`);
 

--- a/packages/terra-slide-group/tests/nightwatch/slide-group-spec.js
+++ b/packages/terra-slide-group/tests/nightwatch/slide-group-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default SlideGroup with the a few items': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/slide-group-tests/default`);
 

--- a/packages/terra-slide-panel/tests/nightwatch/slide-panel-spec.js
+++ b/packages/terra-slide-panel/tests/nightwatch/slide-panel-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a the SlidePanel with defaulted props': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/slide-panel-tests/default`);
 

--- a/packages/terra-slide-panel/tests/nightwatch/slide-panel-spec.js
+++ b/packages/terra-slide-panel/tests/nightwatch/slide-panel-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a the SlidePanel with defaulted props': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/slide-panel-tests/default`);
 

--- a/packages/terra-spacer/tests/nightwatch/spacer-spec.js
+++ b/packages/terra-spacer/tests/nightwatch/spacer-spec.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['medium'], {
   // Just the spacer component with <div> tag as child and without any props set
   'Displays a default spacer': (browser) => {
     browser

--- a/packages/terra-status/tests/nightwatch/status-spec.js
+++ b/packages/terra-status/tests/nightwatch/status-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['medium'], {
   'Displays a default status': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/status-tests/default`)

--- a/packages/terra-table/tests/nightwatch/multi-select-table/multi-select-table-spec.js
+++ b/packages/terra-table/tests/nightwatch/multi-select-table/multi-select-table-spec.js
@@ -29,7 +29,7 @@ let expectRowIsSelected;
 let expectRowIsNotSelected;
 let expectRow;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   beforeEach: (browser) => {
     expectRowIsSelected = index => expectRowForBrowserAtIndexIsSelected(browser, index);
     expectRowIsNotSelected = index => expectRowForBrowserAtIndexIsNotSelected(browser, index);

--- a/packages/terra-table/tests/nightwatch/multi-select-table/multi-select-table-spec.js
+++ b/packages/terra-table/tests/nightwatch/multi-select-table/multi-select-table-spec.js
@@ -29,7 +29,7 @@ let expectRowIsSelected;
 let expectRowIsNotSelected;
 let expectRow;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   beforeEach: (browser) => {
     expectRowIsSelected = index => expectRowForBrowserAtIndexIsSelected(browser, index);
     expectRowIsNotSelected = index => expectRowForBrowserAtIndexIsNotSelected(browser, index);

--- a/packages/terra-table/tests/nightwatch/selectable-table/selectable-table-rows-spec.js
+++ b/packages/terra-table/tests/nightwatch/selectable-table/selectable-table-rows-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default table with the provided text': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/selectable-table-tests/default`)

--- a/packages/terra-table/tests/nightwatch/selectable-table/selectable-table-rows-spec.js
+++ b/packages/terra-table/tests/nightwatch/selectable-table/selectable-table-rows-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default table with the provided text': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/selectable-table-tests/default`)

--- a/packages/terra-table/tests/nightwatch/single-select-table/single-select-table-spec.js
+++ b/packages/terra-table/tests/nightwatch/single-select-table/single-select-table-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default selectable table': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/single-select-table-tests/default`)

--- a/packages/terra-table/tests/nightwatch/single-select-table/single-select-table-spec.js
+++ b/packages/terra-table/tests/nightwatch/single-select-table/single-select-table-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default selectable table': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/single-select-table-tests/default`)

--- a/packages/terra-table/tests/nightwatch/table/table-spec.js
+++ b/packages/terra-table/tests/nightwatch/table/table-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays a default table with the provided text': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/table-tests/default`);
     browser.expect.element('#Table').to.be.present;

--- a/packages/terra-table/tests/nightwatch/table/table-spec.js
+++ b/packages/terra-table/tests/nightwatch/table/table-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays a default table with the provided text': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/table-tests/default`);
     browser.expect.element('#Table').to.be.present;

--- a/packages/terra-text/tests/nightwatch/text-spec.js
+++ b/packages/terra-text/tests/nightwatch/text-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['medium'], {
   'Displays a default text component': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/text-tests/default`);
     browser.expect.element('#text').text.to.equal('Default');

--- a/packages/terra-time-input/tests/nightwatch/time-input-spec.js
+++ b/packages/terra-time-input/tests/nightwatch/time-input-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Displays the time input with default props': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/time-input-tests/default`);
 

--- a/packages/terra-time-input/tests/nightwatch/time-input-spec.js
+++ b/packages/terra-time-input/tests/nightwatch/time-input-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Displays the time input with default props': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/time-input-tests/default`);
 

--- a/packages/terra-time-input/tests/nightwatch/time-input-twelve-hour-spec.js
+++ b/packages/terra-time-input/tests/nightwatch/time-input-twelve-hour-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['tiny', 'medium', 'huge'], {
   'Sets the fields appropriately for a morning time': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/time-input-tests/twelve-hour-filled-morning`);
 

--- a/packages/terra-time-input/tests/nightwatch/time-input-twelve-hour-spec.js
+++ b/packages/terra-time-input/tests/nightwatch/time-input-twelve-hour-spec.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'medium', 'huge'], {
+module.exports = resizeTo(['tiny', 'huge'], {
   'Sets the fields appropriately for a morning time': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/time-input-tests/twelve-hour-filled-morning`);
 

--- a/packages/terra-toggle-button/tests/nightwatch/toggle-button-spec.js
+++ b/packages/terra-toggle-button/tests/nightwatch/toggle-button-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['medium'], {
   'Displays a default toggle-button': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/toggle-button-tests/default`)

--- a/packages/terra-toggle/tests/nightwatch/toggle-spec.js
+++ b/packages/terra-toggle/tests/nightwatch/toggle-spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
 
-module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+module.exports = resizeTo(['medium'], {
   'Displays a default toggle': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/toggle-tests/default`)


### PR DESCRIPTION
### Summary
In an effort to reduce our Travis CI build times and prevent timeouts, the following screen sizes have been removed from various tests.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
