### PR TITLE
Move sort indicator closer to the content of the table header cell by…

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -47,6 +47,7 @@ Cerner Corporation
 - Gerard Isdell [@gerard-isdell]
 - Noah Benham [@noahbenham]
 - Andy Nelson [@anelson425]
+- Dan Plubell [@danplubell]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -95,3 +96,4 @@ Cerner Corporation
 [@gerard-isdell]: https://github.com/gerard-isdell
 [@noahbenham]: https://github.com/noahbenham
 [@anelson425]: https://github.com/anelson425
+[@danplubell]: https://github.com/danplubell

--- a/packages/terra-table/CHANGELOG.md
+++ b/packages/terra-table/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+###Changed
+* Moved table sort indicator 
 
 1.19.0 - (January 18, 2018)
 ------------------

--- a/packages/terra-table/src/Table.scss
+++ b/packages/terra-table/src/Table.scss
@@ -80,7 +80,7 @@
 
   .sort-indicator {
     color: var(--terra-table-sort-indicator-color, #1c1f21);
-    float: right;
+    padding-left: 0.7142857143rem;
   }
 
   .min-width-tiny {


### PR DESCRIPTION
… replacing float to the right with left padding (#1069)

### Summary
Removed the float right in Table.scss and replaces it with left padding.  The intent is to move the sort indicator closer to the content of the table header cell instead of at the end of the cell.
#1069 

