### PR TITLE
Corrected example region's import path.

### DIFF
--- a/packages/terra-dynamic-grid/CHANGELOG.md
+++ b/packages/terra-dynamic-grid/CHANGELOG.md
@@ -3,6 +3,7 @@ ChangeLog
 
 Unreleased
 -----------------
+* Corrected example Region import path.
 
 1.11.0 - (January 18, 2018)
 ------------------

--- a/packages/terra-dynamic-grid/docs/README.md
+++ b/packages/terra-dynamic-grid/docs/README.md
@@ -15,7 +15,7 @@ configuration. The component supports defining custom regions across multiple re
 ```jsx
 import React from 'react';
 import DynamicGrid from 'terra-dynamic-grid';
-import Region from 'terra-dynamic-grid/Region';
+import Region from 'terra-dynamic-grid/lib/Region';
 
 const template = {
   'grid-template-columns': '1fr 1fr',


### PR DESCRIPTION
### Summary
The example for Dynamic Grid has an incorrect import path for the Region component. It needed to path to `lib/`.