### PR TITLE
Lock Down selenium-chrome Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
     - node_modules
 before_install:
   - docker pull selenium/standalone-chrome:3.8.1-erbium
-  - docker run -v /dev/shm:/dev/shm -e TZ=America/Chicago -d -p 4444:4444 selenium/standalone-chrome
+  - docker run -v /dev/shm:/dev/shm -e TZ=America/Chicago -d -p 4444:4444 selenium/standalone-chrome:3.8.1-erbium
 before_deploy:
   - lerna run --scope terra-site compile:prod
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
   directories:
     - node_modules
 before_install:
-  - docker pull selenium/standalone-chrome
+  - docker pull selenium/standalone-chrome:3.8.1-erbium
   - docker run -v /dev/shm:/dev/shm -e TZ=America/Chicago -d -p 4444:4444 selenium/standalone-chrome
 before_deploy:
   - lerna run --scope terra-site compile:prod

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "stylelint-order": "^0.7.0",
     "stylelint-scss": "^2.0.0",
     "stylelint-suitcss": "^1.0.0",
-    "terra-toolkit": "^2.4.0",
+    "terra-toolkit": "git://github.com/cerner/terra-tookit.git#fix-tests",
     "wdio-mocha-framework": "^0.5.11",
     "wdio-visual-regression-service": "^0.8.0",
     "webdriverio": "4.9.9",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "stylelint-order": "^0.7.0",
     "stylelint-scss": "^2.0.0",
     "stylelint-suitcss": "^1.0.0",
-    "terra-toolkit": "git://github.com/cerner/terra-toolkit.git#fix-tests",
+    "terra-toolkit": "^2.7.0",
     "wdio-mocha-framework": "^0.5.11",
     "wdio-visual-regression-service": "^0.8.0",
     "webdriverio": "4.9.9",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "stylelint-order": "^0.7.0",
     "stylelint-scss": "^2.0.0",
     "stylelint-suitcss": "^1.0.0",
-    "terra-toolkit": "git://github.com/cerner/terra-tookit.git#fix-tests",
+    "terra-toolkit": "git://github.com/cerner/terra-toolkit.git#fix-tests",
     "wdio-mocha-framework": "^0.5.11",
     "wdio-visual-regression-service": "^0.8.0",
     "webdriverio": "4.9.9",


### PR DESCRIPTION
Two days ago docker-selenium [released a new version](https://github.com/SeleniumHQ/docker-selenium/commit/cfc1eeb5cdcea02395016685d7012688768ed342) of both selenium/node-chrome and selenium/standalone-chrome. In our tests we pull in the latest tag of both.

The previous version is `3.8.1-erbium` and the latest release is `3.8.1-francium`. 

This pulls the previous version to see if this resolves the issues we are seeing with the repeated
` Expected element ' ' to be present - element was not found`