### PR TITLE
Update Signature to 0.10.0

### DIFF
--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -78,7 +78,7 @@
     "terra-props-table": "^1.11.0",
     "terra-responsive-element": "^1.15.0",
     "terra-search-field": "^1.19.0",
-    "terra-signature": "^0.9.0",
+    "terra-signature": "^0.10.0",
     "terra-slide-group": "^1.15.0",
     "terra-slide-panel": "^1.15.0",
     "terra-spacer": "^1.2.0",


### PR DESCRIPTION
### Summary
terra-signature is not getting symlinked like it should. This is causing the build to fail. In order to symlink it, we need to uplift terra-site to use version 0.10.0.