### PR TITLE
Clean up terra-core-site updates

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,8 +6,7 @@
       "ignore": [
         "DEPENDENCIES.md",
         "terra-button",
-        "terra-dialog",
-        "terra-core-site"
+        "terra-dialog"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "compile": "lerna run compile",
     "compile:heroku": "cd packages/terra-site && npm run compile:heroku",
     "danger": "danger",
-    "deploy": "lerna run --scope terra-site deploy",
+    "deploy": "lerna run --scope terra-core-site deploy",
     "dependency-markdown": "node scripts/dependency-markdown-generator/DependencyMarkdownGenerator.js",
     "heroku-prebuild": "npm install rimraf && npm install -g lerna@2.1.2 && lerna init",
     "heroku-postbuild": "npm install --only=dev && npm run compile:heroku",


### PR DESCRIPTION
### Summary
The change in lerna.json fixes an issue which occurred in the last release. terra-core-site will still not be published as we have `"private": true` set in the package.json for terra-site. But it will be updated during lerna publish so during testing it will have the latest changes from all the symlinked files.

### Additional Details
Additionally, the root package deploy script is updated to account for the package rename of terra-site to terra-core-site.