### PR TITLE
Change British English version of Honor to American English

### DIFF
--- a/packages/terra-form-radio/src/Radio.scss
+++ b/packages/terra-form-radio/src/Radio.scss
@@ -62,7 +62,7 @@
         background-color: var(--terra-form-radio-inner-ring-background-color, transparent);
         border: var(--terra-form-radio-inner-ring-border, 0);
         border-radius: 50%;
-        box-shadow: 0 0 1px 1px #fff; //Safari: overrides span not honouring border-radius
+        box-shadow: 0 0 1px 1px #fff; //Safari: overrides span not honoring border-radius
         height: var(--terra-form-radio-inner-ring-height, 0);
         left: 50%;
         max-width: 100%;
@@ -91,7 +91,7 @@
         background-color: var(--terra-form-radio-inner-ring-checked-background-color, transparent);
         border: var(--terra-form-radio-inner-ring-checked-border, 0);
         border-radius: 50%;
-        box-shadow: 0 0 1px 1px #fff; //Safari: overrides span not honouring border-radius
+        box-shadow: 0 0 1px 1px #fff; //Safari: overrides span not honoring border-radius
         height: var(--terra-form-radio-inner-ring-checked-height, 0);
         left: 50%;
         position: absolute;


### PR DESCRIPTION
### Summary
Change British version of the word 'Honor' to stay consistent with American English throughout the project.
