### PR TITLE
Fix wdio timeouts

### DIFF
--- a/packages/terra-tabs/tests/wdio/tabs-spec.js
+++ b/packages/terra-tabs/tests/wdio/tabs-spec.js
@@ -16,7 +16,7 @@ describe('Tabs - Responsive', () => {
         browser.moveToObject('.tabContent');
       });
       Terra.should.matchScreenshot();
-      Terra.should.beAccessible({ viewports: [viewport] });
+      Terra.should.beAccessible();
     });
     describe('Extended', () => {
       beforeEach(() => {
@@ -25,7 +25,7 @@ describe('Tabs - Responsive', () => {
         browser.moveToObject('.tabContent');
       });
       Terra.should.matchScreenshot();
-      Terra.should.beAccessible({ viewports: [viewport] });
+      Terra.should.beAccessible();
     });
     describe('Icon Only Tabs', () => {
       beforeEach(() => {
@@ -34,7 +34,7 @@ describe('Tabs - Responsive', () => {
         browser.moveToObject('.tabContent');
       });
       Terra.should.matchScreenshot();
-      Terra.should.beAccessible({ viewports: [viewport] });
+      Terra.should.beAccessible();
     });
   });
 

--- a/packages/terra-tabs/tests/wdio/tabs-spec.js
+++ b/packages/terra-tabs/tests/wdio/tabs-spec.js
@@ -15,8 +15,8 @@ describe('Tabs - Responsive', () => {
         browser.setViewportSize(viewport);
         browser.moveToObject('.tabContent');
       });
-      Terra.should.matchScreenshot({ viewports });
-      Terra.should.beAccessible({ viewports });
+      Terra.should.matchScreenshot();
+      Terra.should.beAccessible({ viewports: [viewport] });
     });
     describe('Extended', () => {
       beforeEach(() => {
@@ -24,8 +24,8 @@ describe('Tabs - Responsive', () => {
         browser.setViewportSize(viewport);
         browser.moveToObject('.tabContent');
       });
-      Terra.should.matchScreenshot({ viewports });
-      Terra.should.beAccessible({ viewports });
+      Terra.should.matchScreenshot();
+      Terra.should.beAccessible({ viewports: [viewport] });
     });
     describe('Icon Only Tabs', () => {
       beforeEach(() => {
@@ -33,8 +33,8 @@ describe('Tabs - Responsive', () => {
         browser.setViewportSize(viewport);
         browser.moveToObject('.tabContent');
       });
-      Terra.should.matchScreenshot({ viewports });
-      Terra.should.beAccessible({ viewports });
+      Terra.should.matchScreenshot();
+      Terra.should.beAccessible({ viewports: [viewport] });
     });
   });
 


### PR DESCRIPTION
### Summary
Resolves #1216 WDIO tests are timing out. While looking through the tests, the tabs did a double for loop of rendering the same screenshots. You can see the original code here. 

https://github.com/cerner/terra-core/blob/master/packages/terra-tabs/tests/wdio/tabs-spec.js#L41

To fix it, we just take a screenshot of the current viewport the test is currently running at.