### PR TITLE
Update Peer Dependencies

### DIFF
--- a/packages/terra-alert/package.json
+++ b/packages/terra-alert/package.json
@@ -27,10 +27,10 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
-    "terra-button": "^1.14.0",
-    "terra-icon": "^1.18.0",
-    "terra-responsive-element": "^1.16.0"
+    "terra-base": "^3.0.0",
+    "terra-button": "^2.0.0",
+    "terra-icon": "^2.0.0",
+    "terra-responsive-element": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-arrange/package.json
+++ b/packages/terra-arrange/package.json
@@ -35,7 +35,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-badge/package.json
+++ b/packages/terra-badge/package.json
@@ -35,7 +35,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
+    "terra-base": "^3.0.0",
     "terra-mixins": "^1.13.0"
   },
   "dependencies": {

--- a/packages/terra-button-group/package.json
+++ b/packages/terra-button-group/package.json
@@ -26,8 +26,8 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
-    "terra-button": "^1.14.0"
+    "terra-base": "^3.0.0",
+    "terra-button": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-button/package.json
+++ b/packages/terra-button/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.8.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-card/package.json
+++ b/packages/terra-card/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
+    "terra-base": "^3.0.0",
     "terra-mixins": "^1.13.0"
   },
   "dependencies": {

--- a/packages/terra-collapsible-menu-view/package.json
+++ b/packages/terra-collapsible-menu-view/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-content-container/package.json
+++ b/packages/terra-content-container/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-date-picker/package.json
+++ b/packages/terra-date-picker/package.json
@@ -32,11 +32,11 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-portal": "^4.1.2",
-    "terra-base": "^2.11.0",
-    "terra-button": "^1.14.0",
-    "terra-form": "^1.17.0",
-    "terra-icon": "^1.18.0",
-    "terra-responsive-element": "^1.16.0"
+    "terra-base": "^3.0.0",
+    "terra-button": "^2.0.0",
+    "terra-form": "^2.0.0",
+    "terra-icon": "^2.0.0",
+    "terra-responsive-element": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-date-time-picker/package.json
+++ b/packages/terra-date-time-picker/package.json
@@ -32,11 +32,11 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
-    "terra-button": "^1.14.0",
-    "terra-date-picker": "^1.21.0",
-    "terra-modal": "^1.19.0",
-    "terra-time-input": "^1.18.0"
+    "terra-base": "^3.0.0",
+    "terra-button": "^2.0.0",
+    "terra-date-picker": "^2.0.0",
+    "terra-modal": "^2.0.0",
+    "terra-time-input": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-demographics-banner/package.json
+++ b/packages/terra-demographics-banner/package.json
@@ -27,7 +27,8 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0",
+    "terra-responsive-element": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-dialog/package.json
+++ b/packages/terra-dialog/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.0.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-divider/package.json
+++ b/packages/terra-divider/package.json
@@ -23,7 +23,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-dynamic-grid/package.json
+++ b/packages/terra-dynamic-grid/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "aphrodite": "^1.2.3",

--- a/packages/terra-embedded-content-consumer/package.json
+++ b/packages/terra-embedded-content-consumer/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
+    "terra-base": "^3.0.0",
     "xfc": "^1.0.0"
   },
   "dependencies": {

--- a/packages/terra-form-checkbox/package.json
+++ b/packages/terra-form-checkbox/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
+    "terra-base": "^3.0.0",
     "terra-mixins": "^1.13.0"
   },
   "dependencies": {

--- a/packages/terra-form-field/package.json
+++ b/packages/terra-form-field/package.json
@@ -27,8 +27,8 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
-    "terra-icon": "^1.18.0"
+    "terra-base": "^3.0.0",
+    "terra-icon": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-form-radio/package.json
+++ b/packages/terra-form-radio/package.json
@@ -24,9 +24,9 @@
     "terra-props-table": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
-    "terra-base": "^2.11.0"
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-form-select/package.json
+++ b/packages/terra-form-select/package.json
@@ -28,10 +28,10 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-arrange": "^1.19.0",
-    "terra-base": "^2.11.0",
-    "terra-icon": "^1.18.0",
-    "terra-popup": "^1.20.0"
+    "terra-arrange": "^2.0.0",
+    "terra-base": "^3.0.0",
+    "terra-icon": "^2.0.0",
+    "terra-popup": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-form-textarea/package.json
+++ b/packages/terra-form-textarea/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
+    "terra-base": "^3.0.0",
     "terra-mixins": "^1.13.0"
   },
   "dependencies": {

--- a/packages/terra-form/package.json
+++ b/packages/terra-form/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-grid/package.json
+++ b/packages/terra-grid/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-heading/package.json
+++ b/packages/terra-heading/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-hookshot/package.json
+++ b/packages/terra-hookshot/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-icon/package.json
+++ b/packages/terra-icon/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-image/package.json
+++ b/packages/terra-image/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-list/package.json
+++ b/packages/terra-list/package.json
@@ -26,8 +26,8 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
-    "terra-icon": "^1.18.0"
+    "terra-base": "^3.0.0",
+    "terra-icon": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-menu/package.json
+++ b/packages/terra-menu/package.json
@@ -26,13 +26,13 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-arrange": "^1.19.0",
-    "terra-base": "^2.11.0",
-    "terra-content-container": "^1.16.0",
-    "terra-icon": "^1.18.0",
-    "terra-list": "^1.20.0",
-    "terra-popup": "^1.20.0",
-    "terra-slide-group": "^1.16.0"
+    "terra-arrange": "^2.0.0",
+    "terra-base": "^3.0.0",
+    "terra-content-container": "^2.0.0",
+    "terra-icon": "^2.0.0",
+    "terra-list": "^2.0.0",
+    "terra-popup": "^2.0.0",
+    "terra-slide-group": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-overlay/package.json
+++ b/packages/terra-overlay/package.json
@@ -27,8 +27,8 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
-    "terra-icon": "^1.18.0"
+    "terra-base": "^3.0.0",
+    "terra-icon": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-popup/package.json
+++ b/packages/terra-popup/package.json
@@ -30,10 +30,10 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
-    "terra-content-container": "^1.16.0",
-    "terra-hookshot": "^1.8.0",
-    "terra-icon": "^1.18.0"
+    "terra-base": "^3.0.0",
+    "terra-content-container": "^2.0.0",
+    "terra-hookshot": "^2.0.0",
+    "terra-icon": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-profile-image/package.json
+++ b/packages/terra-profile-image/package.json
@@ -38,8 +38,8 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
-    "terra-image": "^1.16.0"
+    "terra-base": "^3.0.0",
+    "terra-image": "^2.0.0"
   },
   "dependencies": {
     "prop-types": "^15.5.8",

--- a/packages/terra-progress-bar/package.json
+++ b/packages/terra-progress-bar/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-responsive-element/package.json
+++ b/packages/terra-responsive-element/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "prop-types": "^15.5.8",

--- a/packages/terra-search-field/package.json
+++ b/packages/terra-search-field/package.json
@@ -27,10 +27,10 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
-    "terra-button": "^1.14.0",
-    "terra-form": "^1.17.0",
-    "terra-icon": "^1.18.0"
+    "terra-base": "^3.0.0",
+    "terra-button": "^2.0.0",
+    "terra-form": "^2.0.0",
+    "terra-icon": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-signature/package.json
+++ b/packages/terra-signature/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-slide-group/package.json
+++ b/packages/terra-slide-group/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-slide-panel/package.json
+++ b/packages/terra-slide-panel/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-spacer/package.json
+++ b/packages/terra-spacer/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-status-view/package.json
+++ b/packages/terra-status-view/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
+    "terra-base": "^3.0.0",
     "terra-mixins": "^1.13.0"
   },
   "dependencies": {

--- a/packages/terra-status/package.json
+++ b/packages/terra-status/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-table/package.json
+++ b/packages/terra-table/package.json
@@ -26,8 +26,8 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
-    "terra-icon": "^1.18.0"
+    "terra-base": "^3.0.0",
+    "terra-icon": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-tabs/package.json
+++ b/packages/terra-tabs/package.json
@@ -27,8 +27,8 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
-    "terra-menu": "^1.13.0"
+    "terra-base": "^3.0.0",
+    "terra-menu": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-text/package.json
+++ b/packages/terra-text/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-menu": "^3.0.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-text/package.json
+++ b/packages/terra-text/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-menu": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-time-input/package.json
+++ b/packages/terra-time-input/package.json
@@ -26,8 +26,8 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
-    "terra-form": "^1.17.0"
+    "terra-base": "^3.0.0",
+    "terra-form": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-toggle-button/package.json
+++ b/packages/terra-toggle-button/package.json
@@ -26,10 +26,10 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0",
-    "terra-button": "^1.14.0",
-    "terra-icon": "^1.18.0",
-    "terra-toggle": "^1.16.0"
+    "terra-base": "^3.0.0",
+    "terra-button": "^2.0.0",
+    "terra-icon": "^2.0.0",
+    "terra-toggle": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-toggle/package.json
+++ b/packages/terra-toggle/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^2.11.0"
+    "terra-base": "^3.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",


### PR DESCRIPTION
### Summary
Resolves #1241 

Peer Dependencies need to be updated to prevent the console errors from occurring.