### PR TITLE
Removed unclear button variant example

### DIFF
--- a/packages/terra-site/CHANGELOG.md
+++ b/packages/terra-site/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Removed unclear button variant example
 
 2.0.0 - (February 12, 2018)
 ------------------

--- a/packages/terra-site/src/examples/button/ButtonVariant.jsx
+++ b/packages/terra-site/src/examples/button/ButtonVariant.jsx
@@ -10,7 +10,6 @@ const ButtonVariant = () => (
     <Button text="Emphasis" variant="emphasis" style={buttonStyle} />
     <Button text="De-emphasis" variant="de-emphasis" style={buttonStyle} />
     <Button text="Action" variant="action" icon={<IconEdit />} style={buttonStyle} />
-    <Button isIconOnly text="Action" variant="action" icon={<IconEdit />} style={buttonStyle} />
     <Button text="Utility" variant="utility" icon={<IconEdit />} style={buttonStyle} />
   </div>
 );


### PR DESCRIPTION
### Summary
Removed unclear button variant example from `terra-site`.

Fixes: #1251 

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
