### PR TITLE
Fix Issue with locale switching

### DIFF
--- a/packages/terra-base/CHANGELOG.md
+++ b/packages/terra-base/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Fixed bug where new locales did not update correctly
 
 3.0.0 - (February 12, 2018)
 ------------------

--- a/packages/terra-base/src/Base.jsx
+++ b/packages/terra-base/src/Base.jsx
@@ -59,7 +59,7 @@ class Base extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.locale !== undefined && nextProps.locale !== this.props.locale) {
       try {
-        i18nLoader(this.props.locale, this.setState, this);
+        i18nLoader(nextProps.locale, this.setState, this);
       } catch (e) {
         console.error(e);
       }


### PR DESCRIPTION
### Summary
Locale switching broke when I uplifted it in React 16. Sorry about that.

Resolves #1236 