### PR TITLE
Incorrect import in Overlay Doc

### DIFF
--- a/packages/terra-overlay/docs/README.md
+++ b/packages/terra-overlay/docs/README.md
@@ -53,7 +53,7 @@ export default OverlayExample;
 ```jsx
 import React from 'react';
 import Button from 'terra-button';
-import Overlay.LoadingOverlay from 'terra-overlay';
+import Overlay from 'terra-overlay';
 
 class LoadingOverlayExample extends React.Component {
   constructor() {
@@ -73,7 +73,7 @@ class LoadingOverlayExample extends React.Component {
   render() {
     return (
       <div>
-        <LoadingOverlay isOpen={this.state.show} isAnimated />
+        <Overlay.LoadingOverlay isOpen={this.state.show} isAnimated />
         <Button onClick={this.handleTriggerOverlay}>Trigger Loading Overlay</Button>
       </div>
     );


### PR DESCRIPTION
### Summary
An overlay consumer came to me with an issue regarding how to import the LoadingOverlay. Looks like this was incorrectly documented. (Fun fact, I wrote the docs 😅)
