### PR TITLE
Fix button variant export typo

### DIFF
--- a/packages/terra-button/CHANGELOG.md
+++ b/packages/terra-button/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Added font-size theming variable to Button component.
+* Corrected `DE-EMPHSASIS` button variant typo
 
 2.0.0 - (February 23, 2018)
 ----------

--- a/packages/terra-button/src/Button.jsx
+++ b/packages/terra-button/src/Button.jsx
@@ -15,7 +15,7 @@ const KEYCODES = {
 const ButtonVariants = {
   NEUTRAL: 'neutral',
   EMPHASIS: 'emphasis',
-  'DE-EMPSHASIS': 'de-emphasis',
+  'DE-EMPHASIS': 'de-emphasis',
   ACTION: 'action',
   UTILITY: 'utility',
 };
@@ -86,7 +86,7 @@ const propTypes = {
   /**
    * Sets the button variant. One of `Button.Opts.Variants.NEUTRAL`,  `Button.Opts.Variants.EMPHASIS`, `Button.Opts.Variants['DE-EMPSHASIS']`, `Button.Opts.Variants.ACTION` or `Button.Opts.Variants.UTILITY`.
    */
-  variant: PropTypes.oneOf([ButtonVariants.NEUTRAL, ButtonVariants.EMPHASIS, ButtonVariants['DE-EMPSHASIS'], ButtonVariants.ACTION, ButtonVariants.UTILITY]),
+  variant: PropTypes.oneOf([ButtonVariants.NEUTRAL, ButtonVariants.EMPHASIS, ButtonVariants['DE-EMPHASIS'], ButtonVariants.ACTION, ButtonVariants.UTILITY]),
 };
 
 const defaultProps = {


### PR DESCRIPTION
### Summary
Corrected typo in button variant `DE-EMPHASIS` typo.

Fixes: #1276.


Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
