### PR TITLE
Copied fr translation to fr-FR.

### DIFF
--- a/packages/terra-time-input/translations/fr-FR.json
+++ b/packages/terra-time-input/translations/fr-FR.json
@@ -1,7 +1,7 @@
 {
   "Terra.timeInput.am": "a.m.",
   "Terra.timeInput.pm": "p.m.",
-  "Terra.timeInput.hours": "Hours",
+  "Terra.timeInput.hours": "Heures",
   "Terra.timeInput.minutes": "Minutes",
   "Terra.timeInput.hh": "HH",
   "Terra.timeInput.mm": "mm"


### PR DESCRIPTION
### Summary
When we requested timeInput translations, we allowed an English word to make it into the French/France locality.

We decided to copy the translation from the French language file into the French locality.

Closes #1283 

EDIT: We are checking with our translation team to get their opinion.
