### PR TITLE
Update terra-toggle to pull in latest minor release of react-animate-height

### DIFF
--- a/packages/terra-toggle/CHANGELOG.md
+++ b/packages/terra-toggle/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated package to use latest minor release of react-animate-height
 
 2.1.0 - (February 26, 2018)
 ------------------

--- a/packages/terra-toggle/package.json
+++ b/packages/terra-toggle/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "react-animate-height": "^0.9.5",
+    "react-animate-height": "^0",
     "terra-base": "^3.1.0"
   },
   "scripts": {

--- a/packages/terra-toggle/tests/jest/__snapshots__/Toggle.test.jsx.snap
+++ b/packages/terra-toggle/tests/jest/__snapshots__/Toggle.test.jsx.snap
@@ -20,6 +20,7 @@ exports[`Toggle should have all props set correctly 1`] = `
         "staticHeightZero": "rah-static--height-zero",
       }
     }
+    applyInlineTransitions={true}
     duration={250}
     easing="ease"
     height="auto"


### PR DESCRIPTION
### Summary
Updates terra-toggle to use the latest minor release of react-animate-height. Resolves #1281 

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
