### PR TITLE
Fix missing terra-mixins dependency in terra-dialog

### DIFF
--- a/packages/terra-dialog/package.json
+++ b/packages/terra-dialog/package.json
@@ -26,7 +26,8 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^3.0.0"
+    "terra-base": "^3.0.0",
+    "terra-mixins": "^1.13.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
@@ -34,7 +35,8 @@
     "terra-base": "^2.0.0",
     "terra-button": "^2.1.0",
     "terra-content-container": "^2.1.0",
-    "terra-icon": "^2.1.0"
+    "terra-icon": "^2.1.0",
+    "terra-mixins": "^1.13.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",


### PR DESCRIPTION
Terra Dialog is missing the terra-mixins dependency. It is used [here](https://github.com/cerner/terra-core/blob/master/packages/terra-dialog/src/Dialog.scss#L1).
