### PR TITLE
Make directories recursively for aggregated-translations

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -55,6 +55,7 @@ Cerner Corporation
 - Carter Harwood [@harwood]
 - Mukul Dhariwal [@mukuldhariwal94]
 - Praneeth Madamsetti [@praneethm381]
+- Alex Lende [@ajlende]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -112,3 +113,4 @@ Cerner Corporation
 [@harwood]: https://github.com/harwood
 [@mukuldhariwal94]: https://github.com/mukuldhariwal94
 [@praneethm381]: https://github.com/praneethm381
+[@ajlende]: https://github.com/ajlende

--- a/packages/terra-i18n-plugin/CHANGELOG.md
+++ b/packages/terra-i18n-plugin/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated to make directories recursively for `aggregated-translations`
 
 2.0.0 - (February 12, 2018)
 ------------------

--- a/packages/terra-i18n-plugin/src/I18nAggregatorPlugin.js
+++ b/packages/terra-i18n-plugin/src/I18nAggregatorPlugin.js
@@ -87,6 +87,12 @@ function aggregateTranslationMessages(options, inputFileSystem) {
   return languageMessages;
 }
 
+function mkdirpSync(directory) {
+  if (fs.existsSync(directory) && fs.statSync(directory).isDirectory()) return;
+  mkdirpSync(path.dirname(directory));
+  fs.mkdirSync(directory);
+}
+
 function aggregateTranslations(options, compiler) {
   compiler.plugin('after-environment', () => {
     let inputFileSystem = options.inputFileSystem;
@@ -104,9 +110,7 @@ function aggregateTranslations(options, compiler) {
       outputFileSystem.mkdirpSync(directoryPath);
     } else {
       outputFileSystem = fs;
-      if (!outputFileSystem.existsSync(directoryPath)) {
-        outputFileSystem.mkdirSync(directoryPath);
-      }
+      mkdirpSync(directoryPath);
     }
 
     // Create a file for each language for the aggregated messages


### PR DESCRIPTION
### Summary
Makes directories recursively (like `mkdir -p`) when creating the `aggregated-translations` directory. Fixes #1247