### PR TITLE
Update default prop snapshots

### DIFF
--- a/packages/terra-button-group/tests/jest/__snapshots__/ButtonGroupButton.test.jsx.snap
+++ b/packages/terra-button-group/tests/jest/__snapshots__/ButtonGroupButton.test.jsx.snap
@@ -12,8 +12,6 @@ exports[`should render a default component 1`] = `
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   text="Default Button"
-  type="button"
-  variant="neutral"
 />
 `;
 
@@ -29,8 +27,6 @@ exports[`should render as disabled 1`] = `
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   text="Disabled"
-  type="button"
-  variant="neutral"
 />
 `;
 
@@ -51,8 +47,6 @@ exports[`should render with icon only 1`] = `
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   text="Icon Only"
-  type="button"
-  variant="neutral"
 />
 `;
 
@@ -68,8 +62,6 @@ exports[`should render with onBlur 1`] = `
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   text="onBlur"
-  type="button"
-  variant="neutral"
 />
 `;
 
@@ -86,8 +78,6 @@ exports[`should render with onClick 1`] = `
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   text="onClick"
-  type="button"
-  variant="neutral"
 />
 `;
 
@@ -104,8 +94,6 @@ exports[`should render with onFocus 1`] = `
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   text="onFocus"
-  type="button"
-  variant="neutral"
 />
 `;
 
@@ -121,8 +109,6 @@ exports[`should render with onKeyDown 1`] = `
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   text="onKeyDown"
-  type="button"
-  variant="neutral"
 />
 `;
 
@@ -138,7 +124,5 @@ exports[`should render with onKeyUp 1`] = `
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   text="onKeyUp"
-  type="button"
-  variant="neutral"
 />
 `;

--- a/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewItem.test.jsx.snap
+++ b/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewItem.test.jsx.snap
@@ -5,7 +5,6 @@ exports[`CollapsibleMenuViewItem Collapsible Menu Context should not set icon on
   isActive={false}
   isDisabled={false}
   isSelected={false}
-  subMenuItems={Array []}
   text="Testing"
 />
 `;
@@ -15,7 +14,6 @@ exports[`CollapsibleMenuViewItem Collapsible Menu Context should not set icon pr
   isActive={false}
   isDisabled={false}
   isSelected={false}
-  subMenuItems={Array []}
   text="Testing"
 />
 `;
@@ -25,7 +23,6 @@ exports[`CollapsibleMenuViewItem Collapsible Menu Context should not set isRever
   isActive={false}
   isDisabled={false}
   isSelected={false}
-  subMenuItems={Array []}
   text="Testing"
 />
 `;
@@ -35,7 +32,6 @@ exports[`CollapsibleMenuViewItem Collapsible Menu Context should not set selecte
   isActive={false}
   isDisabled={false}
   isSelected={false}
-  subMenuItems={Array []}
   text="Testing"
 />
 `;
@@ -45,7 +41,6 @@ exports[`CollapsibleMenuViewItem Collapsible Menu Context should render a disabl
   isActive={false}
   isDisabled={true}
   isSelected={false}
-  subMenuItems={Array []}
   text="Testing"
 />
 `;
@@ -55,7 +50,6 @@ exports[`CollapsibleMenuViewItem Collapsible Menu Context should render a menu i
   isActive={false}
   isDisabled={false}
   isSelected={false}
-  subMenuItems={Array []}
   text="Testing"
 />
 `;
@@ -85,7 +79,6 @@ exports[`CollapsibleMenuViewItem Collapsible Menu Context should set selected pr
   isActive={false}
   isDisabled={false}
   isSelected={true}
-  subMenuItems={Array []}
   text="Testing"
 />
 `;
@@ -102,8 +95,6 @@ exports[`CollapsibleMenuViewItem should merge custom props 1`] = `
     isIconOnly={false}
     isReversed={false}
     text="Testing"
-    type="button"
-    variant="neutral"
   />
 </div>
 `;
@@ -119,8 +110,6 @@ exports[`CollapsibleMenuViewItem should not set isSelected on button outside of 
     isIconOnly={false}
     isReversed={false}
     text="Testing"
-    type="button"
-    variant="neutral"
   />
 </div>
 `;
@@ -150,8 +139,6 @@ exports[`CollapsibleMenuViewItem should render a button with icon and no text wh
     isIconOnly={true}
     isReversed={false}
     text=""
-    type="button"
-    variant="neutral"
   />
 </div>
 `;
@@ -167,8 +154,6 @@ exports[`CollapsibleMenuViewItem should render a default component 1`] = `
     isIconOnly={false}
     isReversed={false}
     text="Testing"
-    type="button"
-    variant="neutral"
   />
 </div>
 `;
@@ -191,8 +176,6 @@ exports[`CollapsibleMenuViewItem should render a disabled button when isDisabled
     isIconOnly={false}
     isReversed={false}
     text="Testing"
-    type="button"
-    variant="neutral"
   />
 </div>
 `;
@@ -221,7 +204,6 @@ exports[`CollapsibleMenuViewItem should render a menu when subMenuItems are give
     isReversed={false}
     isSelected={false}
     key="1"
-    shouldCloseOnClick={true}
     text="Menu Item"
   />
 </CollapsibleMenu>
@@ -245,8 +227,6 @@ exports[`CollapsibleMenuViewItem should set icon prop on button 1`] = `
     isIconOnly={false}
     isReversed={false}
     text="Testing"
-    type="button"
-    variant="neutral"
   />
 </div>
 `;
@@ -269,8 +249,6 @@ exports[`CollapsibleMenuViewItem should set isReversed prop on button 1`] = `
     isIconOnly={false}
     isReversed={true}
     text="Testing"
-    type="button"
-    variant="neutral"
   />
 </div>
 `;

--- a/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewItemGroup.test.jsx.snap
+++ b/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewItemGroup.test.jsx.snap
@@ -10,14 +10,12 @@ exports[`CollapsibleMenuViewItemGroup Collapsible Menu Context should merge cust
     isIconOnly={false}
     isReversed={false}
     isSelected={false}
-    shouldCloseOnClick={true}
     text="Testing"
   />
   <CollapsibleMenuViewItem
     isIconOnly={false}
     isReversed={false}
     isSelected={false}
-    shouldCloseOnClick={true}
     text="Testing"
   />
 </List>
@@ -33,7 +31,6 @@ exports[`CollapsibleMenuViewItemGroup Collapsible Menu Context should merge cust
     isReversed={false}
     isSelected={false}
     key="key1"
-    shouldCloseOnClick={true}
     text="Testing"
   />
   <CollapsibleMenuViewItem
@@ -41,7 +38,6 @@ exports[`CollapsibleMenuViewItemGroup Collapsible Menu Context should merge cust
     isReversed={false}
     isSelected={false}
     key="key2"
-    shouldCloseOnClick={true}
     text="Testing"
   />
 </MenuItemGroup>
@@ -56,7 +52,6 @@ exports[`CollapsibleMenuViewItemGroup Collapsible Menu Context should render a m
     isReversed={false}
     isSelected={false}
     key="key1"
-    shouldCloseOnClick={true}
     text="Testing"
   />
   <CollapsibleMenuViewItem
@@ -64,7 +59,6 @@ exports[`CollapsibleMenuViewItemGroup Collapsible Menu Context should render a m
     isReversed={false}
     isSelected={false}
     key="key2"
-    shouldCloseOnClick={true}
     text="Testing"
   />
 </MenuItemGroup>
@@ -79,14 +73,12 @@ exports[`CollapsibleMenuViewItemGroup Collapsible Menu Context should render men
     isIconOnly={false}
     isReversed={false}
     isSelected={false}
-    shouldCloseOnClick={true}
     text="Testing"
   />
   <CollapsibleMenuViewItem
     isIconOnly={false}
     isReversed={false}
     isSelected={false}
-    shouldCloseOnClick={true}
     text="Testing"
   />
 </List>
@@ -101,14 +93,12 @@ exports[`CollapsibleMenuViewItemGroup should merge custom props 1`] = `
     isIconOnly={false}
     isReversed={false}
     isSelected={false}
-    shouldCloseOnClick={true}
     text="Testing"
   />
   <CollapsibleMenuViewItem
     isIconOnly={false}
     isReversed={false}
     isSelected={false}
-    shouldCloseOnClick={true}
     text="Testing"
   />
 </ButtonGroup>
@@ -123,14 +113,12 @@ exports[`CollapsibleMenuViewItemGroup should render a default component 1`] = `
     isIconOnly={false}
     isReversed={false}
     isSelected={false}
-    shouldCloseOnClick={true}
     text="Testing"
   />
   <CollapsibleMenuViewItem
     isIconOnly={false}
     isReversed={false}
     isSelected={false}
-    shouldCloseOnClick={true}
     text="Testing"
   />
 </ButtonGroup>
@@ -150,7 +138,6 @@ exports[`CollapsibleMenuViewItemGroup should render a selectable button group 1`
     isReversed={false}
     isSelected={false}
     key="key1"
-    shouldCloseOnClick={true}
     text="Testing"
   />
   <CollapsibleMenuViewItem
@@ -158,7 +145,6 @@ exports[`CollapsibleMenuViewItemGroup should render a selectable button group 1`
     isReversed={false}
     isSelected={false}
     key="key2"
-    shouldCloseOnClick={true}
     text="Testing"
   />
 </ButtonGroup>

--- a/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewToggle.test.jsx.snap
+++ b/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewToggle.test.jsx.snap
@@ -6,7 +6,6 @@ exports[`CollapsibleMenuViewToggle Collapsible Menu Context should render a sele
   isDisabled={false}
   isSelectable={true}
   isSelected={false}
-  subMenuItems={Array []}
   text="Testing"
 />
 `;
@@ -17,7 +16,6 @@ exports[`CollapsibleMenuViewToggle Collapsible Menu Context should set isDisable
   isDisabled={true}
   isSelectable={true}
   isSelected={false}
-  subMenuItems={Array []}
   text="Testing"
 />
 `;
@@ -28,7 +26,6 @@ exports[`CollapsibleMenuViewToggle Collapsible Menu Context should set isSelecta
   isDisabled={false}
   isSelectable={false}
   isSelected={false}
-  subMenuItems={Array []}
   text="Testing"
 />
 `;
@@ -39,7 +36,6 @@ exports[`CollapsibleMenuViewToggle Collapsible Menu Context should set selected 
   isDisabled={false}
   isSelectable={true}
   isSelected={true}
-  subMenuItems={Array []}
   text="Testing"
 />
 `;
@@ -58,7 +54,6 @@ exports[`CollapsibleMenuViewToggle should disable checkbox when isSelectable is 
     }
     isInline={false}
     labelText="Testing"
-    labelTextAttrs={Object {}}
     name={null}
     onChange={[Function]}
     type="checkbox"
@@ -80,7 +75,6 @@ exports[`CollapsibleMenuViewToggle should merge custom props 1`] = `
     }
     isInline={false}
     labelText="Testing"
-    labelTextAttrs={Object {}}
     name={null}
     onChange={[Function]}
     type="checkbox"
@@ -102,7 +96,6 @@ exports[`CollapsibleMenuViewToggle should render a default component 1`] = `
     }
     isInline={false}
     labelText="Testing"
-    labelTextAttrs={Object {}}
     name={null}
     onChange={[Function]}
     type="checkbox"
@@ -124,7 +117,6 @@ exports[`CollapsibleMenuViewToggle should set defaultChecked prop 1`] = `
     }
     isInline={false}
     labelText="Testing"
-    labelTextAttrs={Object {}}
     name={null}
     onChange={[Function]}
     type="checkbox"
@@ -146,7 +138,6 @@ exports[`CollapsibleMenuViewToggle should set isDisabled prop 1`] = `
     }
     isInline={false}
     labelText="Testing"
-    labelTextAttrs={Object {}}
     name={null}
     onChange={[Function]}
     type="checkbox"

--- a/packages/terra-demographics-banner/tests/jest/__snapshots__/DemographicsBanner.test.jsx.snap
+++ b/packages/terra-demographics-banner/tests/jest/__snapshots__/DemographicsBanner.test.jsx.snap
@@ -5,7 +5,6 @@ exports[`renders a blank banner wrapper 1`] = `
   applicationContent={null}
   deceasedDate={null}
   gestationalAge={null}
-  identifiers={Object {}}
   photo={null}
   postMenstrualAge={null}
   preferredFirstName={null}

--- a/packages/terra-demographics-banner/tests/jest/__snapshots__/_LargeDemographicsBannerDisplay.test.jsx.snap
+++ b/packages/terra-demographics-banner/tests/jest/__snapshots__/_LargeDemographicsBannerDisplay.test.jsx.snap
@@ -22,7 +22,6 @@ exports[`renders large banner that contains all valid information 1`] = `
       alt="My Cat"
       isFluid={false}
       src=""
-      variant="default"
     />
   </div>
   <div

--- a/packages/terra-dynamic-grid/tests/jest/__snapshots__/DynamicGrid.test.jsx.snap
+++ b/packages/terra-dynamic-grid/tests/jest/__snapshots__/DynamicGrid.test.jsx.snap
@@ -22,14 +22,7 @@ exports[`DynamicGrid should render a default component 2`] = `
 <div
   className="grid_3hmsj"
 >
-  <Region
-    defaultPosition={Object {}}
-    huge={Object {}}
-    large={Object {}}
-    medium={Object {}}
-    small={Object {}}
-    tiny={Object {}}
-  >
+  <Region>
     Hello
   </Region>
 </div>

--- a/packages/terra-form-field/tests/jest/__snapshots__/Field.test.jsx.snap
+++ b/packages/terra-form-field/tests/jest/__snapshots__/Field.test.jsx.snap
@@ -15,10 +15,7 @@ exports[`should render a field error message 1`] = `
     <div
       className="error-icon-hidden"
     >
-      <IconError
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconError />
     </div>
   </div>
 </div>
@@ -39,10 +36,7 @@ exports[`should render a field help message 1`] = `
     <div
       className="error-icon-hidden"
     >
-      <IconError
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconError />
     </div>
   </div>
   <div
@@ -63,10 +57,7 @@ exports[`should render a field in error 1`] = `
     <div
       className="error-icon"
     >
-      <IconError
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconError />
     </div>
     <label
       className="label"
@@ -102,10 +93,7 @@ exports[`should render a field label 1`] = `
     <div
       className="error-icon-hidden"
     >
-      <IconError
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconError />
     </div>
   </div>
 </div>
@@ -126,10 +114,7 @@ exports[`should render a field with a custom error icon 1`] = `
     <div
       className="error-icon-hidden"
     >
-      <IconHelp
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconHelp />
     </div>
   </div>
 </div>
@@ -150,10 +135,7 @@ exports[`should render a field with a hidden label 1`] = `
     <div
       className="error-icon-hidden"
     >
-      <IconError
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconError />
     </div>
   </div>
 </div>
@@ -169,10 +151,7 @@ exports[`should render a field with a hidden label in error 1`] = `
     <div
       className="error-icon"
     >
-      <IconError
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconError />
     </div>
     <label
       className="label"
@@ -203,10 +182,7 @@ exports[`should render a required field in error 1`] = `
     <div
       className="error-icon"
     >
-      <IconError
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconError />
     </div>
     <label
       className="label"
@@ -252,10 +228,7 @@ exports[`should render a required field label 1`] = `
     <div
       className="error-icon-hidden"
     >
-      <IconError
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconError />
     </div>
   </div>
 </div>
@@ -281,10 +254,7 @@ exports[`should render a required field label with required hidden 1`] = `
     <div
       className="error-icon-hidden"
     >
-      <IconError
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconError />
     </div>
   </div>
 </div>
@@ -310,10 +280,7 @@ exports[`should render a required field with a hidden label 1`] = `
     <div
       className="error-icon-hidden"
     >
-      <IconError
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconError />
     </div>
   </div>
 </div>
@@ -329,10 +296,7 @@ exports[`should render a required field with a hidden label in error 1`] = `
     <div
       className="error-icon"
     >
-      <IconError
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconError />
     </div>
     <label
       className="label"
@@ -374,10 +338,7 @@ exports[`should render an inline field with most of the possible props are passe
     <div
       className="error-icon-hidden"
     >
-      <IconError
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconError />
     </div>
   </div>
   <input
@@ -402,10 +363,7 @@ exports[`should render an optional field in error 1`] = `
     <div
       className="error-icon"
     >
-      <IconError
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconError />
     </div>
     <label
       className="label"
@@ -451,10 +409,7 @@ exports[`should render an optional field label 1`] = `
     <div
       className="error-icon-hidden"
     >
-      <IconError
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <IconError />
     </div>
   </div>
 </div>

--- a/packages/terra-form/tests/jest/__snapshots__/TextareaField.test.jsx.snap
+++ b/packages/terra-form/tests/jest/__snapshots__/TextareaField.test.jsx.snap
@@ -7,7 +7,6 @@ exports[`should render a TextAreaField with the rest of the props 1`] = `
   htmlFor="description"
   isInline={true}
   label="Profile Description"
-  labelAttrs={Object {}}
   required={true}
 >
   <Textarea
@@ -29,7 +28,6 @@ exports[`should render a default TextAreaField component 1`] = `
   help={null}
   isInline={false}
   label={null}
-  labelAttrs={Object {}}
   required={false}
 >
   <Textarea

--- a/packages/terra-hookshot/tests/jest/__snapshots__/Hookshot.test.jsx.snap
+++ b/packages/terra-hookshot/tests/jest/__snapshots__/Hookshot.test.jsx.snap
@@ -11,7 +11,6 @@ exports[`should render a default component 1`] = `
 exports[`should shallow a default component 1`] = `
 <div>
   <Hookshot
-    attachmentBehavior="auto"
     attachmentMargin={0}
     contentAttachment={
       Object {
@@ -19,20 +18,8 @@ exports[`should shallow a default component 1`] = `
         "vertical": "top",
       }
     }
-    contentOffset={
-      Object {
-        "horizontal": 0,
-        "vertical": 0,
-      }
-    }
     isEnabled={true}
     isOpen={false}
-    targetOffset={
-      Object {
-        "horizontal": 0,
-        "vertical": 0,
-      }
-    }
     targetRef={[Function]}
   >
     <OnClickOutside(HookshotContent)

--- a/packages/terra-icon/tests/jest/__snapshots__/Icon.test.jsx.snap
+++ b/packages/terra-icon/tests/jest/__snapshots__/Icon.test.jsx.snap
@@ -4,12 +4,9 @@ exports[`Icon IconAdd should shallow IconBase 1`] = `
 <IconBase
   ariaLabel={null}
   data-name="Layer 1"
-  focusable="false"
-  height="1em"
   isBidi={false}
   isSpin={false}
   viewBox="0 0 48 48"
-  width="1em"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
@@ -40,12 +37,9 @@ exports[`Icon IconComment should shallow IconBase 1`] = `
   ariaLabel={null}
   className=""
   data-name="Layer 1"
-  focusable="false"
-  height="1em"
   isBidi={true}
   isSpin={false}
   viewBox="0 0 48 48"
-  width="1em"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
@@ -59,12 +53,9 @@ exports[`Icon IconSpinner should shallow IconBase 1`] = `
   ariaLabel={null}
   className=""
   data-name="Layer 1"
-  focusable="false"
-  height="1em"
   isBidi={false}
   isSpin={true}
   viewBox="0 0 48 48"
-  width="1em"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path

--- a/packages/terra-menu/tests/jest/__snapshots__/Menu.test.jsx.snap
+++ b/packages/terra-menu/tests/jest/__snapshots__/Menu.test.jsx.snap
@@ -3,7 +3,6 @@
 exports[`Menu should render a default component 1`] = `
 <div>
   <Menu
-    contentWidth="240"
     isArrowDisplayed={false}
     isOpen={true}
     onRequestClose={[Function]}
@@ -13,7 +12,6 @@ exports[`Menu should render a default component 1`] = `
       isActive={false}
       isDisabled={false}
       isSelected={false}
-      subMenuItems={Array []}
       text="testing"
     />
   </Menu>

--- a/packages/terra-modal/tests/jest/__snapshots__/Modal.test.jsx.snap
+++ b/packages/terra-modal/tests/jest/__snapshots__/Modal.test.jsx.snap
@@ -84,14 +84,10 @@ exports[`should shallow an open modal 1`] = `
     ariaLabel="Terra Modal"
     classNameModal={null}
     classNameOverlay={null}
-    closeOnEsc={true}
-    closeOnOutsideClick={true}
-    isFocused={true}
     isFullscreen={false}
     isOpen={true}
     isScrollable={false}
     onRequestClose={[Function]}
-    role="document"
   >
     <div>
       <h1>

--- a/packages/terra-overlay/tests/jest/__snapshots__/Overlay.test.jsx.snap
+++ b/packages/terra-overlay/tests/jest/__snapshots__/Overlay.test.jsx.snap
@@ -4,11 +4,7 @@ exports[`Overlay should render a null component when isOpen is not provided 1`] 
 
 exports[`Overlay when isOpen is provided -backgroundStyle- should render with the clear backgroundStyle 1`] = `
 <FocusTrap
-  _createFocusTrap={[Function]}
-  active={true}
-  focusTrapOptions={Object {}}
   paused={false}
-  tag="div"
 >
   <div
     className="overlay fullscreen clear"
@@ -24,11 +20,7 @@ exports[`Overlay when isOpen is provided -backgroundStyle- should render with th
 
 exports[`Overlay when isOpen is provided -backgroundStyle- should render with the dark backgroundStyle 1`] = `
 <FocusTrap
-  _createFocusTrap={[Function]}
-  active={true}
-  focusTrapOptions={Object {}}
   paused={false}
-  tag="div"
 >
   <div
     className="overlay fullscreen dark"
@@ -44,11 +36,7 @@ exports[`Overlay when isOpen is provided -backgroundStyle- should render with th
 
 exports[`Overlay when isOpen is provided -backgroundStyle- should render with the light backgroundStyle 1`] = `
 <FocusTrap
-  _createFocusTrap={[Function]}
-  active={true}
-  focusTrapOptions={Object {}}
   paused={false}
-  tag="div"
 >
   <div
     className="overlay fullscreen light"
@@ -64,11 +52,7 @@ exports[`Overlay when isOpen is provided -backgroundStyle- should render with th
 
 exports[`Overlay when isOpen is provided -default Overlay when isOpen- should render a default component 1`] = `
 <FocusTrap
-  _createFocusTrap={[Function]}
-  active={true}
-  focusTrapOptions={Object {}}
   paused={false}
-  tag="div"
 >
   <div
     className="overlay fullscreen light"
@@ -84,11 +68,7 @@ exports[`Overlay when isOpen is provided -default Overlay when isOpen- should re
 
 exports[`Overlay when isOpen is provided should render with content 1`] = `
 <FocusTrap
-  _createFocusTrap={[Function]}
-  active={true}
-  focusTrapOptions={Object {}}
   paused={false}
-  tag="div"
 >
   <div
     className="overlay fullscreen light"
@@ -118,11 +98,7 @@ exports[`Overlay when isOpen is provided should render with isRelativeToContaine
 
 exports[`Overlay when isOpen is provided should render with isScrollable 1`] = `
 <FocusTrap
-  _createFocusTrap={[Function]}
-  active={true}
-  focusTrapOptions={Object {}}
   paused={false}
-  tag="div"
 >
   <div
     className="overlay fullscreen light scrollable"
@@ -138,11 +114,7 @@ exports[`Overlay when isOpen is provided should render with isScrollable 1`] = `
 
 exports[`Overlay when isOpen is provided should render with onRequestClose 1`] = `
 <FocusTrap
-  _createFocusTrap={[Function]}
-  active={true}
-  focusTrapOptions={Object {}}
   paused={false}
-  tag="div"
 >
   <div
     className="overlay fullscreen light"

--- a/packages/terra-overlay/tests/jest/__snapshots__/OverlayContainer.test.jsx.snap
+++ b/packages/terra-overlay/tests/jest/__snapshots__/OverlayContainer.test.jsx.snap
@@ -13,7 +13,6 @@ exports[`OverlayContainer should render when children are provided 1`] = `
   tabIndex="-1"
 >
   <Overlay
-    backgroundStyle="light"
     isOpen={false}
     isRelativeToContainer={false}
     isScrollable={false}

--- a/packages/terra-popup/tests/jest/__snapshots__/Popup.test.jsx.snap
+++ b/packages/terra-popup/tests/jest/__snapshots__/Popup.test.jsx.snap
@@ -3,14 +3,10 @@
 exports[`should shallow a default component 1`] = `
 <div>
   <Popup
-    attachmentBehavior="auto"
     boundingRef={null}
     classNameArrow={null}
     classNameContent={null}
     classNameOverlay={null}
-    contentAttachment="top center"
-    contentHeight="80"
-    contentWidth="240"
     isArrowDisplayed={false}
     isContentFocusDisabled={false}
     isHeaderDisabled={false}

--- a/packages/terra-profile-image/tests/jest/__snapshots__/ProfileImage.test.jsx.snap
+++ b/packages/terra-profile-image/tests/jest/__snapshots__/ProfileImage.test.jsx.snap
@@ -3,7 +3,6 @@
 exports[`should render a Terra image with a placeholder prop 1`] = `
 <div>
   <Image
-    alt=" "
     height="75"
     isFluid={false}
     placeholder={
@@ -15,7 +14,6 @@ exports[`should render a Terra image with a placeholder prop 1`] = `
       />
     }
     src="profile.jpg"
-    variant="default"
     width="75"
   />
 </div>

--- a/packages/terra-search-field/tests/jest/__snapshots__/SearchField.test.jsx.snap
+++ b/packages/terra-search-field/tests/jest/__snapshots__/SearchField.test.jsx.snap
@@ -31,8 +31,6 @@ exports[`Snapshots renders a basic search field 1`] = `
     isReversed={false}
     onClick={[Function]}
     text="Search"
-    type="button"
-    variant="neutral"
   />
 </div>
 `;
@@ -68,8 +66,6 @@ exports[`Snapshots renders a disabled search field with a value 1`] = `
     isReversed={false}
     onClick={[Function]}
     text="Search"
-    type="button"
-    variant="neutral"
   />
 </div>
 `;
@@ -105,8 +101,6 @@ exports[`Snapshots renders a search field that displays as a block to fill its c
     isReversed={false}
     onClick={[Function]}
     text="Search"
-    type="button"
-    variant="neutral"
   />
 </div>
 `;
@@ -143,8 +137,6 @@ exports[`Snapshots renders a search field with a defaulted value 1`] = `
     isReversed={false}
     onClick={[Function]}
     text="Search"
-    type="button"
-    variant="neutral"
   />
 </div>
 `;
@@ -180,8 +172,6 @@ exports[`Snapshots renders a search field with a placeholder 1`] = `
     isReversed={false}
     onClick={[Function]}
     text="Search"
-    type="button"
-    variant="neutral"
   />
 </div>
 `;
@@ -218,8 +208,6 @@ exports[`Snapshots renders a search field with a value 1`] = `
     isReversed={false}
     onClick={[Function]}
     text="Search"
-    type="button"
-    variant="neutral"
   />
 </div>
 `;

--- a/packages/terra-slide-group/tests/jest/__snapshots__/SlideGroup.test.jsx.snap
+++ b/packages/terra-slide-group/tests/jest/__snapshots__/SlideGroup.test.jsx.snap
@@ -2,9 +2,7 @@
 
 exports[`should render a SlideGroup with animation enabled 1`] = `
 <TransitionGroup
-  childFactory={[Function]}
   className="slide-group"
-  component="div"
   key="1"
 >
   <CSSTransition
@@ -93,9 +91,7 @@ exports[`should render a SlideGroup with animation enabled 1`] = `
 
 exports[`should render a default SlideGroup 1`] = `
 <TransitionGroup
-  childFactory={[Function]}
   className="slide-group"
-  component="div"
   key="1"
 >
   <CSSTransition

--- a/packages/terra-table/tests/jest/__snapshots__/Table.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/Table.test.jsx.snap
@@ -8,17 +8,14 @@ exports[`should render a default table 1`] = `
     <TableHeaderCell
       content="Name"
       key="NAME"
-      minWidth="small"
     />
     <TableHeaderCell
       content="Address"
       key="ADDRESS"
-      minWidth="small"
     />
     <TableHeaderCell
       content="Phone Number"
       key="PHONE_NUMBER"
-      minWidth="small"
     />
   </TableHeader>
   <TableRows>
@@ -68,17 +65,14 @@ exports[`should render a table without padding 1`] = `
     <TableHeaderCell
       content="Name"
       key="NAME"
-      minWidth="small"
     />
     <TableHeaderCell
       content="Address"
       key="ADDRESS"
-      minWidth="small"
     />
     <TableHeaderCell
       content="Phone Number"
       key="PHONE_NUMBER"
-      minWidth="small"
     />
   </TableHeader>
   <TableRows>
@@ -128,17 +122,14 @@ exports[`should render a table without zebra stripes 1`] = `
     <TableHeaderCell
       content="Name"
       key="NAME"
-      minWidth="small"
     />
     <TableHeaderCell
       content="Address"
       key="ADDRESS"
-      minWidth="small"
     />
     <TableHeaderCell
       content="Phone Number"
       key="PHONE_NUMBER"
-      minWidth="small"
     />
   </TableHeader>
   <TableRows>

--- a/packages/terra-table/tests/jest/__snapshots__/TableHeader.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableHeader.test.jsx.snap
@@ -6,17 +6,14 @@ exports[`should render table header tag 1`] = `
     <TableHeaderCell
       content="Name"
       key=".$NAME"
-      minWidth="small"
     />
     <TableHeaderCell
       content="Address"
       key=".$ADDRESS"
-      minWidth="small"
     />
     <TableHeaderCell
       content="Phone Number"
       key=".$PHONE_NUMBER"
-      minWidth="small"
     />
   </tr>
 </thead>

--- a/packages/terra-table/tests/jest/__snapshots__/TableHeaderContent.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/TableHeaderContent.test.jsx.snap
@@ -21,9 +21,6 @@ exports[`should render table header content tag with ascending sort indicator 1`
   >
     <IconCaretUp
       className=""
-      isBidi={true}
-      viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg"
     />
   </span>
 </th>
@@ -41,9 +38,6 @@ exports[`should render table header content tag with descending sort indicator 1
   >
     <IconCaretDown
       className=""
-      isBidi={true}
-      viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg"
     />
   </span>
 </th>

--- a/packages/terra-toggle-button/tests/jest/__snapshots__/ToggleButton.test.jsx.snap
+++ b/packages/terra-toggle-button/tests/jest/__snapshots__/ToggleButton.test.jsx.snap
@@ -356,8 +356,6 @@ exports[`ToggleButton should set icon prop correctly 1`] = `
     isReversed={false}
     onClick={[Function]}
     text="Show"
-    type="button"
-    variant="neutral"
   />
   <Toggle
     isAnimated={false}
@@ -393,8 +391,6 @@ exports[`ToggleButton should set icon prop correctly with custom icon 1`] = `
     isReversed={false}
     onClick={[Function]}
     text="Show"
-    type="button"
-    variant="neutral"
   />
   <Toggle
     isAnimated={false}

--- a/packages/terra-toggle/tests/jest/__snapshots__/Toggle.test.jsx.snap
+++ b/packages/terra-toggle/tests/jest/__snapshots__/Toggle.test.jsx.snap
@@ -6,25 +6,7 @@ exports[`Toggle should have all props set correctly 1`] = `
   className="toggle"
 >
   <AnimateHeight
-    animationStateClasses={
-      Object {
-        "animating": "rah-animating",
-        "animatingDown": "rah-animating--down",
-        "animatingToHeightAuto": "rah-animating--to-height-auto",
-        "animatingToHeightSpecific": "rah-animating--to-height-specific",
-        "animatingToHeightZero": "rah-animating--to-height-zero",
-        "animatingUp": "rah-animating--up",
-        "static": "rah-static",
-        "staticHeightAuto": "rah-static--height-auto",
-        "staticHeightSpecific": "rah-static--height-specific",
-        "staticHeightZero": "rah-static--height-zero",
-      }
-    }
-    applyInlineTransitions={true}
-    duration={250}
-    easing="ease"
     height="auto"
-    style={Object {}}
   >
     All props
   </AnimateHeight>


### PR DESCRIPTION
### Summary
With enzyme-to-json v3.3.2, default props are no longer listed in snapshots when using `shallow` to render the snapshot per https://github.com/adriantoine/enzyme-to-json/commit/b12686ade62593c873c61040bf5aac82227eb426

Talked amongst team and decided to update snapshots to account for this change.