### PR TITLE
Add edge branch v1.8.47 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_deploy:
   - lerna run --scope terra-core-site compile:prod
 deploy:
   provider: pages
+  edge:
+    branch: v1.8.47
   skip_cleanup: true
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   local_dir: packages/terra-site/build


### PR DESCRIPTION
Recently our deployments to gh-pages via travis stopped working. The break seems rooted in this issue: https://github.com/travis-ci/travis-ci/issues/9312

A suggested fix is to pin the version of deploy to v1.8.47