### PR TITLE
Revert "Add edge branch v1.8.47 to .travis.yml"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ before_deploy:
   - lerna run --scope terra-core-site compile:prod
 deploy:
   provider: pages
-  edge:
-    branch: v1.8.47
   skip_cleanup: true
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   local_dir: packages/terra-site/build


### PR DESCRIPTION
Reverts cerner/terra-core#1338. [Travis fixed this issue in dpl 1.9.1](https://github.com/travis-ci/travis-ci/issues/9312) and we no longer need to pin the version ourselves. 