### PR TITLE
Button: refactor icon css selector

### DIFF
--- a/packages/terra-button/CHANGELOG.md
+++ b/packages/terra-button/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Create a flattened svg css selector.
 
 2.2.0 - (March 6, 2018)
 ------------------

--- a/packages/terra-button/src/Button.jsx
+++ b/packages/terra-button/src/Button.jsx
@@ -207,7 +207,8 @@ class Button extends React.Component {
 
     let buttonIcon = null;
     if (icon) {
-      const cloneIcon = React.cloneElement(icon, { className: cx('icon-svg') });
+      const iconSvgClasses = icon.props.className ? `${icon.props.className} ${cx('icon-svg')}` : cx('icon-svg');
+      const cloneIcon = React.cloneElement(icon, { className: iconSvgClasses });
       buttonIcon = <span className={iconClasses}>{cloneIcon}</span>;
     }
 

--- a/packages/terra-button/src/Button.jsx
+++ b/packages/terra-button/src/Button.jsx
@@ -204,7 +204,12 @@ class Button extends React.Component {
     ]);
 
     const buttonText = !isIconOnly && variant !== 'utility' ? <span className={buttonTextClasses}>{text}</span> : null;
-    const buttonIcon = icon ? <span className={iconClasses}>{icon}</span> : null;
+
+    let buttonIcon = null;
+    if (icon) {
+      const cloneIcon = React.cloneElement(icon, { className: cx('icon-svg') });
+      buttonIcon = <span className={iconClasses}>{cloneIcon}</span>;
+    }
 
     const buttonLabel = (
       <span className={buttonLabelClasses}>

--- a/packages/terra-button/src/Button.scss
+++ b/packages/terra-button/src/Button.scss
@@ -126,10 +126,10 @@
 
   .icon {
     display: inline-block;
+  }
 
-    > svg {
-      height: var(--terra-button-icon-height, 1rem);
-      width: var(--terra-button-icon-width, 1rem);
-    }
+  .icon-svg {
+    height: var(--terra-button-icon-height, 1rem);
+    width: var(--terra-button-icon-width, 1rem);
   }
 }

--- a/packages/terra-button/tests/jest/__snapshots__/Button.test.jsx.snap
+++ b/packages/terra-button/tests/jest/__snapshots__/Button.test.jsx.snap
@@ -226,6 +226,7 @@ exports[`should render an icon 1`] = `
     >
       <img
         alt="icon"
+        className="icon-svg"
       />
     </span>
   </span>
@@ -251,6 +252,7 @@ exports[`should render an icon and a text 1`] = `
     >
       <img
         alt="icon"
+        className="icon-svg"
       />
     </span>
     <span
@@ -334,6 +336,7 @@ exports[`should render text then an icon when reversed 1`] = `
     >
       <img
         alt="icon"
+        className="icon-svg"
       />
     </span>
   </span>

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -27,7 +27,7 @@ exports[`should render a default date input 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="icon"
+          class="icon icon-svg"
           focusable="false"
           height="1em"
           viewBox="0 0 48 48"
@@ -76,7 +76,7 @@ exports[`should render a default date input with all props 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="icon"
+          class="icon icon-svg"
           focusable="false"
           height="1em"
           viewBox="0 0 48 48"

--- a/packages/terra-toggle-button/tests/jest/__snapshots__/ToggleButton.test.jsx.snap
+++ b/packages/terra-toggle-button/tests/jest/__snapshots__/ToggleButton.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`ToggleButton should render a default toggle-button 1`] = `
         class="icon icon-first"
       >
         <span
-          class="icon"
+          class="icon-svg"
         >
           <svg
             aria-hidden="true"
@@ -66,7 +66,7 @@ exports[`ToggleButton should render an animated toggle-button 1`] = `
         class="icon icon-first"
       >
         <span
-          class="icon"
+          class="icon-svg"
         >
           <svg
             aria-hidden="true"
@@ -126,7 +126,7 @@ exports[`ToggleButton should render an icon only toggle-button 1`] = `
         class="icon"
       >
         <span
-          class="icon"
+          class="icon-svg"
         >
           <svg
             aria-hidden="true"
@@ -170,7 +170,7 @@ exports[`ToggleButton should render an initially open toggle-button 1`] = `
         class="icon icon-first"
       >
         <span
-          class="icon"
+          class="icon-svg"
         >
           <svg
             aria-hidden="true"
@@ -268,7 +268,7 @@ exports[`ToggleButton should render an open toggle-button when clicked 1`] = `
             className="icon icon-first"
           >
             <span
-              className="icon"
+              className="icon-svg"
             >
               <IconChevronRight
                 className=""

--- a/packages/terra-toggle-button/tests/jest/__snapshots__/ToggleButton.test.jsx.snap
+++ b/packages/terra-toggle-button/tests/jest/__snapshots__/ToggleButton.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`ToggleButton should render a default toggle-button 1`] = `
         class="icon icon-first"
       >
         <span
-          class="icon-svg"
+          class="icon icon-svg"
         >
           <svg
             aria-hidden="true"
@@ -66,7 +66,7 @@ exports[`ToggleButton should render an animated toggle-button 1`] = `
         class="icon icon-first"
       >
         <span
-          class="icon-svg"
+          class="icon icon-svg"
         >
           <svg
             aria-hidden="true"
@@ -126,7 +126,7 @@ exports[`ToggleButton should render an icon only toggle-button 1`] = `
         class="icon"
       >
         <span
-          class="icon-svg"
+          class="icon icon-svg"
         >
           <svg
             aria-hidden="true"
@@ -170,7 +170,7 @@ exports[`ToggleButton should render an initially open toggle-button 1`] = `
         class="icon icon-first"
       >
         <span
-          class="icon-svg"
+          class="icon icon-svg"
         >
           <svg
             aria-hidden="true"
@@ -268,7 +268,7 @@ exports[`ToggleButton should render an open toggle-button when clicked 1`] = `
             className="icon icon-first"
           >
             <span
-              className="icon-svg"
+              className="icon icon-svg"
             >
               <IconChevronRight
                 className=""


### PR DESCRIPTION
### Summary 
Creates a flattened css selector for the icon. This decreases specificity, which allows custom icon styles to not be overridden by the default styles.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
