### PR TITLE
[terra-i18n] Export injectIntl for consumers of terra-i18n

### DIFF
--- a/packages/terra-i18n/CHANGELOG.md
+++ b/packages/terra-i18n/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ----------
 
+### Added
+* Exported react-intl's injectIntl
+
 2.2.0 - (March 6, 2018)
 ------------------
 ### Removed

--- a/packages/terra-i18n/CHANGELOG.md
+++ b/packages/terra-i18n/CHANGELOG.md
@@ -5,7 +5,7 @@ Unreleased
 ----------
 
 ### Added
-* Exported react-intl's injectIntl
+* Exported react-intl's injectIntl and intlShape
 
 2.2.0 - (March 6, 2018)
 ------------------

--- a/packages/terra-i18n/docs/README.md
+++ b/packages/terra-i18n/docs/README.md
@@ -55,24 +55,6 @@ Note that the state of the object needs to contain keys as follows for the i18nL
 }
 ```
 
-Children of the `I18nProvider` can use the provided `injectIntl` higher-order component generator to interface with the `I18nProvider` context. The `intlShape` prop type is also available for use in the components' prop type specifications.
-
-```jsx
-import React from 'react';
-import { injectIntl, intlShape } from 'terra-i18n';
-
-const ChildComponent = ({ intl }) => (
-  <p>{intl.formatMessage({ id: 'my.string.id' })}</p>
-);
-
-ChildComponent.propTypes = {
-  intl: intlShape,
-};
-
-export default injectIntl(ChildComponent);
-```
-
-
 ## Component Features
 * [Cross-Browser Support](https://github.com/cerner/terra-core/wiki/Component-Features#cross-browser-support)
 * [Internationalization Support](https://github.com/cerner/terra-core/wiki/Component-Features#internationalization-i18n-support)

--- a/packages/terra-i18n/docs/README.md
+++ b/packages/terra-i18n/docs/README.md
@@ -55,15 +55,19 @@ Note that the state of the object needs to contain keys as follows for the i18nL
 }
 ```
 
-Children of the `I18nProvider` can use the provided `injectIntl` higher-order component generator to interface with the `I18nProvider` context:
+Children of the `I18nProvider` can use the provided `injectIntl` higher-order component generator to interface with the `I18nProvider` context. The `intlShape` prop type is also available for use in the components' prop type specifications.
 
 ```jsx
 import React from 'react';
-import { injectIntl } from 'terra-i18n';
+import { injectIntl, intlShape } from 'terra-i18n';
 
 const ChildComponent = ({ intl }) => (
   <p>{intl.formatMessage({ id: 'my.string.id' })}</p>
 );
+
+ChildComponent.propTypes = {
+  intl: intlShape,
+};
 
 export default injectIntl(ChildComponent);
 ```

--- a/packages/terra-i18n/docs/README.md
+++ b/packages/terra-i18n/docs/README.md
@@ -55,6 +55,20 @@ Note that the state of the object needs to contain keys as follows for the i18nL
 }
 ```
 
+Children of the `I18nProvider` can use the provided `injectIntl` higher-order component generator to interface with the `I18nProvider` context:
+
+```jsx
+import React from 'react';
+import { injectIntl } from 'terra-i18n';
+
+const ChildComponent = ({ intl }) => (
+  <p>{intl.formatMessage({ id: 'my.string.id' })}</p>
+);
+
+export default injectIntl(ChildComponent);
+```
+
+
 ## Component Features
 * [Cross-Browser Support](https://github.com/cerner/terra-core/wiki/Component-Features#cross-browser-support)
 * [Internationalization Support](https://github.com/cerner/terra-core/wiki/Component-Features#internationalization-i18n-support)

--- a/packages/terra-i18n/src/I18n.js
+++ b/packages/terra-i18n/src/I18n.js
@@ -1,3 +1,4 @@
+import { injectIntl } from 'react-intl';
 import I18nProvider from './I18nProvider';
 import i18nLoader from './i18nLoader';
 

--- a/packages/terra-i18n/src/I18n.js
+++ b/packages/terra-i18n/src/I18n.js
@@ -1,4 +1,4 @@
-import { injectIntl } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
 import I18nProvider from './I18nProvider';
 import i18nLoader from './i18nLoader';
 
@@ -6,4 +6,5 @@ module.exports = {
   I18nProvider,
   i18nLoader,
   injectIntl,
+  intlShape,
 };

--- a/packages/terra-i18n/src/I18n.js
+++ b/packages/terra-i18n/src/I18n.js
@@ -5,4 +5,5 @@ import i18nLoader from './i18nLoader';
 module.exports = {
   I18nProvider,
   i18nLoader,
+  injectIntl,
 };


### PR DESCRIPTION
### Summary
The I18nProvider exposes its translated messages to its children through its React context. This in turn causes the child components to write boilerplate context interfacing code to actually get those values.

Something like this: https://github.com/cerner/terra-clinical/blob/master/packages/terra-clinical-action-header/src/ActionHeader.jsx#L84

However, react-intl includes a higher-order component generator that does that interfacing for us. However, to access it, consumers would have to add a dependency to react-intl, which terra-18n is trying to mask. So I have updated the terra-i18n package to export injectIntl.

This might save us a little trouble when the old context API is deprecated. In the meantime, it will be a nice convenience.