### PR TITLE
Removed isInline prop for form-fieldset

### DIFF
--- a/packages/terra-form-fieldset/CHANGELOG.md
+++ b/packages/terra-form-fieldset/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 -----------------
+### Removed
+* Removed isInline prop
 
 1.0.0 - (March 14, 2018)
 ------------------

--- a/packages/terra-form-fieldset/src/Fieldset.jsx
+++ b/packages/terra-form-fieldset/src/Fieldset.jsx
@@ -18,10 +18,6 @@ const propTypes = {
    */
   help: PropTypes.node,
   /**
-   * Determines whether the fieldset is an inline fieldset.
-   */
-  isInline: PropTypes.bool,
-  /**
    * Legend for the input group.
    */
   legend: PropTypes.string,
@@ -36,15 +32,13 @@ const propTypes = {
 };
 
 const defaultProps = {
-  isInline: false,
   legendAttrs: {},
   required: false,
 };
 
-const Fieldset = ({ children, help, isInline, legend, legendAttrs, required, ...customProps }) => {
+const Fieldset = ({ children, help, legend, legendAttrs, required, ...customProps }) => {
   const fieldsetClasses = cx([
     'fieldset',
-    { 'fieldset-inline': isInline },
     { 'fieldset-required': required },
     customProps.className,
   ]);

--- a/packages/terra-form-fieldset/tests/jest/FormFieldset.test.jsx
+++ b/packages/terra-form-fieldset/tests/jest/FormFieldset.test.jsx
@@ -16,7 +16,6 @@ it('should render a Fieldset when all the possible props are passed into it', ()
       className="fieldset-custom"
       legendAttrs={{ className: 'healtheintent-legend' }}
       help="This is a test input"
-      isInline
       required
     >
       <input type="radio" value="Test" />

--- a/packages/terra-form-fieldset/tests/jest/__snapshots__/FormFieldset.test.jsx.snap
+++ b/packages/terra-form-fieldset/tests/jest/__snapshots__/FormFieldset.test.jsx.snap
@@ -2,7 +2,8 @@
 
 exports[`should render a Fieldset when all the possible props are passed into it 1`] = `
 <fieldset
-  className="fieldset fieldset-inline fieldset-required fieldset-custom"
+  className="fieldset fieldset-required fieldset-custom"
+  isInline={true}
 >
   <legend
     className="legend healtheintent-legend"

--- a/packages/terra-form-fieldset/tests/jest/__snapshots__/FormFieldset.test.jsx.snap
+++ b/packages/terra-form-fieldset/tests/jest/__snapshots__/FormFieldset.test.jsx.snap
@@ -3,7 +3,6 @@
 exports[`should render a Fieldset when all the possible props are passed into it 1`] = `
 <fieldset
   className="fieldset fieldset-required fieldset-custom"
-  isInline={true}
 >
   <legend
     className="legend healtheintent-legend"

--- a/packages/terra-form-fieldset/tests/nightwatch/PopulatedFieldset.jsx
+++ b/packages/terra-form-fieldset/tests/nightwatch/PopulatedFieldset.jsx
@@ -11,7 +11,6 @@ const fieldset = () =>
     value="children_present"
     help="Families are eligible for family package plans"
     required
-    isInline
   />;
 
 export default fieldset;


### PR DESCRIPTION
### Summary
Resolves [this](https://github.com/cerner/terra-core/issues/1349).

### Additional Details
Removed isInline prop because field-set no longer needs it thinking of it as a wrapper to the form fields.

### Deployment links
https://terra-core-deployed-pr-1354.herokuapp.com/static/#/site/form-fieldset
https://terra-core-deployed-pr-1354.herokuapp.com/static/#/tests/form-fieldset-tests