### PR TITLE
Add compile:prod task to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "clean:obsolete-snapshots": "npm test -- -u",
     "compile": "lerna run compile",
     "compile:heroku": "webpack --config webpack.prod.config --p",
+    "compile:prod": "webpack --config webpack.prod.config --p",
     "danger": "danger",
     "deploy": "webpack --config webpack.prod.config -p && gh-pages -d build",
     "dependency-markdown": "node scripts/dependency-markdown-generator/DependencyMarkdownGenerator.js",


### PR DESCRIPTION
### Summary
In the [travis.yml file, it has a before_deploy hook that runs an npm script named compile:prod](https://github.com/cerner/terra-core/blob/master/.travis.yml#L14), but no script was defined.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
