### PR TITLE
[wdio-config] Lock maxInstance to 1 for selenium/hub:3:11:0-anatomy

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -19,8 +19,7 @@ const config = {
   baseUrl: `http://${localIP.address()}:${webpackPort}`,
   specs,
 
-  // Travis only has 1 browser instace, set maxInstances to 1 to prevent timeouts
-  maxInstances: process.env.CI ? 1 : wdioConf.config.maxInstances,
+  maxInstances: 1,
   seleniumDocker: {
     enabled: !process.env.TRAVIS,
   },

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -19,7 +19,6 @@ const config = {
   baseUrl: `http://${localIP.address()}:${webpackPort}`,
   specs,
 
-  maxInstances: 1,
   seleniumDocker: {
     enabled: !process.env.TRAVIS,
   },


### PR DESCRIPTION
### Summary
Selenium released [3.11.0-anatomy](https://github.com/SeleniumHQ/docker-selenium/releases/tag/3.11.0-antimony) 03/11/18. 

Locally when using `selenium/hub:3.11.0-anatomy` the ChromeDriver instances were not being closed/cleaned as expected when using `wdio.maxInstances > 1`. We have not seen this error in Travis, because we were toggling `maxInstances` to be 1 with the `process.env.CI`varaible, where as locally `maxInstances`  is set to 5. This sets `maxInstances = 1` until this issue is resolved. 

This is being tracked in terra-toolkit. See https://github.com/cerner/terra-toolkit/issues/57