### PR TITLE
Make terra-markdown easily testable with Jest

### DIFF
--- a/jestconfig.json
+++ b/jestconfig.json
@@ -7,7 +7,7 @@
     "./node_modules/enzyme-to-json/serializer"
   ],
   "moduleNameMapper": {
-    "\\.(svg|jpg|png)$": "<rootDir>/__mocks__/fileMock.js",
+    "\\.(svg|jpg|png|md)$": "<rootDir>/__mocks__/fileMock.js",
     "\\.(css|scss)$": "identity-obj-proxy"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       "<rootDir>/node_modules/enzyme-to-json/serializer"
     ],
     "moduleNameMapper": {
-      "\\.(svg|jpg|png)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(svg|jpg|png|md)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|scss)$": "identity-obj-proxy"
     }
   },

--- a/packages/terra-markdown/CHANGELOG.md
+++ b/packages/terra-markdown/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Import css file inside github-markdown-css instead of importing package.
 
 2.2.0 - (March 30, 2018)
 ------------------

--- a/packages/terra-markdown/src/Markdown.jsx
+++ b/packages/terra-markdown/src/Markdown.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import marked from 'marked';
 /* github-markdown-css's main entry in package.json resolves to a CSS file and this seems to be causing issues with eslint */
 /* eslint-disable import/extensions */
-import 'github-markdown-css';
+import 'github-markdown-css/github-markdown.css';
 /* eslint-enable import/extensions */
 import './Markdown.scss';
 

--- a/packages/terra-markdown/tests/jest/__snapshots__/markdown.test.jsx.snap
+++ b/packages/terra-markdown/tests/jest/__snapshots__/markdown.test.jsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render correctly 1`] = `
+<Markdown
+  id="Markdown"
+  src="test-file-stub"
+>
+  <div
+    className="markdown-body"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<p>test-file-stub</p>
+",
+      }
+    }
+    dir="ltr"
+    style={
+      Object {
+        "listStyle": "initial",
+      }
+    }
+  />
+</Markdown>
+`;

--- a/packages/terra-markdown/tests/jest/markdown.test.jsx
+++ b/packages/terra-markdown/tests/jest/markdown.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Markdown from '../../lib/Markdown';
+import Markdown from '../../src/Markdown';
 import MockREADME from '../nightwatch/MockREADME.md';
 
 it('should render correctly', () => {

--- a/packages/terra-markdown/tests/jest/markdown.test.jsx
+++ b/packages/terra-markdown/tests/jest/markdown.test.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import Markdown from '../../lib/Markdown';
+import MockREADME from '../nightwatch/MockREADME.md';
+
+it('should render correctly', () => {
+  const singleSelect = mount(<Markdown id="Markdown" src={MockREADME} />);
+  expect(singleSelect).toMatchSnapshot();
+});


### PR DESCRIPTION
### Summary
Fixes #1407 

Jest will not run with terra-markdown due to this import statement.

    import 'github-markdown-css';

Even though our mocks have css use a fileMock package, this will not be mocked because it does not have the .css or .scss extension. In order to ensure terra-markdown can easily be integrated with other packages, it's recommend to import the css file that this package contains.

    import 'github-markdown-css/github-markdown.css';

