### PR TITLE
Update modal manager devDependency

### DIFF
--- a/packages/terra-date-picker/package.json
+++ b/packages/terra-date-picker/package.json
@@ -25,7 +25,7 @@
     "react-redux": "^5.0.4",
     "redux": "^3.6.0",
     "terra-app-delegate": "^1.9.0",
-    "terra-modal-manager": "^1.18.0"
+    "terra-modal-manager": "^2.0.0"
   },
   "peerDependencies": {
     "react": "^16.2.0",

--- a/packages/terra-date-time-picker/package.json
+++ b/packages/terra-date-time-picker/package.json
@@ -26,7 +26,7 @@
     "redux": "^3.6.0",
     "terra-app-delegate": "^1.9.0",
     "terra-date-picker": "^2.7.0",
-    "terra-modal-manager": "^1.18.0"
+    "terra-modal-manager": "^2.0.0"
   },
   "peerDependencies": {
     "react": "^16.2.0",

--- a/packages/terra-site/package.json
+++ b/packages/terra-site/package.json
@@ -63,7 +63,7 @@
     "terra-markdown": "^2.4.0",
     "terra-menu": "^2.7.0",
     "terra-mixins": "^1.14.0",
-    "terra-modal-manager": "^1.18.0",
+    "terra-modal-manager": "^2.0.0",
     "terra-overlay": "^2.7.0",
     "terra-profile-image": "^2.6.0",
     "terra-progress-bar": "^2.6.0",

--- a/themeable-variables.json
+++ b/themeable-variables.json
@@ -545,6 +545,7 @@
     "--terra-modal-fixed-margin": "0 auto"
   },
   "ModalOverlay": {
+    "--terra-abstract-modal-overlay-background-color": "rgba(0, 0, 0, 0.4)",
     "--terra-modal-overlay-background-color": "rgba(0, 0, 0, 0.4)"
   },
   "NavigationSideMenu": {


### PR DESCRIPTION
### Summary
We had some packages that had a devDependency on an older version of modal-manager. Updated them to pull in the 2.x version of modal manager and its transitive dependencies.