### PR TITLE
Fix #1351 Add aria-label collapsible menu view ellipses button

### DIFF
--- a/packages/terra-collapsible-menu-view/CHANGELOG.md
+++ b/packages/terra-collapsible-menu-view/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+Added localized aria-label to ellipses "view more" button
 
 2.7.0 - (April 20, 2018)
 ------------------

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuView.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuView.jsx
@@ -31,6 +31,15 @@ const propTypes = {
   boundingRef: PropTypes.func,
 };
 
+const contextTypes = {
+  /* eslint-disable consistent-return */
+  intl: (context) => {
+    if (context.intl === undefined) {
+      return new Error('Please add locale prop to Base component to load translations');
+    }
+  },
+};
+
 class CollapsibleMenuView extends React.Component {
   constructor(props) {
     super(props);
@@ -97,6 +106,8 @@ class CollapsibleMenuView extends React.Component {
 
   render() {
     const { children, boundingRef, menuWidth, ...customProps } = this.props;
+    const intl = this.context.intl;
+    const ellipsesText = intl.formatMessage({ id: 'Terra.collapsibleMenuView.more' });
     const visibleChildren = React.Children.toArray(children);
 
     let hiddenChildren = null;
@@ -125,6 +136,7 @@ class CollapsibleMenuView extends React.Component {
             boundingRef={boundingRef}
             menuWidth={menuWidth}
             isIconOnly
+            text={ellipsesText}
           />
         </div>
       </div>
@@ -138,5 +150,6 @@ CollapsibleMenuView.Toggle = CollapsibleMenuViewToggle;
 CollapsibleMenuView.Divider = CollapsibleMenuViewDivider;
 
 CollapsibleMenuView.propTypes = propTypes;
+CollapsibleMenuView.contextTypes = contextTypes;
 
 export default CollapsibleMenuView;

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItem.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItem.jsx
@@ -112,7 +112,6 @@ class CollapsibleMenuViewItem extends React.Component {
 
     const { isCollapsibleGroupItem, isCollapsibleMenuItem } = this.context;
     const attributes = Object.assign({}, customProps);
-    const faceUpText = isIconOnly && !isCollapsibleMenuItem ? '' : text;
     let item;
 
     if (isCollapsibleMenuItem) {
@@ -130,7 +129,7 @@ class CollapsibleMenuViewItem extends React.Component {
         <ButtonGroup.Button
           {...attributes}
           icon={icon}
-          text={faceUpText}
+          text={text}
           isDisabled={isDisabled}
         />
       );
@@ -143,7 +142,7 @@ class CollapsibleMenuViewItem extends React.Component {
             <Button
               {...attributes}
               icon={icon}
-              text={faceUpText}
+              text={text}
               isReversed={isReversed}
               isDisabled={isDisabled}
               onClick={this.handleButtonClick}
@@ -159,7 +158,7 @@ class CollapsibleMenuViewItem extends React.Component {
           <Button
             {...attributes}
             icon={icon}
-            text={faceUpText}
+            text={text}
             isReversed={isReversed}
             isDisabled={isDisabled}
             isIconOnly={isIconOnly}

--- a/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewDivider.test.jsx
+++ b/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewDivider.test.jsx
@@ -11,7 +11,7 @@ describe('CollapsibleMenuViewDivider', () => {
 
   it('should render a menu divider in the context of the collapsible menu', () => {
     const context = { isCollapsibleMenuItem: true };
-    const wrapper = shallow(<CollapsibleMenuViewDivider />, { ...context, ...intlContexts.shallowContext });
+    const wrapper = shallow(<CollapsibleMenuViewDivider />, { context });
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewDivider.test.jsx
+++ b/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewDivider.test.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import CollapsibleMenuViewDivider from '../../src/CollapsibleMenuViewDivider';
+import intlContexts from './intl-context-setup';
 
 describe('CollapsibleMenuViewDivider', () => {
   // Snapshot Tests
   it('should render a default component', () => {
-    const wrapper = shallow(<CollapsibleMenuViewDivider />);
+    const wrapper = shallow(<CollapsibleMenuViewDivider />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should render a menu divider in the context of the collapsible menu', () => {
     const context = { isCollapsibleMenuItem: true };
-    const wrapper = shallow(<CollapsibleMenuViewDivider />, { context });
+    const wrapper = shallow(<CollapsibleMenuViewDivider />, { ...context, ...intlContexts.shallowContext });
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewItem.test.jsx
+++ b/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewItem.test.jsx
@@ -1,102 +1,103 @@
 import React from 'react';
 import IconTrash from 'terra-icon/lib/icon/IconTrash';
 import CollapsibleMenuViewItem from '../../src/CollapsibleMenuViewItem';
+import intlContexts from './intl-context-setup';
 
 describe('CollapsibleMenuViewItem', () => {
   // Snapshot Tests
   it('should render a default component', () => {
-    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" />);
+    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
   // Props
   it('should merge custom props', () => {
-    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" className="Testing" />);
+    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" className="Testing" />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should not set isSelected on button outside of an item group', () => {
-    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isSelected />);
+    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isSelected />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should render a button group button when in an item group', () => {
     const context = { isCollapsibleGroupItem: true };
-    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" />, { context });
+    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" />, { ...context, ...intlContexts.shallowContext });
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should set isSelected on button that is inside item group', () => {
     const context = { isCollapsibleGroupItem: true };
-    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isSelected />, { context });
+    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isSelected />, { ...context, ...intlContexts.shallowContext });
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should set icon prop on button', () => {
-    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} />);
+    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should set isReversed prop on button', () => {
-    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} isReversed />);
+    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} isReversed />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should render a button with icon and no text when isIconOnly is set', () => {
-    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} isIconOnly />);
+    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} isIconOnly />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should render a menu when subMenuItems are given', () => {
-    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" subMenuItems={[<CollapsibleMenuViewItem text="Menu Item" key="1" />]} />);
+    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" subMenuItems={[<CollapsibleMenuViewItem text="Menu Item" key="1" />]} />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should render a disabled button when isDisabled is set', () => {
-    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isDisabled />);
+    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isDisabled />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should render a disabled button group button that is inside a button group when isDisabled is set', () => {
     const context = { isCollapsibleGroupItem: true };
-    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isDisabled />, { context });
+    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isDisabled />, { ...context, ...intlContexts.shallowContext });
     expect(wrapper).toMatchSnapshot();
   });
 
   describe('Collapsible Menu Context', () => {
     it('should render a menu item', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" />, { context });
+      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" />, { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
 
     it('should not set selected prop on menu item outside of item group', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isSelected />, { context });
+      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isSelected />, { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
 
     it('should set selected prop on menu item when inside item group', () => {
       const context = { isCollapsibleMenuItem: true, isCollapsibleGroupItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isSelected />, { context });
+      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isSelected />, { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
 
     it('should not set icon prop menu item, but should render text', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} />, { context });
+      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} />, { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
 
     it('should not set isReversed prop on menu item', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} isReversed />, { context });
+      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} isReversed />, { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
 
     it('should not set icon on menu item when isIconOnly is set, but should set the text', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} isIconOnly />, { context });
+      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} isIconOnly />, { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
 
@@ -107,13 +108,13 @@ describe('CollapsibleMenuViewItem', () => {
           text="Testing"
           subMenuItems={[<CollapsibleMenuViewItem text="Menu Item" key="1" />]}
         />
-      ), { context });
+    ), { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
 
     it('should render a disabled menu item when isDisabled is set', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isDisabled />, { context });
+      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isDisabled />, { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
   });

--- a/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewItem.test.jsx
+++ b/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewItem.test.jsx
@@ -23,13 +23,13 @@ describe('CollapsibleMenuViewItem', () => {
 
   it('should render a button group button when in an item group', () => {
     const context = { isCollapsibleGroupItem: true };
-    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" />, { ...context, ...intlContexts.shallowContext });
+    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" />, { context });
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should set isSelected on button that is inside item group', () => {
     const context = { isCollapsibleGroupItem: true };
-    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isSelected />, { ...context, ...intlContexts.shallowContext });
+    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isSelected />, { context });
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -43,7 +43,7 @@ describe('CollapsibleMenuViewItem', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should render a button with icon and no text when isIconOnly is set', () => {
+  it('should render a button with icon and text when isIconOnly and text is set', () => {
     const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} isIconOnly />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
@@ -60,44 +60,44 @@ describe('CollapsibleMenuViewItem', () => {
 
   it('should render a disabled button group button that is inside a button group when isDisabled is set', () => {
     const context = { isCollapsibleGroupItem: true };
-    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isDisabled />, { ...context, ...intlContexts.shallowContext });
+    const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isDisabled />, { context });
     expect(wrapper).toMatchSnapshot();
   });
 
   describe('Collapsible Menu Context', () => {
     it('should render a menu item', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" />, { ...context, ...intlContexts.shallowContext });
+      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" />, { context });
       expect(wrapper).toMatchSnapshot();
     });
 
     it('should not set selected prop on menu item outside of item group', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isSelected />, { ...context, ...intlContexts.shallowContext });
+      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isSelected />, { context });
       expect(wrapper).toMatchSnapshot();
     });
 
     it('should set selected prop on menu item when inside item group', () => {
       const context = { isCollapsibleMenuItem: true, isCollapsibleGroupItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isSelected />, { ...context, ...intlContexts.shallowContext });
+      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isSelected />, { context });
       expect(wrapper).toMatchSnapshot();
     });
 
     it('should not set icon prop menu item, but should render text', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} />, { ...context, ...intlContexts.shallowContext });
+      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} />, { context });
       expect(wrapper).toMatchSnapshot();
     });
 
     it('should not set isReversed prop on menu item', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} isReversed />, { ...context, ...intlContexts.shallowContext });
+      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} isReversed />, { context });
       expect(wrapper).toMatchSnapshot();
     });
 
     it('should not set icon on menu item when isIconOnly is set, but should set the text', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} isIconOnly />, { ...context, ...intlContexts.shallowContext });
+      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" icon={<IconTrash />} isIconOnly />, { context });
       expect(wrapper).toMatchSnapshot();
     });
 
@@ -108,13 +108,13 @@ describe('CollapsibleMenuViewItem', () => {
           text="Testing"
           subMenuItems={[<CollapsibleMenuViewItem text="Menu Item" key="1" />]}
         />
-    ), { ...context, ...intlContexts.shallowContext });
+    ), { context });
       expect(wrapper).toMatchSnapshot();
     });
 
     it('should render a disabled menu item when isDisabled is set', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isDisabled />, { ...context, ...intlContexts.shallowContext });
+      const wrapper = shallow(<CollapsibleMenuViewItem text="Testing" isDisabled />, { context });
       expect(wrapper).toMatchSnapshot();
     });
   });

--- a/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewItemGroup.test.jsx
+++ b/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewItemGroup.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import CollapsibleMenuViewItemGroup from '../../src/CollapsibleMenuViewItemGroup';
 import CollapsibleMenuViewItem from '../../src/CollapsibleMenuViewItem';
+import intlContexts from './intl-context-setup';
 
 describe('CollapsibleMenuViewItemGroup', () => {
   // Snapshot Tests
@@ -9,7 +10,8 @@ describe('CollapsibleMenuViewItemGroup', () => {
       <CollapsibleMenuViewItemGroup>
         <CollapsibleMenuViewItem text="Testing" />
         <CollapsibleMenuViewItem text="Testing" />
-      </CollapsibleMenuViewItemGroup>
+      </CollapsibleMenuViewItemGroup>,
+      intlContexts.shallowContext
     ));
     expect(wrapper).toMatchSnapshot();
   });
@@ -20,7 +22,8 @@ describe('CollapsibleMenuViewItemGroup', () => {
       <CollapsibleMenuViewItemGroup className="Testing">
         <CollapsibleMenuViewItem text="Testing" />
         <CollapsibleMenuViewItem text="Testing" />
-      </CollapsibleMenuViewItemGroup>
+      </CollapsibleMenuViewItemGroup>,
+      intlContexts.shallowContext
     ));
     expect(wrapper).toMatchSnapshot();
   });
@@ -30,7 +33,8 @@ describe('CollapsibleMenuViewItemGroup', () => {
       <CollapsibleMenuViewItemGroup selectedKeys={['key1']}>
         <CollapsibleMenuViewItem text="Testing" key="key1" />
         <CollapsibleMenuViewItem text="Testing" key="key2" />
-      </CollapsibleMenuViewItemGroup>
+      </CollapsibleMenuViewItemGroup>,
+      intlContexts.shallowContext
     ));
     expect(wrapper).toMatchSnapshot();
   });
@@ -43,7 +47,7 @@ describe('CollapsibleMenuViewItemGroup', () => {
           <CollapsibleMenuViewItem text="Testing" key="key1" />
           <CollapsibleMenuViewItem text="Testing" key="key2" />
         </CollapsibleMenuViewItemGroup>
-      ), { context });
+      ), { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
 
@@ -54,7 +58,7 @@ describe('CollapsibleMenuViewItemGroup', () => {
           <CollapsibleMenuViewItem text="Testing" />
           <CollapsibleMenuViewItem text="Testing" />
         </CollapsibleMenuViewItemGroup>
-      ), { context });
+      ), { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
 
@@ -65,7 +69,7 @@ describe('CollapsibleMenuViewItemGroup', () => {
           <CollapsibleMenuViewItem text="Testing" key="key1" />
           <CollapsibleMenuViewItem text="Testing" key="key2" />
         </CollapsibleMenuViewItemGroup>
-      ), { context });
+      ), { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
 
@@ -76,7 +80,7 @@ describe('CollapsibleMenuViewItemGroup', () => {
           <CollapsibleMenuViewItem text="Testing" />
           <CollapsibleMenuViewItem text="Testing" />
         </CollapsibleMenuViewItemGroup>
-      ), { context });
+      ), { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
   });

--- a/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewItemGroup.test.jsx
+++ b/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewItemGroup.test.jsx
@@ -10,9 +10,8 @@ describe('CollapsibleMenuViewItemGroup', () => {
       <CollapsibleMenuViewItemGroup>
         <CollapsibleMenuViewItem text="Testing" />
         <CollapsibleMenuViewItem text="Testing" />
-      </CollapsibleMenuViewItemGroup>,
-      intlContexts.shallowContext
-    ));
+      </CollapsibleMenuViewItemGroup>
+    ), intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -22,9 +21,8 @@ describe('CollapsibleMenuViewItemGroup', () => {
       <CollapsibleMenuViewItemGroup className="Testing">
         <CollapsibleMenuViewItem text="Testing" />
         <CollapsibleMenuViewItem text="Testing" />
-      </CollapsibleMenuViewItemGroup>,
-      intlContexts.shallowContext
-    ));
+      </CollapsibleMenuViewItemGroup>
+    ), intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -33,9 +31,8 @@ describe('CollapsibleMenuViewItemGroup', () => {
       <CollapsibleMenuViewItemGroup selectedKeys={['key1']}>
         <CollapsibleMenuViewItem text="Testing" key="key1" />
         <CollapsibleMenuViewItem text="Testing" key="key2" />
-      </CollapsibleMenuViewItemGroup>,
-      intlContexts.shallowContext
-    ));
+      </CollapsibleMenuViewItemGroup>
+    ), intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -47,7 +44,7 @@ describe('CollapsibleMenuViewItemGroup', () => {
           <CollapsibleMenuViewItem text="Testing" key="key1" />
           <CollapsibleMenuViewItem text="Testing" key="key2" />
         </CollapsibleMenuViewItemGroup>
-      ), { ...context, ...intlContexts.shallowContext });
+      ), { context });
       expect(wrapper).toMatchSnapshot();
     });
 
@@ -58,7 +55,7 @@ describe('CollapsibleMenuViewItemGroup', () => {
           <CollapsibleMenuViewItem text="Testing" />
           <CollapsibleMenuViewItem text="Testing" />
         </CollapsibleMenuViewItemGroup>
-      ), { ...context, ...intlContexts.shallowContext });
+      ), { context });
       expect(wrapper).toMatchSnapshot();
     });
 
@@ -69,7 +66,7 @@ describe('CollapsibleMenuViewItemGroup', () => {
           <CollapsibleMenuViewItem text="Testing" key="key1" />
           <CollapsibleMenuViewItem text="Testing" key="key2" />
         </CollapsibleMenuViewItemGroup>
-      ), { ...context, ...intlContexts.shallowContext });
+      ), { context });
       expect(wrapper).toMatchSnapshot();
     });
 
@@ -80,7 +77,7 @@ describe('CollapsibleMenuViewItemGroup', () => {
           <CollapsibleMenuViewItem text="Testing" />
           <CollapsibleMenuViewItem text="Testing" />
         </CollapsibleMenuViewItemGroup>
-      ), { ...context, ...intlContexts.shallowContext });
+      ), { context });
       expect(wrapper).toMatchSnapshot();
     });
   });

--- a/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewToggle.test.jsx
+++ b/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewToggle.test.jsx
@@ -1,53 +1,54 @@
 import React from 'react';
 import CollapsibleMenuViewToggle from '../../src/CollapsibleMenuViewToggle';
+import intlContexts from './intl-context-setup';
 
 describe('CollapsibleMenuViewToggle', () => {
   // Snapshot Tests
   it('should render a default component', () => {
-    const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" />);
+    const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
   // Props
   it('should merge custom props', () => {
-    const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" className="Testing" />);
+    const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" className="Testing" />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should set defaultChecked prop', () => {
-    const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isSelected />);
+    const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isSelected />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should disable checkbox when isSelectable is false', () => {
-    const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isSelectable={false} />);
+    const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isSelectable={false} />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should set isDisabled prop', () => {
-    const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isDisabled />);
+    const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isDisabled />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
 
   describe('Collapsible Menu Context', () => {
     it('should render a selectable menu item', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" />, { context });
+      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" />, { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
     it('should set selected prop on menu item', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isSelected />, { context });
+      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isSelected />, { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
     it('should set isSelectable prop on menu item to false', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isSelectable={false} />, { context });
+      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isSelectable={false} />, { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
     it('should set isDisabled prop on menu item', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isDisabled />, { context });
+      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isDisabled />, { ...context, ...intlContexts.shallowContext });
       expect(wrapper).toMatchSnapshot();
     });
   });

--- a/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewToggle.test.jsx
+++ b/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewToggle.test.jsx
@@ -33,22 +33,22 @@ describe('CollapsibleMenuViewToggle', () => {
   describe('Collapsible Menu Context', () => {
     it('should render a selectable menu item', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" />, { ...context, ...intlContexts.shallowContext });
+      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" />, { context });
       expect(wrapper).toMatchSnapshot();
     });
     it('should set selected prop on menu item', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isSelected />, { ...context, ...intlContexts.shallowContext });
+      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isSelected />, { context });
       expect(wrapper).toMatchSnapshot();
     });
     it('should set isSelectable prop on menu item to false', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isSelectable={false} />, { ...context, ...intlContexts.shallowContext });
+      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isSelectable={false} />, { context });
       expect(wrapper).toMatchSnapshot();
     });
     it('should set isDisabled prop on menu item', () => {
       const context = { isCollapsibleMenuItem: true };
-      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isDisabled />, { ...context, ...intlContexts.shallowContext });
+      const wrapper = shallow(<CollapsibleMenuViewToggle text="Testing" isDisabled />, { context });
       expect(wrapper).toMatchSnapshot();
     });
   });

--- a/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewItem.test.jsx.snap
+++ b/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewItem.test.jsx.snap
@@ -132,7 +132,7 @@ exports[`CollapsibleMenuViewItem should render a button group button when in an 
 />
 `;
 
-exports[`CollapsibleMenuViewItem should render a button with icon and no text when isIconOnly is set 1`] = `
+exports[`CollapsibleMenuViewItem should render a button with icon and text when isIconOnly and text is set 1`] = `
 <div
   className="face-up-item"
 >
@@ -149,7 +149,7 @@ exports[`CollapsibleMenuViewItem should render a button with icon and no text wh
     isDisabled={false}
     isIconOnly={true}
     isReversed={false}
-    text=""
+    text="Testing"
     type="button"
     variant="neutral"
   />

--- a/packages/terra-collapsible-menu-view/tests/jest/intl-context-setup.js
+++ b/packages/terra-collapsible-menu-view/tests/jest/intl-context-setup.js
@@ -1,0 +1,14 @@
+/* eslint-disable react/jsx-boolean-value, import/no-extraneous-dependencies */
+import { IntlProvider, intlShape } from 'react-intl';
+import messages from '../../translations/en-US.json';
+
+const locale = 'en-US';
+const intlProvider = new IntlProvider({ locale, messages }, {});
+const { intl } = intlProvider.getChildContext();
+
+const shallowContext = { context: { intl } };
+const mountContext = { context: { intl }, childContextTypes: { intl: intlShape } };
+
+const intlContexts = { shallowContext, mountContext };
+
+export default intlContexts;

--- a/packages/terra-collapsible-menu-view/translations/ar.json
+++ b/packages/terra-collapsible-menu-view/translations/ar.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "المزيد"
+}

--- a/packages/terra-collapsible-menu-view/translations/de.json
+++ b/packages/terra-collapsible-menu-view/translations/de.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "Mehr"
+}

--- a/packages/terra-collapsible-menu-view/translations/en-GB.json
+++ b/packages/terra-collapsible-menu-view/translations/en-GB.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "More"
+}

--- a/packages/terra-collapsible-menu-view/translations/en-US.json
+++ b/packages/terra-collapsible-menu-view/translations/en-US.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "More"
+}

--- a/packages/terra-collapsible-menu-view/translations/en.json
+++ b/packages/terra-collapsible-menu-view/translations/en.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "More"
+}

--- a/packages/terra-collapsible-menu-view/translations/es-ES.json
+++ b/packages/terra-collapsible-menu-view/translations/es-ES.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "Más"
+}

--- a/packages/terra-collapsible-menu-view/translations/es-US.json
+++ b/packages/terra-collapsible-menu-view/translations/es-US.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "Más"
+}

--- a/packages/terra-collapsible-menu-view/translations/es.json
+++ b/packages/terra-collapsible-menu-view/translations/es.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "Más"
+}

--- a/packages/terra-collapsible-menu-view/translations/fi-FI.json
+++ b/packages/terra-collapsible-menu-view/translations/fi-FI.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "More"
+}

--- a/packages/terra-collapsible-menu-view/translations/fr-FR.json
+++ b/packages/terra-collapsible-menu-view/translations/fr-FR.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "Plus"
+}

--- a/packages/terra-collapsible-menu-view/translations/fr.json
+++ b/packages/terra-collapsible-menu-view/translations/fr.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "Plus"
+}

--- a/packages/terra-collapsible-menu-view/translations/nl-BE.json
+++ b/packages/terra-collapsible-menu-view/translations/nl-BE.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "Meer"
+}

--- a/packages/terra-collapsible-menu-view/translations/nl.json
+++ b/packages/terra-collapsible-menu-view/translations/nl.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "Meer"
+}

--- a/packages/terra-collapsible-menu-view/translations/pt-BR.json
+++ b/packages/terra-collapsible-menu-view/translations/pt-BR.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "Mais"
+}

--- a/packages/terra-collapsible-menu-view/translations/pt.json
+++ b/packages/terra-collapsible-menu-view/translations/pt.json
@@ -1,0 +1,3 @@
+{
+  "Terra.collapsibleMenuView.more": "Mais"
+}

--- a/packages/terra-site/src/examples/collapsible-menu-view/CollapsibleMenuViewDemo.jsx
+++ b/packages/terra-site/src/examples/collapsible-menu-view/CollapsibleMenuViewDemo.jsx
@@ -6,7 +6,7 @@ import IconSend from 'terra-icon/lib/icon/IconSend';
 import IconPrinter from 'terra-icon/lib/icon/IconPrinter';
 import IconFolder from 'terra-icon/lib/icon/IconFolder';
 import IconTrash from 'terra-icon/lib/icon/IconTrash';
-import CollapsibleMenuView from 'terra-collapsible-menu-view';
+import CollapsibleMenuView from 'terra-collapsible-menu-view/src/CollapsibleMenuView';
 
 class CollapsibleMenuViewDemo extends React.Component {
   constructor(props) {


### PR DESCRIPTION
### Summary
Resolves #1151 

* Added localized "more" as aria-label to ellipses button
* Updated jest tests to work with intl context
* Removed snapshot test that expected empty text when iconOnly was set
* Added jest test to cover use case