### PR TITLE
[doc-template] Missed in Props Mapping Fix

### DIFF
--- a/packages/terra-site/src/examples/doc-template/Index.jsx
+++ b/packages/terra-site/src/examples/doc-template/Index.jsx
@@ -23,7 +23,7 @@ const DocTemplateExamples = () => (
     propsTables={[
       {
         componentName: 'DocTemplate',
-        componentSource: DocTemplateSrc,
+        componentSrc: DocTemplateSrc,
       },
     ]}
   />


### PR DESCRIPTION
### Summary
Whoops. When fixing the doc-template mapping, I didn't update the site-page.

Closes #1485 