### PR TITLE
Only Highlight JSX to make the package size smaller.

### DIFF
--- a/packages/terra-doc-template/CHANGELOG.md
+++ b/packages/terra-doc-template/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Add 15px padding to template
+* Limit syntax hilighting support to jsx only to limit package size.
 
 1.1.0 - (May 9, 2018)
 ------------------

--- a/packages/terra-doc-template/src/ExampleTemplate.jsx
+++ b/packages/terra-doc-template/src/ExampleTemplate.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ToggleButton from 'terra-toggle-button';
-import SyntaxHighlighter from 'react-syntax-highlighter/prism';
+import SyntaxHighlighter, { registerLanguage } from 'react-syntax-highlighter/prism-light';
 import { okaidia } from 'react-syntax-highlighter/styles/prism';
+import jsx from 'react-syntax-highlighter/languages/prism/jsx';
+
+registerLanguage('jsx', jsx);
 
 const propTypes = {
   /**


### PR DESCRIPTION
### Summary
Only Highlight JSX to make the package size smaller.
Based on instructions here:
https://github.com/conorhastings/react-syntax-highlighter#light-build

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
