### PR TITLE
Update date time picker to consume abstract-modal.

### DIFF
--- a/packages/terra-date-time-picker/package.json
+++ b/packages/terra-date-time-picker/package.json
@@ -42,10 +42,10 @@
     "moment": "^2.21.0",
     "moment-timezone": "^0.5.13",
     "prop-types": "^15.5.8",
+    "terra-abstract-modal": "^1.3.0",
     "terra-base": "^3.9.0",
     "terra-button": "^2.10.0",
     "terra-date-picker": "^2.11.0",
-    "terra-modal": "^2.5.0",
     "terra-time-input": "^2.10.0"
   },
   "scripts": {

--- a/packages/terra-date-time-picker/src/DateTimePicker.jsx
+++ b/packages/terra-date-time-picker/src/DateTimePicker.jsx
@@ -136,6 +136,8 @@ class DateTimePicker extends React.Component {
     this.handleOnDateInputFocus = this.handleOnDateInputFocus.bind(this);
     this.handleOnTimeInputFocus = this.handleOnTimeInputFocus.bind(this);
     this.handleOnCalendarButtonClick = this.handleOnCalendarButtonClick.bind(this);
+    this.handleOffsetButtonClick = this.handleOffsetButtonClick.bind(this);
+    this.handleOnRequestClose = this.handleOnRequestClose.bind(this);
   }
 
   componentWillMount() {
@@ -347,6 +349,14 @@ class DateTimePicker extends React.Component {
     }
   }
 
+  handleOffsetButtonClick(event) {
+    this.setState({ isTimeClarificationOpen: !this.state.isTimeClarificationOpen });
+  }
+
+  handleOnRequestClose(event) {
+    this.setState({ isTimeClarificationOpen: false });
+  }
+
   renderTimeClarification() {
     return (
       <TimeClarification
@@ -354,6 +364,10 @@ class DateTimePicker extends React.Component {
         isOffsetButtonHidden={!this.state.isAmbiguousTime}
         onDaylightSavingButtonClick={this.handleDaylightSavingButtonClick}
         onStandardTimeButtonClick={this.handleStandardTimeButtonClick}
+        onOffsetButtonClick={this.handleOffsetButtonClick}
+        onRequestClose={this.handleOnRequestClose}
+        releaseFocus={this.props.releaseFocus}
+        requestFocus={this.props.requestFocus}
       />
     );
   }

--- a/packages/terra-date-time-picker/src/_TimeClarification.jsx
+++ b/packages/terra-date-time-picker/src/_TimeClarification.jsx
@@ -49,6 +49,7 @@ const defaultProps = {
   onDaylightSavingButtonClick: undefined,
   onStandardTimeButtonClick: undefined,
   onOffsetButtonClick: undefined,
+  onRequestClose: undefined,
   releaseFocus: undefined,
   requestFocus: undefined,
 };

--- a/packages/terra-date-time-picker/src/_TimeClarification.scss
+++ b/packages/terra-date-time-picker/src/_TimeClarification.scss
@@ -1,5 +1,14 @@
 /* stylelint-disable selector-max-compound-selectors, max-nesting-depth */
 :local {
+  .time-clarification{
+    background-color: var(--terra-date-time-clarification-modal-background-color, #fff);
+    border: var(--terra-date-time-clarification-modal-border);
+    border-radius: var(--terra-date-time-clarification-modal-border-radius, 5px);
+    box-shadow: var(--terra-date-time-clarification-modal-box-shadow, 0 3px 7px rgba(0, 0, 0, 0.3));
+    color: var(--terra-date-time-clarification-modal-foreground-color);
+    width: 640px;
+  }
+
   .header {
     background-color: #f4f4f4;
     border-bottom-color: #dedfe0;


### PR DESCRIPTION
### Summary
Remove the DateTimePicker's dependency on the deprecated terra-modal. Now implements a custom abstract modal that is analogous to the terra-dialog-modal. Now handles focus state when presented from modal manager.

Thanks for contributing to Terra. 
@cerner/terra
