### PR TITLE
Theme tabs

### DIFF
--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* New variables for theming
 
 3.0.0 - (May 9, 2018)
 ------------------

--- a/packages/terra-tabs/examples/test-examples/Tabs/TabsTemplate.jsx
+++ b/packages/terra-tabs/examples/test-examples/Tabs/TabsTemplate.jsx
@@ -19,7 +19,7 @@ const defaultProps = {
 
 const TabsTemplate = props => (
   <Base locale={locale}>
-    <div style={{ backgroundColor: 'lightgrey', height: props.containerHeight }}>
+    <div style={{ height: props.containerHeight }}>
       <Tabs
         tabFill={props.tabFill}
         fill={props.fill}

--- a/packages/terra-tabs/src/StructuralTabs.scss
+++ b/packages/terra-tabs/src/StructuralTabs.scss
@@ -9,6 +9,7 @@
       background-color: var(--terra-tabs-structural-content-background-color, #fff);
       border-radius: var(--terra-tabs-structural-content-border-radius, 0);
       box-shadow: var(--terra-tabs-structural-content-box-shadow, 0);
+      //Used to make the content sit above the tab to block the box shadow that can be applied
       z-index: var(--terra-tabs-structural-content-z-index, 0);
     }
 

--- a/packages/terra-tabs/src/StructuralTabs.scss
+++ b/packages/terra-tabs/src/StructuralTabs.scss
@@ -8,6 +8,8 @@
     > :nth-child(2) {
       background-color: var(--terra-tabs-structural-content-background-color, #fff);
       border-radius: var(--terra-tabs-structural-content-border-radius, 0);
+      box-shadow: var(--terra-tabs-structural-content-box-shadow, 0);
+      z-index: var(--terra-tabs-structural-content-z-index, 0)
     }
 
     .collapsed-tabs-container {
@@ -21,11 +23,11 @@
       }
 
       .tab-menu.is-active {
-        background-size: 0 0;
+        background-size: var(--terra-tabs-collapsed-tab-menu-active-background-size, 0 0);
       }
 
       .tab-menu:hover {
-        background-size: 0 0;
+        background-size: var(--terra-tabs-collapsed-tab-menu-hover-background-size, 0 0);
       }
     }
 
@@ -33,6 +35,25 @@
       border-bottom-color: var(--terra-tabs-structural-tab-bar-border-color, #dddedf);
       border-bottom-style: solid;
       border-bottom-width: var(--terra-tabs-structural-tab-bar-border-width, 1px);
+
+      // Only target the tabs when in collapsible-tabs-container. When it is collapsed, the menu shouldn't have the stripe
+      .tab,
+      .tab-menu  {
+        position: var(--terra-tabs-structural-position, static);
+        // Typically we use the background image to set a blue stripe and animate it..
+        // However in the scenario where you need to also set the background image as a gradient to give a transparent
+        // affect, you then can't use it for the blue strip.
+        &:before {
+          content: '';
+          height: var(--terra-tabs-structural-tab-before-content-height, 0);
+          display: block;
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 0%;
+          background: var(--terra-tabs-structural-tab-before-content-background, none);
+        }
+      }
     }
 
     //Extended Tabs
@@ -63,7 +84,16 @@
       &.is-active {
         background-color: var(--terra-tabs-structural-active-background-color, #fff);
         background-size: var(--terra-tabs-structural-active-background-size, 100% 2px);
+        box-shadow: var(--terra-tabs-structural-active-box-shadow, none);
         color: var(--terra-tabs-structural-active-color, #000);
+        position: relative;
+
+        &:before {
+          width: 100%;
+          transition-duration: var(--terra-tabs-structural-transition-duration, 0);
+          transition-property: width;
+          transition-timing-function: var(--terra-tabs-structural-transition-timing, ease);
+        }
       }
 
       &.is-disabled,

--- a/packages/terra-tabs/src/StructuralTabs.scss
+++ b/packages/terra-tabs/src/StructuralTabs.scss
@@ -9,7 +9,7 @@
       background-color: var(--terra-tabs-structural-content-background-color, #fff);
       border-radius: var(--terra-tabs-structural-content-border-radius, 0);
       box-shadow: var(--terra-tabs-structural-content-box-shadow, 0);
-      z-index: var(--terra-tabs-structural-content-z-index, 0)
+      z-index: var(--terra-tabs-structural-content-z-index, 0);
     }
 
     .collapsed-tabs-container {
@@ -38,20 +38,20 @@
 
       // Only target the tabs when in collapsible-tabs-container. When it is collapsed, the menu shouldn't have the stripe
       .tab,
-      .tab-menu  {
+      .tab-menu {
         position: var(--terra-tabs-structural-position, static);
-        // Typically we use the background image to set a blue stripe and animate it..
+        // Typically we use the background image to set a blue stripe and animate it...
         // However in the scenario where you need to also set the background image as a gradient to give a transparent
-        // affect, you then can't use it for the blue strip.
-        &:before {
+        // affect and make it 100% height, but you then can't use it for the blue stripe.
+        &::before {
+          background: var(--terra-tabs-structural-tab-before-content-background, none);
           content: '';
-          height: var(--terra-tabs-structural-tab-before-content-height, 0);
           display: block;
+          height: var(--terra-tabs-structural-tab-before-content-height, 0);
+          left: 0;
           position: absolute;
           top: 0;
-          left: 0;
           width: 0%;
-          background: var(--terra-tabs-structural-tab-before-content-background, none);
         }
       }
     }
@@ -88,11 +88,11 @@
         color: var(--terra-tabs-structural-active-color, #000);
         position: relative;
 
-        &:before {
-          width: 100%;
+        &::before {
           transition-duration: var(--terra-tabs-structural-transition-duration, 0);
           transition-property: width;
           transition-timing-function: var(--terra-tabs-structural-transition-timing, ease);
+          width: 100%;
         }
       }
 

--- a/packages/terra-tabs/src/Tabs.jsx
+++ b/packages/terra-tabs/src/Tabs.jsx
@@ -13,7 +13,7 @@ import styles from './Tabs.scss';
 const cx = classNames.bind(styles);
 
 /**
-NOTE: This is being commented out until descussions have been resolved around if modular tabs should be removed.
+NOTE: This is being commented out until discussions have been resolved around if modular tabs should be removed.
 const variants = {
   MODULAR_CENTERED: 'modular-centered',
   MODULAR_LEFT_ALIGNED: 'modular-left-aligned',
@@ -25,7 +25,7 @@ const propTypes = {
 
   /**
    * Tabs style. One of: Tabs.Opts.Variants.MODULAR_CENTERED, Tabs.Opts.Variants.MODULAR_LEFT_ALIGNED, or Tabs.Opts.Variants.STRUCTURAL.
-   * NOTE: This is being commented out until descussions have been resolved around if we want modular tabs.
+   * NOTE: This is being commented out until discussions have been resolved around if we want modular tabs.
   variant: PropTypes.oneOf([variants.MODULAR_CENTERED, variants.MODULAR_LEFT_ALIGNED, variants.STRUCTURAL]),
   */
 
@@ -137,7 +137,7 @@ class Tabs extends React.Component {
       ...customProps
     } = this.props;
 
-    // NOTE: Hardcoding variant to structural until descussions have resolved around if we want modular tabs.
+    // NOTE: Hardcoding variant to structural until discussions have resolved around if we want modular tabs.
     const variant = 'structural';
     const tabsClassNames = cx([
       'tabs-container',
@@ -171,7 +171,7 @@ class Tabs extends React.Component {
       React.cloneElement(contentItem, { isLabelHidden: isIconOnly || this.state.isLabelTruncated })
     ));
 
-    const collasibleTabs = (
+    const collapsibleTabs = (
       <CollapsibleTabs
         activeKey={activeKey || this.state.activeKey}
         activeIndex={this.getActiveTabIndex()}
@@ -197,7 +197,7 @@ class Tabs extends React.Component {
         header={(
           <ResponsiveElement
             defaultElement={collapsedTabs}
-            tiny={collasibleTabs}
+            tiny={collapsibleTabs}
           />
         )}
       >
@@ -217,7 +217,7 @@ Tabs.defaultProps = defaultProps;
 Tabs.Pane = TabPane;
 Tabs.Utils = TabUtils;
 /**
-Note: This is being commented out until descussions have been resolved around if we want modular tabs.
+Note: This is being commented out until discussions have been resolved around if we want modular tabs.
 Tabs.Opts = {
   Variants: variants,
 };


### PR DESCRIPTION
### Summary
As an engineer, in order to theme the tabs component, I want a couple more css variables available

### Additional Details
The specific new piece added is a before content in order to control the blue stripe at the top. Typically we do this with the background-image and set the size. However this doesn't work in our specific theme case because we need to be able to set the background image to a linear gradient thats transparent. Since we can't use it for both, the before content is an optional way to do it.

I left the existing way in there for passivity.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
