### PR TITLE
[terra-form-select] Added a positioning flag to replace a width check

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -5,7 +5,7 @@ Unreleased
 ----------
 ### Breaking Changes - [Upgrade Guide](https://github.com/cerner/terra-core/tree/master/packages/terra-form-select/docs/UPGRADEGUIDE.md)
 * Removed `boundingRef`
-* Removed `isPlaceholderHidden` - The placeholder option is no longer added by default.
+* Removed `isPlaceholderHidden` - A placeholder option is no longer added by default.
 * Removed `name` - Terra recommends handling validations with [react-final-form](https://github.com/final-form/react-final-form).
 * Removed `required` - Terra recommends handling validations with [react-final-form](https://github.com/final-form/react-final-form).
 * Removed `releaseFocus` - Focus no longer needs to be managed.

--- a/packages/terra-form-select/src/_Frame.jsx
+++ b/packages/terra-form-select/src/_Frame.jsx
@@ -98,9 +98,9 @@ class Frame extends React.Component {
     this.state = {
       isOpen: false,
       isFocused: false,
+      isPositioned: false,
       hasSearchChanged: false,
       searchValue: '',
-      width: 0,
     };
 
     this.setInput = this.setInput.bind(this);
@@ -173,9 +173,9 @@ class Frame extends React.Component {
       isAbove: false,
       isFocused: document.activeElement === this.input || document.activeElement === this.select,
       isOpen: false,
+      isPositioned: false,
       hasSearchChanged: false,
       searchValue: '',
-      width: 0,
     });
 
     // Tags and Comboboxes will select the current search value when the component loses focus.
@@ -196,7 +196,7 @@ class Frame extends React.Component {
       this.input.focus();
     }
 
-    this.setState({ isOpen: true, isFocused: true, width: 0 });
+    this.setState({ isOpen: true, isFocused: true, isPositioned: false });
   }
 
   /**
@@ -376,7 +376,7 @@ class Frame extends React.Component {
             id={this.state.isOpen ? 'terra-select-dropdown' : undefined}
             target={this.select}
             isAbove={this.state.isAbove}
-            isEnabled={this.state.width > 0}
+            isEnabled={this.state.isPositioned}
             onResize={this.positionDropdown}
             refCallback={(ref) => { this.dropdown = ref; }}
             style={Util.dropdownStyle(dropdownAttrs, this.state)}

--- a/packages/terra-form-select/src/_FrameUtil.js
+++ b/packages/terra-form-select/src/_FrameUtil.js
@@ -34,6 +34,7 @@ class FrameUtil {
       width,
       maxHeight: Math.min(maxHeight, availableSpace - 10),
       isAbove: !canFitBelow,
+      isPositioned: true,
     };
   }
 


### PR DESCRIPTION
### Summary
Added a boolean flag to determine if the dropdown has been positioned. 

The width was originally being set to hide the content until the dropdown had been positioned, but Hookshot already sets the opacity to 0. We should remove the width manipulation as a flag.  

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
