### PR TITLE
Is it Example or Examples?

### DIFF
--- a/packages/terra-doc-template/CHANGELOG.md
+++ b/packages/terra-doc-template/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Update example header to display the singular or pluralized form of example (Example or Examples)
 
 1.3.0 - (May 23, 2018)
 ------------------

--- a/packages/terra-doc-template/src/DocTemplate.jsx
+++ b/packages/terra-doc-template/src/DocTemplate.jsx
@@ -86,6 +86,12 @@ const DocTemplate = ({ packageName, readme, srcPath, examples, propsTables, ...c
     customProps.className,
   ]);
 
+  let exampleHeader;
+  if (localExamples.length > 0) {
+    const exampleHeaderText = localExamples.length > 1 ? 'Examples' : 'Example';
+    exampleHeader = <h1 className={cx('.examples-header')} >{exampleHeaderText}</h1>;
+  }
+  
   return (
     <div {...customProps} className={docTemplateClassNames}>
       {packageName && <a href={`https://www.npmjs.org/package/${packageName}`}>
@@ -95,7 +101,7 @@ const DocTemplate = ({ packageName, readme, srcPath, examples, propsTables, ...c
       {readme && <Markdown src={readme} />}
       {srcPath && <a href={srcPath}>View component source code</a>}
 
-      {localExamples.length > 0 && <h1 className={cx('.examples-header')} >Examples</h1>}
+      {exampleHeader}
       {localExamples.map(example =>
         <IndexExampleTemplate
           title={example.title}

--- a/packages/terra-doc-template/src/DocTemplate.jsx
+++ b/packages/terra-doc-template/src/DocTemplate.jsx
@@ -89,7 +89,7 @@ const DocTemplate = ({ packageName, readme, srcPath, examples, propsTables, ...c
   let exampleHeader;
   if (localExamples.length > 0) {
     const exampleHeaderText = localExamples.length > 1 ? 'Examples' : 'Example';
-    exampleHeader = <h1 className={cx('.examples-header')} >{exampleHeaderText}</h1>;
+    exampleHeader = <h1 className={cx('.examples-header')}>{exampleHeaderText}</h1>;
   }
   
   return (

--- a/packages/terra-doc-template/src/DocTemplate.jsx
+++ b/packages/terra-doc-template/src/DocTemplate.jsx
@@ -91,7 +91,7 @@ const DocTemplate = ({ packageName, readme, srcPath, examples, propsTables, ...c
     const exampleHeaderText = localExamples.length > 1 ? 'Examples' : 'Example';
     exampleHeader = <h1 className={cx('.examples-header')}>{exampleHeaderText}</h1>;
   }
-  
+
   return (
     <div {...customProps} className={docTemplateClassNames}>
       {packageName && <a href={`https://www.npmjs.org/package/${packageName}`}>

--- a/packages/terra-doc-template/tests/jest/__snapshots__/DocTemplate.test.jsx.snap
+++ b/packages/terra-doc-template/tests/jest/__snapshots__/DocTemplate.test.jsx.snap
@@ -56,7 +56,7 @@ exports[`DocTemplate should show one example 1`] = `
   <h1
     className=".examples-header"
   >
-    Examples
+    Example
   </h1>
   <ExampleTemplate
     description="Describing the test"


### PR DESCRIPTION
### Summary
On pages where there is only one example, the header still says 'Examples'.