### PR TITLE
[terra-form-select] - Allow custom onBlur

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Updated field documentation to be more inline with other examples
+* Updated to allow a custom onBlur
 
 4.2.0 - (May 30, 2018)
 ------------------

--- a/packages/terra-form-select/src/_Frame.jsx
+++ b/packages/terra-form-select/src/_Frame.jsx
@@ -39,6 +39,10 @@ const propTypes = {
    */
   onDeselect: PropTypes.func,
   /**
+   * Callback function triggered when the frame loses focus.
+   */
+  onBlur: PropTypes.func,
+  /**
    * Callback function triggered when the frame gains focus.
    */
   onFocus: PropTypes.func,
@@ -109,6 +113,7 @@ class Frame extends React.Component {
     this.closeDropdown = this.closeDropdown.bind(this);
     this.toggleDropdown = this.toggleDropdown.bind(this);
     this.positionDropdown = this.positionDropdown.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
     this.handleFocus = this.handleFocus.bind(this);
     this.handleSelect = this.handleSelect.bind(this);
     this.handleSearch = this.handleSearch.bind(this);
@@ -210,6 +215,17 @@ class Frame extends React.Component {
     const { dropdownAttrs } = this.props;
     const { select, dropdown, state } = this;
     this.setState(Util.dropdownPosition(dropdownAttrs, state, select, dropdown));
+  }
+
+  /**
+   * Handles the blur event.
+   */
+  handleBlur(event) {
+    this.closeDropdown();
+
+    if (this.props.onBlur) {
+      this.props.onBlur(event);
+    }
   }
 
   /**
@@ -357,7 +373,7 @@ class Frame extends React.Component {
         aria-haspopup="true"
         aria-owns={this.state.isOpen ? 'terra-select-dropdown' : undefined}
         className={selectClasses}
-        onBlur={this.closeDropdown}
+        onBlur={this.handleBlur}
         onFocus={this.handleFocus}
         onKeyDown={this.handleKeyDown}
         onMouseDown={this.handleMouseDown}

--- a/packages/terra-form-select/tests/jest/Frame.test.jsx
+++ b/packages/terra-form-select/tests/jest/Frame.test.jsx
@@ -107,4 +107,14 @@ describe('Frame', () => {
     const wrapper = shallow(<Frame variant="tag" dropdown={() => <div>Custom</div>} />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should call a custom onBlur', () => {
+    const mockBlur = jest.fn();
+    const wrapper = shallow(<Frame onBlur={mockBlur} />, intlContexts.shallowContext);
+
+    wrapper.simulate('focus');
+    wrapper.simulate('blur');
+
+    expect(mockBlur).toBeCalled();
+  });
 });


### PR DESCRIPTION
### Summary
This change allows a user to pass a custom onBlur

Resolves https://github.com/cerner/terra-core/issues/1560.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
