### PR TITLE
[terra-paginator] Align peerDependencies for paginator component

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -63,6 +63,7 @@ Cerner Corporation
 - Alex Bezek [@alex-bezek]
 - Ben Boersma [@BenBoersma]
 - Cory McDonald [@corymcdonald]
+- Anthony Ross [@AnthonyRoss]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -128,3 +129,4 @@ Cerner Corporation
 [@alex-bezek]: https://github.com/alex-bezek
 [@BenBoersma]: https://github.com/BenBoersma
 [@CoryMcDonald]: https://github.com/CoryMcDonald
+[@AnthonyRoss]: https://github.com/AnthonyRoss

--- a/packages/terra-paginator/package.json
+++ b/packages/terra-paginator/package.json
@@ -26,13 +26,11 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^3.7.0",
-    "terra-mixins": "^1.15.0"
+    "terra-base": "^3.7.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^3.11.0",
     "terra-button": "^2.12.0",
     "terra-dialog": "^1.12.0",
     "terra-doc-template": "^1.5.0",


### PR DESCRIPTION
Summary
Hopefully fixing #1543 with this pull request.

Additional Details
If you look at the sass-loader changelog you will see the following breaking change documented in version 7.0+.

The sass-loader throws an error at runtime now and refuses to compile if the peer dependency is wrong. This could break applications where npm's peer dependency warning was just ignored.

See https://github.com/cerner/terra-core/pull/1583 for more information on this change

@cerner/terra