### PR TITLE
[terra-form-select] - Fixed CSS theme variable names

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,11 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* CSS variable for placeholder font size
+
+### Fixed
+* Renamed duplicate CSS variables
 
 4.4.0 - (June 13, 2018)
 ------------------

--- a/packages/terra-form-select/src/_Frame.module.scss
+++ b/packages/terra-form-select/src/_Frame.module.scss
@@ -164,7 +164,7 @@
   .search-input::placeholder,
   .placeholder {
     color: var(--terra-select-search-placeholder-color, #bcbfc0);
-    font-size: 1.143rem;
+    font-size: var(--terra-select-search-placeholder-font-size, 1.143rem);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/terra-form-select/src/_OptGroup.module.scss
+++ b/packages/terra-form-select/src/_OptGroup.module.scss
@@ -12,11 +12,11 @@
 
   .label {
     background-color: var(--terra-select-optgroup-label-background-color, #f4f4f4);
-    color: var(--terra-select-optgroup-label-background-color, #64696c);
-    font-size: var(--terra-select-optgroup-label-color, 0.9286rem);
+    color: var(--terra-select-optgroup-label-color, #64696c);
+    font-size: var(--terra-select-optgroup-font-size, 0.9286rem);
     font-weight: var(--terra-select-optgroup-label-font-weight, bold);
     line-height: var(--terra-select-optgroup-label-line-height, 1.23);
-    padding: var(--terra-select-optgroup-label-line-height, 0.38461538461538464rem);
+    padding: var(--terra-select-optgroup-label-padding, 0.38461538461538464rem);
     word-break: break-all;
   }
 

--- a/packages/terra-form-select/src/_Option.module.scss
+++ b/packages/terra-form-select/src/_Option.module.scss
@@ -14,9 +14,9 @@
 
   .is-default {
     &:active:not(.is-disabled) {
-      background-color: var(--terra-select-option-active-background-color, #0079be);
-      color: var(--terra-select-option-active-color, #fff);
-      font-weight: var(--terra-select-option-active-font-weight, normal);
+      background-color: var(--terra-select-option-active-pressed-background-color, #0079be);
+      color: var(--terra-select-option-active-pressed-color, #fff);
+      font-weight: var(--terra-select-option-active-pressed-font-weight, normal);
     }
 
     &.is-selected {

--- a/packages/terra-form-select/src/_Option.module.scss
+++ b/packages/terra-form-select/src/_Option.module.scss
@@ -14,9 +14,9 @@
 
   .is-default {
     &:active:not(.is-disabled) {
-      background-color: var(--terra-select-option-active-pressed-background-color, #0079be);
-      color: var(--terra-select-option-active-pressed-color, #fff);
-      font-weight: var(--terra-select-option-active-pressed-font-weight, normal);
+      background-color: var(--terra-select-option-pressed-background-color, #0079be);
+      color: var(--terra-select-option-pressed-color, #fff);
+      font-weight: var(--terra-select-option-pressed-font-weight, normal);
     }
 
     &.is-selected {


### PR DESCRIPTION
### Summary
- Fixed a couple theme-able variable names within the OptGroup.
- Added a theme-able variable for the placeholder font-size

Fixes https://github.com/cerner/terra-core/issues/1598

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
