### PR TITLE
Fix error ResizeObserver loop limit exceeded

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -65,6 +65,7 @@ Cerner Corporation
 - Tom Wu [@tomleewu]
 - Cory McDonald [@corymcdonald]
 - Anthony Ross [@AnthonyRoss]
+- Ajay Philip Sabu [@ap056120]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -132,3 +133,4 @@ Cerner Corporation
 [@tomleewu]: https:/github.com/tomleewu
 [@CoryMcDonald]: https://github.com/CoryMcDonald
 [@AnthonyRoss]: https://github.com/AnthonyRoss
+[@ap056120]: https://github.com/ap056120

--- a/packages/terra-responsive-element/CHANGELOG.md
+++ b/packages/terra-responsive-element/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ----------
 
+3.2.0 - (June 25, 2018)
+------------------
+### Fixed
+* Fixed ResizeObserver loop limit exceeded error for Responsive Elements
+
 3.1.0 - (June 22, 2018)
 ------------------
 ### Changed

--- a/packages/terra-responsive-element/src/ResponsiveElement.jsx
+++ b/packages/terra-responsive-element/src/ResponsiveElement.jsx
@@ -52,8 +52,11 @@ class ResponsiveElement extends React.Component {
 
   componentDidMount() {
     if (this.container) {
-      this.handleResize(this.container.innerWidth);
-      this.resizeObserver = new ResizeObserver((entries) => { this.handleResize(entries[0].contentRect.width); });
+      this.resizeObserver = new ResizeObserver((entries) => {
+        window.requestAnimationFrame(() => {
+          this.handleResize(entries[0].contentRect.width);
+        });
+      });
       this.resizeObserver.observe(this.container);
     } else {
       this.handleResize(window.innerWidth);

--- a/packages/terra-responsive-element/src/ResponsiveElement.jsx
+++ b/packages/terra-responsive-element/src/ResponsiveElement.jsx
@@ -92,7 +92,9 @@ class ResponsiveElement extends React.Component {
     }
 
     if (this.state.element !== element) {
-      this.setState({ element });
+      window.requestAnimationFrame(function() {
+        this.setState({ element });
+      });
     }
   }
 

--- a/packages/terra-responsive-element/src/ResponsiveElement.jsx
+++ b/packages/terra-responsive-element/src/ResponsiveElement.jsx
@@ -52,6 +52,7 @@ class ResponsiveElement extends React.Component {
 
   componentDidMount() {
     if (this.container) {
+      this.handleResize(this.container.innerWidth);
       this.resizeObserver = new ResizeObserver((entries) => { this.handleResize(entries[0].contentRect.width); });
       this.resizeObserver.observe(this.container);
     } else {
@@ -92,9 +93,7 @@ class ResponsiveElement extends React.Component {
     }
 
     if (this.state.element !== element) {
-      window.requestAnimationFrame(() => {
-        this.setState({ element });
-      });
+      this.setState({ element });
     }
   }
 

--- a/packages/terra-responsive-element/src/ResponsiveElement.jsx
+++ b/packages/terra-responsive-element/src/ResponsiveElement.jsx
@@ -92,7 +92,7 @@ class ResponsiveElement extends React.Component {
     }
 
     if (this.state.element !== element) {
-      window.requestAnimationFrame(function() {
+      window.requestAnimationFrame(() => {
         this.setState({ element });
       });
     }


### PR DESCRIPTION
### Summary
Resolves the ResizeObserver loop limit exceeded error that is thrown when Responsive elements are loaded.

#### Additional Details
When a ResponsiveElement is mounted for the first time, the ResizeObserver receives an event with the size of the ResponsiveElement’s parent, which the ResponsiveElement uses to render the correct component in place of the div it used to initially get the ref.  In cases where the ResponsiveElement’s parent is wrapped to its contents, the act of rendering the actual responsive component will cause another resize event to be triggered, which the ResizeObserver will detect as a potential infinite loop.  The error thrown by the ResizeObserver is intended as a warning, doesn’t actually prevent infinite loops, and the ResponsiveElement already has logic to prevent accidental infinite loops, so the error just gets in the way.  In our case, however, other components we are consuming don’t realize this and overreact to the error, so we need to suppress it.  We can fix this by delaying the second rendering (the first one where an actual child component is rendered) for one frame after the first rendering with the ref div.

The 'ResizeObserver loop limit exceeded' error is not thrown in the JavaScript console of a browser, but it can be caught using a simple [extension](https://chrome.google.com/webstore/detail/javascript-errors-notifie/jafmfknfnkoekkdocjiaipcnmkklaajd?hl=en) that is available for Chrome/Firefox: 

The error can currently be demonstrated in [Kaiju](https://kaiju.cerner.com/projects/dark-gyaos-TAZ-MA/workspaces/muddy-shadow-_9LZPw/preview) as well. This [JS Fiddle]( https://jsfiddle.net/que_etc/ba1ad26e/) demonstrates that the loop limit is 0, and any size modification within the resize handler triggers the warning.

[Documentation for ResizeObserver](https://developers.google.com/web/updates/2016/10/resizeobserver)

This [GitHub issue](https://github.com/WICG/ResizeObserver/issues/38) proposes an alternate solution to the loop limit problem, but the current implementation of the ResizeObserver doesn’t allow that to solution to work.