### PR TITLE
Correct terra-content-container IE10 'initial' style bug.

### DIFF
--- a/packages/terra-content-container/CHANGELOG.md
+++ b/packages/terra-content-container/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* IE10 bug using static styles with no sized parent. No longer using 'initial'.
 
 2.14.0 - (June 28, 2018)
 ------------------

--- a/packages/terra-content-container/src/ContentContainer.scss
+++ b/packages/terra-content-container/src/ContentContainer.scss
@@ -4,12 +4,13 @@
     display: flex;
     flex-direction: column;
     
-    // reset scroll styles to intial defaults to handle stack/block style layout.
+    // reset scroll styles to standard div defaults to handle stack/block style layout.
+    // IE10 does not properly support 'initial', so we need to be explicit.
     > .main > .normalizer {
-      height: initial; // auto
-      overflow: initial; // visible
-      position: initial; // static
-      width: initial; // auto
+      height: auto;
+      overflow: visible;
+      position: static;
+      width: auto;
     }
   }
   


### PR DESCRIPTION
### Summary
Change static normalizer styles to use explicit values, rather than 'initial' as it's not supported.

Thanks for contributing to Terra. 
@cerner/terra
