### PR TITLE
Add testURL to jestconfig

### DIFF
--- a/jestconfig.js
+++ b/jestconfig.js
@@ -18,4 +18,5 @@ module.exports = {
     '\\.(svg|jpg|png|md)$': '<rootDir>/__mocks__/fileMock.js',
     '\\.(css|scss)$': 'identity-obj-proxy',
   },
+  testURL: 'http://localhost',
 };


### PR DESCRIPTION
### Summary
Adding testURL to jest config to resolve issue related to [jsdom](https://github.com/jsdom/jsdom/issues/2304) / [jest](https://github.com/facebook/jest/issues/6766) issues with the jsdom 11.12.0 release.