### PR TITLE
[terra-spacer] Removed unnecessary spacer CSS class

### DIFF
--- a/packages/terra-spacer/CHANGELOG.md
+++ b/packages/terra-spacer/CHANGELOG.md
@@ -4,6 +4,9 @@ ChangeLog
 Unreleased
 ----------
 
+### Removed
+* Remove 'spacer' CSS class
+
 2.17.0 - (July 19, 2018)
 ------------------
 ### Changed

--- a/packages/terra-spacer/src/Spacer.jsx
+++ b/packages/terra-spacer/src/Spacer.jsx
@@ -116,7 +116,6 @@ const Spacer = ({
   };
 
   const SpacerClassNames = cx([
-    'spacer',
     `margin-top-${SpacerClassMappings[marginAttributes.marginTop]}`,
     `margin-bottom-${SpacerClassMappings[marginAttributes.marginBottom]}`,
     `margin-left-${SpacerClassMappings[marginAttributes.marginLeft]}`,

--- a/packages/terra-spacer/tests/jest/__snapshots__/Spacer.test.jsx.snap
+++ b/packages/terra-spacer/tests/jest/__snapshots__/Spacer.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Spacer it should pass in a custom prop 1`] = `
 <div
-  class="spacer margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-none padding-bottom-none padding-left-none padding-right-none spacer"
+  class="margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-none padding-bottom-none padding-left-none padding-right-none spacer"
 >
   <p>
     Test
@@ -12,7 +12,7 @@ exports[`Spacer it should pass in a custom prop 1`] = `
 
 exports[`Spacer should render a default component 1`] = `
 <div
-  class="spacer margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-none padding-bottom-none padding-left-none padding-right-none"
+  class="margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-none padding-bottom-none padding-left-none padding-right-none"
 >
   <div>
     Test Component
@@ -22,7 +22,7 @@ exports[`Spacer should render a default component 1`] = `
 
 exports[`Spacer should render a spacer component with all margin props set to the given values 1`] = `
 <div
-  class="spacer margin-top-small margin-bottom-small-minus-1 margin-left-small-minus-2 margin-right-medium padding-top-none padding-bottom-none padding-left-none padding-right-none"
+  class="margin-top-small margin-bottom-small-minus-1 margin-left-small-minus-2 margin-right-medium padding-top-none padding-bottom-none padding-left-none padding-right-none"
 >
   <p>
     Test
@@ -32,7 +32,7 @@ exports[`Spacer should render a spacer component with all margin props set to th
 
 exports[`Spacer should render a spacer component with all padding props set to the given values 1`] = `
 <div
-  class="spacer margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-large-plus-1 padding-bottom-large-plus-2 padding-left-large-plus-3 padding-right-large-plus-4"
+  class="margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-large-plus-1 padding-bottom-large-plus-2 padding-left-large-plus-3 padding-right-large-plus-4"
 >
   <p>
     Test
@@ -42,7 +42,7 @@ exports[`Spacer should render a spacer component with all padding props set to t
 
 exports[`Spacer should render a spacer component with inline-block display 1`] = `
 <div
-  class="spacer margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-none padding-bottom-none padding-left-none padding-right-none is-inline-block"
+  class="margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-none padding-bottom-none padding-left-none padding-right-none is-inline-block"
 >
   <p>
     Test
@@ -52,7 +52,7 @@ exports[`Spacer should render a spacer component with inline-block display 1`] =
 
 exports[`Spacer should render a spacer component with large left padding 1`] = `
 <div
-  class="spacer margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-none padding-bottom-none padding-left-large padding-right-none"
+  class="margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-none padding-bottom-none padding-left-large padding-right-none"
 >
   <p>
     Test
@@ -62,7 +62,7 @@ exports[`Spacer should render a spacer component with large left padding 1`] = `
 
 exports[`Spacer should render a spacer component with large vertical and small horizontal margin 1`] = `
 <div
-  class="spacer margin-top-large margin-bottom-large margin-left-small margin-right-small padding-top-none padding-bottom-none padding-left-none padding-right-none"
+  class="margin-top-large margin-bottom-large margin-left-small margin-right-small padding-top-none padding-bottom-none padding-left-none padding-right-none"
 >
   <p>
     Test
@@ -72,7 +72,7 @@ exports[`Spacer should render a spacer component with large vertical and small h
 
 exports[`Spacer should render a spacer component with medium bottom margin 1`] = `
 <div
-  class="spacer margin-top-none margin-bottom-medium margin-left-none margin-right-none padding-top-none padding-bottom-none padding-left-none padding-right-none"
+  class="margin-top-none margin-bottom-medium margin-left-none margin-right-none padding-top-none padding-bottom-none padding-left-none padding-right-none"
 >
   <p>
     Test
@@ -82,7 +82,7 @@ exports[`Spacer should render a spacer component with medium bottom margin 1`] =
 
 exports[`Spacer should render a spacer component with small top margin 1`] = `
 <div
-  class="spacer margin-top-small margin-bottom-none margin-left-none margin-right-none padding-top-none padding-bottom-none padding-left-none padding-right-none"
+  class="margin-top-small margin-bottom-none margin-left-none margin-right-none padding-top-none padding-bottom-none padding-left-none padding-right-none"
 >
   <p>
     Test
@@ -92,7 +92,7 @@ exports[`Spacer should render a spacer component with small top margin 1`] = `
 
 exports[`Spacer should render a spacer component with top, right, bottom, and left margin set to large 1`] = `
 <div
-  class="spacer margin-top-large margin-bottom-large margin-left-large margin-right-large padding-top-none padding-bottom-none padding-left-none padding-right-none"
+  class="margin-top-large margin-bottom-large margin-left-large margin-right-large padding-top-none padding-bottom-none padding-left-none padding-right-none"
 >
   <p>
     Test
@@ -102,7 +102,7 @@ exports[`Spacer should render a spacer component with top, right, bottom, and le
 
 exports[`Spacer should render a spacer component with top, right, bottom, and left padding set to large 1`] = `
 <div
-  class="spacer margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-large padding-bottom-large padding-left-large padding-right-large"
+  class="margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-large padding-bottom-large padding-left-large padding-right-large"
 >
   <p>
     Test
@@ -112,7 +112,7 @@ exports[`Spacer should render a spacer component with top, right, bottom, and le
 
 exports[`Spacer should render a spacer component with vertical margin set to large and horizontal margin set to small 1`] = `
 <div
-  class="spacer margin-top-large margin-bottom-large margin-left-small margin-right-small padding-top-none padding-bottom-none padding-left-none padding-right-none"
+  class="margin-top-large margin-bottom-large margin-left-small margin-right-small padding-top-none padding-bottom-none padding-left-none padding-right-none"
 >
   <p>
     Test
@@ -122,7 +122,7 @@ exports[`Spacer should render a spacer component with vertical margin set to lar
 
 exports[`Spacer should render a spacer component with vertical padding set to large and horizontal padding set to small 1`] = `
 <div
-  class="spacer margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-large padding-bottom-large padding-left-small padding-right-small"
+  class="margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-large padding-bottom-large padding-left-small padding-right-small"
 >
   <p>
     Test
@@ -132,7 +132,7 @@ exports[`Spacer should render a spacer component with vertical padding set to la
 
 exports[`Spacer should render a spacer component with vertical top margin set to large, horizontal margin set to medium, and bottom margin set to small 1`] = `
 <div
-  class="spacer margin-top-large margin-bottom-small margin-left-medium margin-right-medium padding-top-none padding-bottom-none padding-left-none padding-right-none"
+  class="margin-top-large margin-bottom-small margin-left-medium margin-right-medium padding-top-none padding-bottom-none padding-left-none padding-right-none"
 >
   <p>
     Test
@@ -142,7 +142,7 @@ exports[`Spacer should render a spacer component with vertical top margin set to
 
 exports[`Spacer should render a spacer component with vertical top margin set to large, right margin set to medium, bottom margin set to small, and left margin set to small-1  1`] = `
 <div
-  class="spacer margin-top-large margin-bottom-small margin-left-small-minus-1 margin-right-medium padding-top-none padding-bottom-none padding-left-none padding-right-none"
+  class="margin-top-large margin-bottom-small margin-left-small-minus-1 margin-right-medium padding-top-none padding-bottom-none padding-left-none padding-right-none"
 >
   <p>
     Test
@@ -152,7 +152,7 @@ exports[`Spacer should render a spacer component with vertical top margin set to
 
 exports[`Spacer should render a spacer component with vertical top padding set to large, horizontal padding set to medium, and bottom padding set to small 1`] = `
 <div
-  class="spacer margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-large padding-bottom-small padding-left-medium padding-right-medium"
+  class="margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-large padding-bottom-small padding-left-medium padding-right-medium"
 >
   <p>
     Test
@@ -162,7 +162,7 @@ exports[`Spacer should render a spacer component with vertical top padding set t
 
 exports[`Spacer should render a spacer component with vertical top padding set to large, right padding set to medium, bottom padding set to small, and left padding set to small-1  1`] = `
 <div
-  class="spacer margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-large padding-bottom-small padding-left-small-minus-1 padding-right-medium"
+  class="margin-top-none margin-bottom-none margin-left-none margin-right-none padding-top-large padding-bottom-small padding-left-small-minus-1 padding-right-medium"
 >
   <p>
     Test


### PR DESCRIPTION
### Summary
Removed the CSS class 'spacer' that wasn't being used.

Closes #1737.