### PR TITLE
fix link when viewed from https://engineering.cerner.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Components in beta stage may include breaking changes, new features, and bug fix
 
 ## Internationalization (I18n)
 
-1. Please follow [Base Getting Started](packages/terra-base/README.md#getting-started) to install `Base`, and consume it with `locale` props.
+1. Please follow [Base Getting Started](https://github.com/cerner/terra-core/blob/master/packages/terra-base/README.md#getting-started) to install `Base`, and consume it with `locale` props.
 2. Please follow [terra-i18n Aggregate Translations Guide](https://github.com/cerner/terra-core/blob/master/packages/terra-i18n/docs/AggregateTranslations.md) to set up aggregated translations.
 3. Install and config `react-intl`
     - Install it `npm install --save react-intl`.


### PR DESCRIPTION
### Summary
Fixing a link that doesn't work when viewed from https://engineering.cerner.com/terra-core/#/home.