### PR TITLE
[terra-overlay] Updated backgroundStyle documentation

### DIFF
--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated backgroundStyle documentation
 
 2.22.0 - (August 8, 2018)
 ------------------

--- a/packages/terra-overlay/src/Overlay.jsx
+++ b/packages/terra-overlay/src/Overlay.jsx
@@ -24,9 +24,9 @@ const propTypes = {
   */
   isOpen: PropTypes.bool,
   /**
-  * The visual theme to be applied to the overlay background. Accepts 'light', 'dark', and 'clear' or BackgroundStyles.LIGHT, BackgroundStyles.DARK, and BackgroundStyles.CLEAR.
+  * The visual theme to be applied to the overlay background. Accepts 'light', 'dark', and 'clear'.
   */
-  backgroundStyle: PropTypes.oneOf(['light', 'dark', 'clear', BackgroundStyles]),
+  backgroundStyle: PropTypes.oneOf(['light', 'dark', 'clear']),
   /**
   * Indicates if the overlay content is scrollable.
   */


### PR DESCRIPTION
### Summary
The prop declaration `backgroundStyle` included the BackgroundStyles object listed as an option.

Running react-docgen against terra-overlay returns this object which cannot be converted into a valid background style.

- Removed the BackgroundStyles object from the prop declaration.
- Removed inaccurate object documentation. 

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
