### PR TITLE
added refCallback prop to terra-button

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -67,6 +67,7 @@ Cerner Corporation
 - Anthony Ross [@AnthonyRoss]
 - Julia Calandro [@JuliaCalandro]
 - Adam Parker [@amichaelparker]
+- Matthew Carr [@Matthematic]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -136,3 +137,4 @@ Cerner Corporation
 [@AnthonyRoss]: https://github.com/AnthonyRoss
 [@JuliaCalandro]: https://github.com/JuliaCalandro
 [@amichaelparker]: https://github.com/amichaelparker
+[@Matthematic]: https://github.com/Matthematic

--- a/packages/terra-button/CHANGELOG.md
+++ b/packages/terra-button/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added refCallback prop to the Button component
 
 2.19.0 - (August 1, 2018)
 ------------------

--- a/packages/terra-button/src/Button.jsx
+++ b/packages/terra-button/src/Button.jsx
@@ -78,6 +78,10 @@ const propTypes = {
    */
   onKeyUp: PropTypes.func,
   /**
+   * Callback ref to pass into the dom element.
+   */
+  refCallback: PropTypes.func,
+  /**
    * Sets the button text. If the button `isIconOnly` or of variant `utility`, this text is set as the aria-label for accessibility.
    */
   text: PropTypes.string.isRequired,
@@ -97,6 +101,7 @@ const defaultProps = {
   isDisabled: false,
   isIconOnly: false,
   isReversed: false,
+  refCallback: undefined,
   type: ButtonTypes.BUTTON,
   variant: ButtonVariants.NEUTRAL,
 };
@@ -174,6 +179,7 @@ class Button extends React.Component {
       onFocus,
       onKeyDown,
       onKeyUp,
+      refCallback,
       ...customProps
     } = this.props;
 
@@ -235,6 +241,7 @@ class Button extends React.Component {
         onClick={onClick}
         onFocus={onFocus}
         href={href}
+        ref={refCallback}
       >
         {buttonLabel}
       </ComponentType>

--- a/packages/terra-button/tests/jest/Button.test.jsx
+++ b/packages/terra-button/tests/jest/Button.test.jsx
@@ -111,6 +111,13 @@ it('should be disabled when set', () => {
   expect(button.prop('disabled')).toEqual(true);
 });
 
+it('should pass in refCallback as the ref prop of the input element', () => {
+  const refCallback = jest.fn();
+  const wrapper = mount(<Button text="text" refCallback={refCallback} />);
+  expect(refCallback).toBeCalled();
+  expect(wrapper).toMatchSnapshot();
+});
+
 // Structure
 it('should have the class text-only when only text is provided', () => {
   const button = shallow(<Button text="text" />);

--- a/packages/terra-button/tests/jest/__snapshots__/Button.test.jsx.snap
+++ b/packages/terra-button/tests/jest/__snapshots__/Button.test.jsx.snap
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should pass in refCallback as the ref prop of the input element 1`] = `
+<Button
+  isBlock={false}
+  isCompact={false}
+  isDisabled={false}
+  isIconOnly={false}
+  isReversed={false}
+  refCallback={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          <button
+            aria-disabled="false"
+            class="button neutral"
+            type="button"
+          >
+            <span
+              class="text-only"
+            >
+              <span
+                class=""
+              >
+                text
+              </span>
+            </span>
+          </button>,
+        ],
+      ],
+      "results": Array [
+        Object {
+          "isThrow": false,
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  text="text"
+  type="button"
+  variant="neutral"
+>
+  <button
+    aria-disabled={false}
+    aria-label={null}
+    className="button neutral"
+    disabled={false}
+    onBlur={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    type="button"
+  >
+    <span
+      className="text-only"
+    >
+      <span
+        className=""
+      >
+        text
+      </span>
+    </span>
+  </button>
+</Button>
+`;
+
 exports[`should render a Button with merged attributes 1`] = `
 <button
   aria-disabled={false}


### PR DESCRIPTION
### Summary
Added the refCallback prop to terra-button and passed it into the <ComponentType /> object during render.
fixes #1780 