### PR TITLE
Expose the ability to set propsResolution prop in doc template

### DIFF
--- a/packages/terra-doc-template/CHANGELOG.md
+++ b/packages/terra-doc-template/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 ### Changed
 * Bumped minimum react peerDependency version from ^16.2.0 to ^16.4.2
 * Bumped minimum react-dom peerDependency version from ^16.2.0 to ^16.4.2
+* Expose propsResolution prop in propTable via doc-template component
 
 1.14.0 - (September 4, 2018)
 ------------------

--- a/packages/terra-doc-template/src/DocTemplate.jsx
+++ b/packages/terra-doc-template/src/DocTemplate.jsx
@@ -50,6 +50,7 @@ const propTypes = {
   propsTables: PropTypes.arrayOf(PropTypes.shape({
     componentSrc: PropTypes.string,
     componentName: PropTypes.string,
+    propsResolution: PropTypes.string,
   })),
 };
 
@@ -118,6 +119,7 @@ const DocTemplate = ({
           src={propsTable.componentSrc}
           componentName={propsTable.componentName}
           key={propsTable.id}
+          propsResolution={propsTable.propsResolution}
         />
       ))}
       {children}

--- a/packages/terra-doc-template/tests/jest/DocTemplate.test.jsx
+++ b/packages/terra-doc-template/tests/jest/DocTemplate.test.jsx
@@ -72,6 +72,11 @@ describe('DocTemplate', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should show props table with findAllComponentDefinitions prop resolution', () => {
+    const wrapper = shallow(<DocTemplate propsTables={[{ componentSrc: testComponentSrc, componentName: 'Test Component', propsResolution: 'findAllComponentDefinitions' }]} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('should show the version, readme, source link, examples, and props tables', () => {
     const wrapper = shallow(<DocTemplate
       packageName="terra-doc-template"

--- a/packages/terra-doc-template/tests/jest/__snapshots__/DocTemplate.test.jsx.snap
+++ b/packages/terra-doc-template/tests/jest/__snapshots__/DocTemplate.test.jsx.snap
@@ -132,6 +132,19 @@ exports[`DocTemplate should show one props table 1`] = `
 </div>
 `;
 
+exports[`DocTemplate should show props table with findAllComponentDefinitions prop resolution 1`] = `
+<div
+  className="doc-template"
+>
+  <PropsTable
+    componentName="Test Component"
+    key="0"
+    propsResolution="findAllComponentDefinitions"
+    src="test-file-stub"
+  />
+</div>
+`;
+
 exports[`DocTemplate should show the readme 1`] = `
 <div
   className="doc-template"


### PR DESCRIPTION
### Summary
Recently we added the ability to select how you'd want react-docgen to parse component files to resolve props to the terra-props-table component. This PR adds the ability to interface with the new propsResolution prop added to the terra-props-table component from the terra-doc-template component.