### PR TITLE
Fix bug where props-table component eagerly parsed component src code

### DIFF
--- a/packages/terra-props-table/CHANGELOG.md
+++ b/packages/terra-props-table/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Fixed bug where props-table eagerly parsed component source code
 
 2.17.0 - (September 5, 2018)
 ------------------

--- a/packages/terra-props-table/src/PropsTable.jsx
+++ b/packages/terra-props-table/src/PropsTable.jsx
@@ -101,19 +101,23 @@ const PropsTable = ({
    * function to account for mutiple export.
    * @type {Object}
    */
-  let componentMetaData = parse(src);
+  let componentMetaData;
 
   /**
    * Alias for props object from componentMetaData
    * @type {Object}
    */
-  let componentProps = componentMetaData.props;
+  let componentProps;
 
-  // If user wants to resolve all component definitions in file, use react-docgen's
-  // findAllComponentDefinitions resolver
+  // Resolve using react-docgen's default resolver
+  if (propsResolution === 'default') {
+    componentMetaData = parse(src);
+    componentProps = componentMetaData.props;
+  }
+
+  // Resolve using react-docgen's findAllComponentDefinitions resolver
   if (propsResolution === 'findAllComponentDefinitions') {
     componentMetaData = parse(src, resolver.findAllComponentDefinitions);
-
     componentProps = componentMetaData[0].props;
   }
 


### PR DESCRIPTION
### Summary
Ran into a bug with recent props-table updated where it was parsing code soon than anticipated and throwing an error when users set `propsResolution` to `findAllComponentDefinitions`. This change ensures that parse is called accordingly with the supplied `propsResolution` value.