### PR TITLE
Clean up un-needed globals

### DIFF
--- a/packages/terra-abstract-modal/tests/wdio/abstract-modal-spec.js
+++ b/packages/terra-abstract-modal/tests/wdio/abstract-modal-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 describe('Abstract Modal', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-action-footer/tests/wdio/action-footer-spec.js
+++ b/packages/terra-action-footer/tests/wdio/action-footer-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const {
   viewports,
   withActionsThemeables,

--- a/packages/terra-action-footer/tests/wdio/block-action-footer-spec.js
+++ b/packages/terra-action-footer/tests/wdio/block-action-footer-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra */
 const {
   viewports,
   withActionsThemeables,

--- a/packages/terra-action-footer/tests/wdio/centered-action-footer-spec.js
+++ b/packages/terra-action-footer/tests/wdio/centered-action-footer-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const {
   viewports,
   withActionsThemeables,

--- a/packages/terra-action-header/tests/wdio/action-header-spec.js
+++ b/packages/terra-action-header/tests/wdio/action-header-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 const viewports = Terra.viewports('tiny', 'medium', 'large');
 
 viewports.forEach((viewport) => {

--- a/packages/terra-alert/tests/wdio/alert-spec.js
+++ b/packages/terra-alert/tests/wdio/alert-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('tiny', 'large');
 
 describe('Alert', () => {

--- a/packages/terra-arrange/tests/wdio/arrange-spec.js
+++ b/packages/terra-arrange/tests/wdio/arrange-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 const viewports = Terra.viewports('tiny', 'medium');
 
 describe('Arrange', () => {

--- a/packages/terra-avatar/tests/wdio/avatar-spec.js
+++ b/packages/terra-avatar/tests/wdio/avatar-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 describe('Avatar', () => {
   describe('User', () => {
     before(() => browser.url('/#/raw/tests/terra-avatar/avatar/user-avatar'));

--- a/packages/terra-badge/tests/wdio/badge-spec.js
+++ b/packages/terra-badge/tests/wdio/badge-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('tiny', 'medium');
 
 describe('Badge', () => {

--- a/packages/terra-base/tests/wdio/base-spec.js
+++ b/packages/terra-base/tests/wdio/base-spec.js
@@ -1,4 +1,4 @@
-/* global Terra, $, before, browser */
+/* global $ */
 
 describe('Base', () => {
   before(() => browser.setViewportSize(Terra.viewports('tiny')[0]));

--- a/packages/terra-button-group/tests/wdio/button-group-spec.js
+++ b/packages/terra-button-group/tests/wdio/button-group-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 describe('Button Group', () => {
   describe('Text Button', () => {
     beforeEach(() => browser.url('/#/raw/tests/terra-button-group/button-group/button-group-text'));

--- a/packages/terra-button/tests/wdio/button-spec.js
+++ b/packages/terra-button/tests/wdio/button-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 describe('Button', () => {
   before(() => browser.setViewportSize(Terra.viewports('tiny')[0]));
 

--- a/packages/terra-card/tests/wdio/card-spec.js
+++ b/packages/terra-card/tests/wdio/card-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('tiny');
 
 describe('Card', () => {

--- a/packages/terra-collapsible-menu-view/tests/wdio/collapsible-menu-view-spec.js
+++ b/packages/terra-collapsible-menu-view/tests/wdio/collapsible-menu-view-spec.js
@@ -1,5 +1,3 @@
-/* global browser, before, Terra */
-
 describe('Collapsible Menu View', () => {
   Terra.viewports().forEach((viewport) => {
     describe('Responsive', () => {

--- a/packages/terra-content-container/tests/wdio/content-container-spec.js
+++ b/packages/terra-content-container/tests/wdio/content-container-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 describe('Content Container', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
   describe('Default', () => {

--- a/packages/terra-date-picker/tests/wdio/date-picker-spec.js
+++ b/packages/terra-date-picker/tests/wdio/date-picker-spec.js
@@ -1,5 +1,3 @@
-/* global browser, before, Terra */
-
 const ignoredA11y = {
   'color-contrast': { enabled: false },
   label: { enabled: false },

--- a/packages/terra-date-time-picker/tests/wdio/date-time-picker-spec.js
+++ b/packages/terra-date-time-picker/tests/wdio/date-time-picker-spec.js
@@ -1,5 +1,3 @@
-/* global browser, before, Terra */
-
 /* eslint-disable no-unused-expressions */
 const moment = require('moment-timezone');
 

--- a/packages/terra-demographics-banner/tests/wdio/demographics-banner-spec.js
+++ b/packages/terra-demographics-banner/tests/wdio/demographics-banner-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 const viewports = Terra.viewports('tiny', 'large');
 
 describe('Demographics Banner', () => {

--- a/packages/terra-dialog/tests/wdio/dialog-spec.js
+++ b/packages/terra-dialog/tests/wdio/dialog-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('tiny', 'large');
 
 describe('Dialog', () => {

--- a/packages/terra-divider/tests/wdio/divider-spec.js
+++ b/packages/terra-divider/tests/wdio/divider-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('medium');
 
 describe('Divider', () => {

--- a/packages/terra-doc-template/tests/wdio/doc-template-spec.js
+++ b/packages/terra-doc-template/tests/wdio/doc-template-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 describe('DocTemplate', () => {
   before(() => browser.setViewportSize(Terra.viewports('huge')[0]));
 

--- a/packages/terra-dynamic-grid/tests/wdio/dynamic-grid-spec.js
+++ b/packages/terra-dynamic-grid/tests/wdio/dynamic-grid-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('tiny', 'huge');
 
 describe('Dynamic Grid', () => {

--- a/packages/terra-embedded-content-consumer/tests/wdio/embedded-content-consumer-spec.js
+++ b/packages/terra-embedded-content-consumer/tests/wdio/embedded-content-consumer-spec.js
@@ -1,4 +1,4 @@
-/* global browser, Terra, before, $ */
+/* global $ */
 const viewports = Terra.viewports('tiny', 'large');
 
 describe('Embedded Content Consumer', () => {

--- a/packages/terra-form-checkbox/tests/wdio/form-checkbox-field-spec.js
+++ b/packages/terra-form-checkbox/tests/wdio/form-checkbox-field-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 const viewports = Terra.viewports('tiny', 'large');
 
 describe('CheckboxField', () => {

--- a/packages/terra-form-checkbox/tests/wdio/form-checkbox-spec.js
+++ b/packages/terra-form-checkbox/tests/wdio/form-checkbox-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 describe('Checkbox', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-form-field/tests/wdio/form-field-spec.js
+++ b/packages/terra-form-field/tests/wdio/form-field-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 describe('Form-field', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-form-fieldset/tests/wdio/fieldset-spec.js
+++ b/packages/terra-form-fieldset/tests/wdio/fieldset-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('tiny', 'medium');
 
 describe('Fieldset', () => {

--- a/packages/terra-form-input/tests/wdio/form-input-spec.js
+++ b/packages/terra-form-input/tests/wdio/form-input-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('tiny', 'large');
 
 describe('Form-Input', () => {

--- a/packages/terra-form-radio/tests/wdio/form-radio-field-spec.js
+++ b/packages/terra-form-radio/tests/wdio/form-radio-field-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 const viewports = Terra.viewports('tiny', 'large');
 
 describe('RadioField', () => {

--- a/packages/terra-form-radio/tests/wdio/form-radio-spec.js
+++ b/packages/terra-form-radio/tests/wdio/form-radio-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 describe('Radio', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-form-select/tests/wdio/_frame-spec.js
+++ b/packages/terra-form-select/tests/wdio/_frame-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('tiny');
 
 describe('Frame', () => {

--- a/packages/terra-form-select/tests/wdio/select-field-spec.js
+++ b/packages/terra-form-select/tests/wdio/select-field-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('tiny');
 
 describe('Select Field', () => {

--- a/packages/terra-form-select/tests/wdio/select-spec.js
+++ b/packages/terra-form-select/tests/wdio/select-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('tiny');
 
 describe('Select', () => {

--- a/packages/terra-form-textarea/tests/wdio/form-textarea-spec.js
+++ b/packages/terra-form-textarea/tests/wdio/form-textarea-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 const viewports = Terra.viewports('tiny', 'large');
 
 const ignoredA11y = {

--- a/packages/terra-grid/tests/wdio/grid-spec.js
+++ b/packages/terra-grid/tests/wdio/grid-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 describe('Grid', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-heading/tests/wdio/heading-spec.js
+++ b/packages/terra-heading/tests/wdio/heading-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('medium');
 
 describe('Heading', () => {

--- a/packages/terra-hyperlink/tests/wdio/hyperlink-spec.js
+++ b/packages/terra-hyperlink/tests/wdio/hyperlink-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 describe('Hyperlink', () => {
   before(() => browser.setViewportSize(Terra.viewports('tiny')[0]));
 

--- a/packages/terra-i18n/tests/wdio/i18n-spec.js
+++ b/packages/terra-i18n/tests/wdio/i18n-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 const i18nSupportedLocales = require('../../src/i18nSupportedLocales');
 
 // Add Portuguese-Guinea-Bissau, Zulu & Zulu-South African locales as test locales (supported by intl)

--- a/packages/terra-icon/tests/wdio/icon-spec.js
+++ b/packages/terra-icon/tests/wdio/icon-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 describe('Icon', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
   describe('Default', () => {

--- a/packages/terra-image/tests/wdio/image-spec.js
+++ b/packages/terra-image/tests/wdio/image-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 describe('Image', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-legacy-theme/tests/wdio/theme-spec.js
+++ b/packages/terra-legacy-theme/tests/wdio/theme-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 describe('Legacy Theme', () => {
   before(() => browser.setViewportSize(Terra.viewports('large')[0]));
 

--- a/packages/terra-list/tests/wdio/list-spec.js
+++ b/packages/terra-list/tests/wdio/list-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 describe('List', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-list/tests/wdio/multi-select-list-spec.js
+++ b/packages/terra-list/tests/wdio/multi-select-list-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 describe('Multi Select List', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-list/tests/wdio/selectable-list-spec.js
+++ b/packages/terra-list/tests/wdio/selectable-list-spec.js
@@ -1,5 +1,3 @@
-/* global before, Terra, browser */
-
 describe('Selectable List', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-list/tests/wdio/single-select-list-spec.js
+++ b/packages/terra-list/tests/wdio/single-select-list-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 describe('Single Select List', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-menu/tests/wdio/menu-item-group-spec.js
+++ b/packages/terra-menu/tests/wdio/menu-item-group-spec.js
@@ -1,5 +1,3 @@
-/* global browser, describe, it, before, expect, Terra */
-
 const ignoredA11y = {
   'aria-required-parent': { enabled: false },
 };

--- a/packages/terra-menu/tests/wdio/menu-item-spec.js
+++ b/packages/terra-menu/tests/wdio/menu-item-spec.js
@@ -1,5 +1,3 @@
-/* global browser, describe, it, before, expect, Terra */
-
 const ignoredA11y = {
   'aria-required-parent': { enabled: false },
 };

--- a/packages/terra-menu/tests/wdio/menu-spec.js
+++ b/packages/terra-menu/tests/wdio/menu-spec.js
@@ -1,5 +1,3 @@
-/* global browser, describe, it, before, expect, Terra */
-
 const ignoredA11y = {
   // Issue logged here: https://github.com/cerner/terra-core/issues/1585
   'button-name': { enabled: false },

--- a/packages/terra-overlay/tests/wdio/loading-overlay-spec.js
+++ b/packages/terra-overlay/tests/wdio/loading-overlay-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 describe('Loading Overlay', () => {
   describe('Loading Overlay Default', () => {
     before(() => browser.url('/#/raw/tests/terra-overlay/overlay/loading-overlay/default-loading-overlay'));

--- a/packages/terra-overlay/tests/wdio/overlay-container-spec.js
+++ b/packages/terra-overlay/tests/wdio/overlay-container-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 describe('Overlay Container Default', () => {
   before(() => browser.url('/#/raw/tests/terra-overlay/overlay/overlay-container/default-overlay-container'));
 

--- a/packages/terra-overlay/tests/wdio/overlay-spec.js
+++ b/packages/terra-overlay/tests/wdio/overlay-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 describe('Overlay', () => {
   describe('Default', () => {
     before(() => browser.url('/#/raw/tests/terra-overlay/overlay/overlay/default-overlay'));

--- a/packages/terra-paginator/tests/wdio/paginator-spec.js
+++ b/packages/terra-paginator/tests/wdio/paginator-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 const viewports = Terra.viewports('tiny', 'medium', 'large');
 
 describe('Paginator', () => {

--- a/packages/terra-profile-image/tests/wdio/profile-image-spec.js
+++ b/packages/terra-profile-image/tests/wdio/profile-image-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 describe('Profile Image', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-progress-bar/tests/wdio/progress-bar-spec.js
+++ b/packages/terra-progress-bar/tests/wdio/progress-bar-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 describe('Progress Bar', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-props-table/tests/wdio/props-table-spec.js
+++ b/packages/terra-props-table/tests/wdio/props-table-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 const viewports = Terra.viewports('medium', 'large');
 
 describe('Props Table', () => {

--- a/packages/terra-responsive-element/tests/wdio/responsive-element-spec.js
+++ b/packages/terra-responsive-element/tests/wdio/responsive-element-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('tiny', 'small', 'medium', 'large', 'huge');
 
 describe('Responsive Element', () => {

--- a/packages/terra-scroll/tests/wdio/scroll-spec.js
+++ b/packages/terra-scroll/tests/wdio/scroll-spec.js
@@ -1,5 +1,3 @@
-/* global browser, before, Terra */
-
 describe('Scroll', () => {
   before(() => {
     browser.url('/#/raw/tests/terra-scroll/scroll/default');

--- a/packages/terra-search-field/tests/wdio/search-field-spec.js
+++ b/packages/terra-search-field/tests/wdio/search-field-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 describe('Search Field', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-section-header/tests/wdio/section-header-spec.js
+++ b/packages/terra-section-header/tests/wdio/section-header-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 describe('SectionHeader', () => {
   describe('Default Section Header', () => {
     before(() => browser.url('/#/raw/tests/terra-section-header/section-header/default-section-header'));

--- a/packages/terra-signature/tests/wdio/signature-spec.js
+++ b/packages/terra-signature/tests/wdio/signature-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 const viewports = Terra.viewports('medium');
 
 describe('Signature', () => {

--- a/packages/terra-slide-group/tests/wdio/slide-group-spec.js
+++ b/packages/terra-slide-group/tests/wdio/slide-group-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 describe('Slide Group', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-spacer/tests/wdio/spacer-spec.js
+++ b/packages/terra-spacer/tests/wdio/spacer-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 describe('Spacer', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-status-view/tests/wdio/status-view-spec.js
+++ b/packages/terra-status-view/tests/wdio/status-view-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 const viewports = Terra.viewports('tiny', 'medium');
 
 describe('StatusView', () => {

--- a/packages/terra-status/tests/wdio/status-spec.js
+++ b/packages/terra-status/tests/wdio/status-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 describe('Status', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-table/tests/wdio/multi-select-table-spec.js
+++ b/packages/terra-table/tests/wdio/multi-select-table-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 const viewports = Terra.viewports('medium');
 
 describe('Multi-Select Table', () => {

--- a/packages/terra-table/tests/wdio/selectable-table-rows-spec.js
+++ b/packages/terra-table/tests/wdio/selectable-table-rows-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 const viewports = Terra.viewports('medium');
 
 describe('Selectable Table Rows', () => {

--- a/packages/terra-table/tests/wdio/single-select-table-spec.js
+++ b/packages/terra-table/tests/wdio/single-select-table-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 const viewports = Terra.viewports('medium');
 
 describe('Single-Select Table', () => {

--- a/packages/terra-table/tests/wdio/table-spec.js
+++ b/packages/terra-table/tests/wdio/table-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 const viewports = Terra.viewports('medium');
 
 describe('Table', () => {

--- a/packages/terra-tabs/tests/wdio/tab-pane-spec.js
+++ b/packages/terra-tabs/tests/wdio/tab-pane-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 describe('TabPane', () => {
   before(() => browser.setViewportSize(Terra.viewports('tiny')[0]));
 

--- a/packages/terra-tabs/tests/wdio/tabs-spec.js
+++ b/packages/terra-tabs/tests/wdio/tabs-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 const viewports = Terra.viewports('tiny', 'small', 'medium', 'large', 'huge', 'enormous');
 
 const ignoredA11y = {

--- a/packages/terra-tag/tests/wdio/tag-spec.js
+++ b/packages/terra-tag/tests/wdio/tag-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('tiny', 'medium', 'large');
 
 describe('Tag', () => {

--- a/packages/terra-text/tests/wdio/text-spec.js
+++ b/packages/terra-text/tests/wdio/text-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('medium');
 
 describe('Text', () => {

--- a/packages/terra-time-input/tests/wdio/time-input-spec.js
+++ b/packages/terra-time-input/tests/wdio/time-input-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 const viewports = Terra.viewports('medium');
 
 describe('Time Input', () => {

--- a/packages/terra-time-input/tests/wdio/time-input-twelve-hour-mobile-spec.js
+++ b/packages/terra-time-input/tests/wdio/time-input-twelve-hour-mobile-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 const viewports = Terra.viewports('medium');
 
 // Color contrast will be resolved in https://github.com/cerner/terra-core/issues/1670

--- a/packages/terra-time-input/tests/wdio/time-input-twelve-hour-spec.js
+++ b/packages/terra-time-input/tests/wdio/time-input-twelve-hour-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before */
 const viewports = Terra.viewports('medium');
 
 describe('Time Input Twelve Hour', () => {

--- a/packages/terra-toggle-button/tests/wdio/toggle-button-spec.js
+++ b/packages/terra-toggle-button/tests/wdio/toggle-button-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 describe('Toggle Button', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 

--- a/packages/terra-toggle-section-header/tests/wdio/toggle-section-header-spec.js
+++ b/packages/terra-toggle-section-header/tests/wdio/toggle-section-header-spec.js
@@ -1,5 +1,3 @@
-/* global before, browser, Terra */
-
 describe('ToggleSectionHeader', () => {
   describe('Default', () => {
     beforeEach(() => browser.url('/#/raw/tests/terra-toggle-section-header/toggle-section-header/default-toggle-section-header'));

--- a/packages/terra-toggle/tests/wdio/toggle-spec.js
+++ b/packages/terra-toggle/tests/wdio/toggle-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 describe('Toggle', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
 


### PR DESCRIPTION
### Summary
eslint-config module defines before, browser, and Terra as globals for test files recursively under a "wdio" directory
