### PR TITLE
Issue 1935: Use absolute positioning in modals.

### DIFF
--- a/packages/terra-abstract-modal/CHANGELOG.md
+++ b/packages/terra-abstract-modal/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
 ------------------
 ### Changed
 * Minor dependency version bump
+* Use absolute position for modal and modal overlay for iOS stability
 
 1.17.1 - (September 6, 2018)
 ------------------

--- a/packages/terra-abstract-modal/src/AbstractModal.module.scss
+++ b/packages/terra-abstract-modal/src/AbstractModal.module.scss
@@ -6,7 +6,7 @@
     max-width: calc(100% - 2 * var(--terra-abstract-modal-horizontal-inset, 10px));
     outline: none;
     overflow: hidden;
-    position: fixed;
+    position: absolute;
     top: 50%;
     transform: translate(-50%, -50%);
 

--- a/packages/terra-abstract-modal/src/ModalOverlay.module.scss
+++ b/packages/terra-abstract-modal/src/ModalOverlay.module.scss
@@ -6,7 +6,7 @@
     color: var(--terra-abstract-modal-overlay-foreground-color);
     left: 0;
     opacity: var(--terra-abstract-modal-overlay-opacity);
-    position: fixed;
+    position: absolute;
     right: 0;
     top: 0;
 


### PR DESCRIPTION
### Summary
Use absolute positioning instead of fixed for modals.
Fixes #1935 

### Additional Details
There are many open bugs for iOS detailing how editable content inside of fixed elements does not behave as expected when the iOS keyboard is open (see the screenshot on the linked issue for a particularly annoying example). Using absolute positioning for modals resolves some of these issues and will behave the same since the modals are being shown with react-portal and being attached to the document body.  

This would be non-passive for anybody that is explicitly setting the body's position to relative and the body is scrollable.

### Deployment URL
https://terra-core-deployed-pr-1937.herokuapp.com/#/components/terra-abstract-modal/abstract-modal/abstract-modal

Thanks for contributing to Terra. 
@cerner/terra 
