### PR TITLE
[terra-form-select] - Added first-class prop support and documentation for onBlur, onFocus, and onClick

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* First class prop support and documentation for onBlur, onFocus, and onClick 
 
 4.18.0 - (September 25, 2018)
 ------------------

--- a/packages/terra-form-select/src/Select.jsx
+++ b/packages/terra-form-select/src/Select.jsx
@@ -39,7 +39,7 @@ const propTypes = {
    */
   noResultContent: PropTypes.node,
   /**
-   * Callback function triggered when the select loses focus.
+   * Callback function triggered when the select loses focus. function(event)
    */
   onBlur: PropTypes.func,
   /**
@@ -47,7 +47,7 @@ const propTypes = {
    */
   onChange: PropTypes.func,
   /**
-   * Callback function triggered when the select is clicked.
+   * Callback function triggered when the select is clicked. function(event)
    */
   onClick: PropTypes.func,
   /**
@@ -55,7 +55,7 @@ const propTypes = {
    */
   onDeselect: PropTypes.func,
   /**
-   * Callback function triggered when the select receives focus.
+   * Callback function triggered when the select receives focus. function(event)
    */
   onFocus: PropTypes.func,
   /**

--- a/packages/terra-form-select/src/Select.jsx
+++ b/packages/terra-form-select/src/Select.jsx
@@ -39,13 +39,25 @@ const propTypes = {
    */
   noResultContent: PropTypes.node,
   /**
+   * Callback function triggered when the select loses focus.
+   */
+  onBlur: PropTypes.func,
+  /**
    * Callback function triggered when the value changes. function(value)
    */
   onChange: PropTypes.func,
   /**
+   * Callback function triggered when the select is clicked.
+   */
+  onClick: PropTypes.func,
+  /**
    * Callback function triggered when an option is deselected. function(value)
    */
   onDeselect: PropTypes.func,
+  /**
+   * Callback function triggered when the select receives focus.
+   */
+  onFocus: PropTypes.func,
   /**
    * Callback function triggered when the search criteria changes. function(searchValue)
    */

--- a/packages/terra-form-select/tests/jest/Select.test.jsx
+++ b/packages/terra-form-select/tests/jest/Select.test.jsx
@@ -102,4 +102,32 @@ describe('Select', () => {
     const wrapper = shallow(<Select variant="tag" isInvalid />, intlContexts.shallowContext);
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should call onBlur', () => {
+    const mockBlur = jest.fn();
+    const wrapper = shallow(<Select onBlur={mockBlur} />, intlContexts.shallowContext);
+
+    wrapper.simulate('focus');
+    wrapper.simulate('blur');
+
+    expect(mockBlur).toBeCalled();
+  });
+
+  it('should call onFocus', () => {
+    const mockFocus = jest.fn();
+    const wrapper = shallow(<Select onFocus={mockFocus} />, intlContexts.shallowContext);
+
+    wrapper.simulate('focus');
+
+    expect(mockFocus).toBeCalled();
+  });
+
+  it('should call onClick', () => {
+    const mockClick = jest.fn();
+    const wrapper = shallow(<Select onClick={mockClick} />, intlContexts.shallowContext);
+
+    wrapper.simulate('click');
+
+    expect(mockClick).toBeCalled();
+  });
 });


### PR DESCRIPTION
### Summary
Added first-class documentation to onBlur, onFocus, and onClick to alleviate consumer concerns regarding potential non-passive changes to these callbacks.

Resolves #1947 

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
