### PR TITLE
Fix terra-image docs usage example

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -72,6 +72,7 @@ Cerner Corporation
 - Alexander Brisimitzakis [@AlexBrizi]
 - Kyle Roush [@kyleroush]
 - Sharynne Azhar [@sharynneazhar]
+- Eric Wilson [@eawww]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -146,3 +147,4 @@ Cerner Corporation
 [@AlexBrizi]: https://github.com/AlexBrizi
 [@kyleroush]: https://github.com/kyleroush
 [@sharynneazhar]: https://github.com/sharynneazhar
+[@eawww]: https://github.com/eawww

--- a/packages/terra-image/CHANGELOG.md
+++ b/packages/terra-image/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Correct example in docs/README.md
 
 2.24.0 - (October 8, 2018)
 ------------------

--- a/packages/terra-image/docs/README.md
+++ b/packages/terra-image/docs/README.md
@@ -18,11 +18,13 @@ import placeholderSrc from './mock/valid/path/placeholder.png';
 import invalidImageSrc from './mock/invalid/path/image.png';
 import validImageSrc from './mock/valid/path/image.png';
 
-// Providing an invalid or unresolvable path with cause the placeholder image to be displayed.
-<Image src={invalidImageSrc} placeholder={placeholderSrc} alt="placeholder image" />
+const placeholderNode = (<img src={placeholderSrc} alt="placeholder image" />);
+
+// Providing an invalid or unresolvable path with cause the placeholder node to be displayed.
+<Image src={invalidImageSrc} placeholder={placeholderNode} alt="invalid image" />
 
 // Providing a valid path will cause the src image to be displayed.
-<Image src={validImageSrc} placeholder={placeholderSrc} alt="placeholder image" />
+<Image src={validImageSrc} placeholder={placeholderNode} alt="valid image" />
 ```
 
 ## Component Features


### PR DESCRIPTION
### Summary
* Corrections to the following errors in `terra-image` documentation example. 
  * Uses an image source string for the `placeholder` prop where an `element` type is expected.
  * Uses `"placeholder image"` as `alt` prop where a alt text of the primary image is expected.

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
