### PR TITLE
Fix Image flicker #1748

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -72,6 +72,7 @@ Cerner Corporation
 - Alexander Brisimitzakis [@AlexBrizi]
 - Kyle Roush [@kyleroush]
 - Sharynne Azhar [@sharynneazhar]
+- Eric Wilson [@eawww]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -146,3 +147,4 @@ Cerner Corporation
 [@AlexBrizi]: https://github.com/AlexBrizi
 [@kyleroush]: https://github.com/kyleroush
 [@sharynneazhar]: https://github.com/sharynneazhar
+[@eawww]: https://github.com/eawww

--- a/packages/terra-image/CHANGELOG.md
+++ b/packages/terra-image/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Fix flickering on new props #1748.
 
 2.24.0 - (October 8, 2018)
 ------------------

--- a/packages/terra-image/src/Image.jsx
+++ b/packages/terra-image/src/Image.jsx
@@ -72,7 +72,7 @@ class Image extends React.Component {
 
   componentWillReceiveProps(newProps) {
     // If a new image is being loaded, reset the state to loading
-    if (newProps.src !== this.props.src || newProps.placeholder !== this.props.placeholder) {
+    if (newProps.src !== this.props.src) {
       this.setState({ isLoading: true, isError: false });
     }
   }


### PR DESCRIPTION
### Summary
* Prevent `terra-image` from flickering due to entering `isLoading` state on any new props.
  * Fixes #1748 

### Additional Details
**Rationale:**
Image was flickering to placeholder element each time new props were given. This was due to the inequality condition between two objects always evaluating to true, specifically on the `placeholder` node prop, which caused the component to render with `isLoading` set to true on any change in props. 
```js
componentWillReceiveProps(newProps) {
    // If a new image is being loaded, reset the state to loading
    if (newProps.src !== this.props.src || newProps.placeholder !== this.props.placeholder) {
      this.setState({ isLoading: true, isError: false });
    }
  }
```

I just removed that condition because, not only was it the source of this issue, but it didn't seem to be necessary. Entering the loading state when a new `src` prop is passed makes sense, but, when a new placeholder is passed, there would be no reason to fall back to the placeholder while the new placeholder loads. This would only cause a properly loaded primary image to flicker even if the check were working as intended.

This should fix 'er right up! Thanks for making contributing to this project a pleasant experience! 😁

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
