### PR TITLE
Expose zIndexes Opts to LoadingOverlay

### DIFF
--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* LoadingOverlay Opts includes zIndexes
 
 2.32.0 - (October 30, 2018)
 ------------------

--- a/packages/terra-overlay/src/LoadingOverlay.jsx
+++ b/packages/terra-overlay/src/LoadingOverlay.jsx
@@ -75,11 +75,9 @@ const LoadingOverlay = ({
   );
 };
 
-const Opts = { BackgroundStyles };
-
 LoadingOverlay.propTypes = propTypes;
 LoadingOverlay.defaultProps = defaultProps;
 LoadingOverlay.contextTypes = contextTypes;
-LoadingOverlay.Opts = Opts;
+LoadingOverlay.Opts = Overlay.Opts;
 
 export default LoadingOverlay;


### PR DESCRIPTION
### Summary
I'm trying to do
```jsx
<LoadingOverlay
   isAnimated
   isOpen
   zIndex={LoadingOverlay.Opts.zIndexes[1]}
/>
```
but `LoadingOverlay` doesn't expose the `zIndexes` opt like `Overlay` does, requiring me to import both and do this instead:
```jsx
<LoadingOverlay
   isAnimated
   isOpen
   zIndex={Overlay.Opts.zIndexes[1]}
/>
```

### Additional Details
N/A

Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
