### PR TITLE
Update terra-breakpoints README.md

### DIFF
--- a/packages/terra-breakpoints/CHANGELOG.md
+++ b/packages/terra-breakpoints/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Fixed
 * Lint Errors
 
+### Changed
+* Updated README to include a consumer-focused import for the SASS media queries
+
 1.0.0 - (November 19, 2018)
 ------------------
 * Initial stable release

--- a/packages/terra-breakpoints/docs/README.md
+++ b/packages/terra-breakpoints/docs/README.md
@@ -116,7 +116,7 @@ const ActiveBreakpointProviderExample = () => (
 `terra-breakpoints` includes `_media-queries.scss`, which contains a set of Sass mixins that define media queries for the supported breakpoints.
 
 ```scss
-@import 'terra-breakpoints/media-queries';
+@import '~terra-breakpoints/lib/media-queries';
 
 .example {
   color: blue;


### PR DESCRIPTION
### Summary
The import for the terra-breakpoints media queries was specific to the monorepo. Now it's not.