### PR TITLE
Note Added to Pattern Prop on Input Component Regarding Types

### DIFF
--- a/packages/terra-form-input/CHANGELOG.md
+++ b/packages/terra-form-input/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
 ### Added
 * Pattern prop added to Input component 
 * maxWidth prop added to pass through to terra-form-field
+* Note added regarding input types to pattern prop
 
 1.31.1 - (November 20, 2018)
 ------------------

--- a/packages/terra-form-input/src/Input.jsx
+++ b/packages/terra-form-input/src/Input.jsx
@@ -42,6 +42,7 @@ const propTypes = {
   name: PropTypes.string,
   /**
    * The regular expression that the input's value is checked against.
+   * NOTE: The pattern attribute works with the following input types: text, date, search, url, tel, email, and password.
    */
   pattern: PropTypes.string,
   /**


### PR DESCRIPTION
### Summary
Adds a note to the terra-form-input pattern prop specifying the types of input for which the pattern prop is valid.

Closes [#2106](https://github.com/cerner/terra-core/issues/2106)
