### PR TITLE
[do not merge] Update Test Selectors via Eslint Rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     "webpack-merge": "^4.1.2"
   },
   "dependencies": {
-    "eslint-plugin-react": "^7.11.0"
+    "eslint-plugin-react": "7.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.2.2",
     "eslint": "^5.0.0",
-    "eslint-config-terra": "^2.0.0",
+    "eslint-config-terra": "git://github.com/cerner/eslint-config-terra.git#add-terra-eslint-pluign",
     "gh-pages": "^1.1.0",
     "glob": "^7.1.1",
     "identity-obj-proxy": "^3.0.0",
@@ -93,5 +93,8 @@
     "terra-dev-site": "^2.0.0",
     "terra-toolkit": "^4.5.0",
     "webpack-merge": "^4.1.2"
+  },
+  "dependencies": {
+    "eslint-plugin-react": "^7.11.0"
   }
 }

--- a/packages/terra-abstract-modal/tests/wdio/abstract-modal-spec.js
+++ b/packages/terra-abstract-modal/tests/wdio/abstract-modal-spec.js
@@ -50,7 +50,7 @@ describe('Abstract Modal', () => {
 
     it('focuses on the first button', () => {
       browser.keys(['Tab']);
-      browser.hasFocus('#focus-button');
+      browser.hasFocus('[id=focus-button]');
     });
 
     Terra.should.matchScreenshot({ selector: 'div[role="dialog"]' });
@@ -125,7 +125,7 @@ describe('Abstract Modal', () => {
     Terra.should.matchScreenshot({ selector: 'div[role="dialog"]' });
 
     it('has the appropriate focus', () => {
-      browser.hasFocus('#focus-element');
+      browser.hasFocus('[id=focus-element]');
     });
   });
 
@@ -139,7 +139,7 @@ describe('Abstract Modal', () => {
     Terra.should.matchScreenshot({ selector: 'div[role="dialog"]' });
 
     it('has the appropriate focus', () => {
-      browser.hasFocus('#focus-element');
+      browser.hasFocus('[id=focus-element]');
     });
   });
 

--- a/packages/terra-alert/tests/wdio/alert-spec.js
+++ b/packages/terra-alert/tests/wdio/alert-spec.js
@@ -73,9 +73,9 @@ describe('Alert', () => {
       Terra.should.beAccessible();
 
       it('should be register actions', () => {
-        expect(browser.getText('#actionButtonClickCount')).to.equal('0');
-        browser.click('#actionAlert button');
-        expect(browser.getText('#actionButtonClickCount')).to.equal('1');
+        expect(browser.getText('[id=actionButtonClickCount]')).to.equal('0');
+        browser.click('[id=actionAlert] button');
+        expect(browser.getText('[id=actionButtonClickCount]')).to.equal('1');
       });
     });
 
@@ -90,8 +90,8 @@ describe('Alert', () => {
       Terra.should.beAccessible();
 
       it('should dismiss', () => {
-        browser.click('#dismissibleAlert button');
-        expect(browser.getText('#dismissed')).to.equal('Alert was dismissed');
+        browser.click('[id=dismissibleAlert] button');
+        expect(browser.getText('[id=dismissed]')).to.equal('Alert was dismissed');
       });
     });
   });

--- a/packages/terra-avatar/tests/wdio/avatar-common-spec.js
+++ b/packages/terra-avatar/tests/wdio/avatar-common-spec.js
@@ -2,15 +2,15 @@ describe('Avatar', () => {
   describe('Icon Avatar', () => {
     before(() => browser.url('/#/raw/tests/terra-avatar/avatar/avatar/user-avatar'));
 
-    Terra.should.beAccessible({ selector: '#user-avatar' });
-    Terra.should.matchScreenshot({ selector: '#user-avatar' });
+    Terra.should.beAccessible({ selector: '[id=user-avatar]' });
+    Terra.should.matchScreenshot({ selector: '[id=user-avatar]' });
   });
 
   describe('Image Avatar', () => {
     before(() => browser.url('/#/raw/tests/terra-avatar/avatar/avatar/image-avatar'));
 
-    Terra.should.beAccessible({ selector: '#image-avatar' });
-    Terra.should.matchScreenshot({ selector: '#image-avatar' });
+    Terra.should.beAccessible({ selector: '[id=image-avatar]' });
+    Terra.should.matchScreenshot({ selector: '[id=image-avatar]' });
   });
 
   describe('Image Avatar Spacing', () => {
@@ -21,36 +21,36 @@ describe('Avatar', () => {
   describe('One Initial Avatar', () => {
     before(() => browser.url('/#/raw/tests/terra-avatar/avatar/avatar/one-initial-avatar'));
 
-    Terra.should.beAccessible({ selector: '#one-initial-avatar' });
-    Terra.should.matchScreenshot({ selector: '#one-initial-avatar' });
+    Terra.should.beAccessible({ selector: '[id=one-initial-avatar]' });
+    Terra.should.matchScreenshot({ selector: '[id=one-initial-avatar]' });
   });
 
   describe('Two Initials Avatar', () => {
     before(() => browser.url('/#/raw/tests/terra-avatar/avatar/avatar/two-initials-avatar'));
 
-    Terra.should.beAccessible({ selector: '#two-initials-avatar' });
-    Terra.should.matchScreenshot({ selector: '#two-initials-avatar' });
+    Terra.should.beAccessible({ selector: '[id=two-initials-avatar]' });
+    Terra.should.matchScreenshot({ selector: '[id=two-initials-avatar]' });
   });
 
   describe('Deceased Avatar', () => {
     before(() => browser.url('/#/raw/tests/terra-avatar/avatar/avatar/is-deceased-avatar'));
 
-    Terra.should.beAccessible({ selector: '#is-deceased-avatar' });
-    Terra.should.matchScreenshot({ selector: '#is-deceased-avatar' });
+    Terra.should.beAccessible({ selector: '[id=is-deceased-avatar]' });
+    Terra.should.matchScreenshot({ selector: '[id=is-deceased-avatar]' });
   });
 
   describe('Deceased Initials Avatar', () => {
     before(() => browser.url('/#/raw/tests/terra-avatar/avatar/avatar/is-deceased-initials-avatar'));
 
-    Terra.should.beAccessible({ selector: '#is-deceased-initials-avatar' });
-    Terra.should.matchScreenshot({ selector: '#is-deceased-initials-avatar' });
+    Terra.should.beAccessible({ selector: '[id=is-deceased-initials-avatar]' });
+    Terra.should.matchScreenshot({ selector: '[id=is-deceased-initials-avatar]' });
   });
 
   describe('Deceased Image Avatar', () => {
     before(() => browser.url('/#/raw/tests/terra-avatar/avatar/avatar/is-deceased-image-avatar'));
 
-    Terra.should.beAccessible({ selector: '#is-deceased-image-avatar' });
-    Terra.should.matchScreenshot({ selector: '#is-deceased-image-avatar' });
+    Terra.should.beAccessible({ selector: '[id=is-deceased-image-avatar]' });
+    Terra.should.matchScreenshot({ selector: '[id=is-deceased-image-avatar]' });
   });
 });
 
@@ -58,15 +58,15 @@ describe('Facility', () => {
   describe('Icon Facility', () => {
     before(() => browser.url('/#/raw/tests/terra-avatar/avatar/facility/default-facility'));
 
-    Terra.should.beAccessible({ selector: '#default-facility' });
-    Terra.should.matchScreenshot({ selector: '#default-facility' });
+    Terra.should.beAccessible({ selector: '[id=default-facility]' });
+    Terra.should.matchScreenshot({ selector: '[id=default-facility]' });
   });
 
   describe('Image Facility', () => {
     before(() => browser.url('/#/raw/tests/terra-avatar/avatar/facility/image-facility'));
 
-    Terra.should.beAccessible({ selector: '#image-facility' });
-    Terra.should.matchScreenshot({ selector: '#image-facility' });
+    Terra.should.beAccessible({ selector: '[id=image-facility]' });
+    Terra.should.matchScreenshot({ selector: '[id=image-facility]' });
   });
 });
 
@@ -74,7 +74,7 @@ describe('Shared User', () => {
   describe('Icon Shared User', () => {
     before(() => browser.url('/#/raw/tests/terra-avatar/avatar/shared-user/shared-user'));
 
-    Terra.should.beAccessible({ selector: '#shared-user' });
-    Terra.should.matchScreenshot({ selector: '#shared-user' });
+    Terra.should.beAccessible({ selector: '[id=shared-user]' });
+    Terra.should.matchScreenshot({ selector: '[id=shared-user]' });
   });
 });

--- a/packages/terra-avatar/tests/wdio/theme/avatar-common-theme-spec.js
+++ b/packages/terra-avatar/tests/wdio/theme/avatar-common-theme-spec.js
@@ -3,7 +3,7 @@ describe('Avatar', () => {
     before(() => browser.url('/#/raw/tests/terra-avatar/avatar/avatar/user-avatar'));
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#user-avatar',
+      selector: '[id=user-avatar]',
       properties: {
         '--terra-avatar-border': '0.07143rem solid rgb(0, 0, 255)',
         '--terra-avatar-height': '5em',
@@ -20,7 +20,7 @@ describe('Avatar', () => {
 
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#two-initials-avatar',
+      selector: '[id=two-initials-avatar]',
       properties: {
         '--terra-avatar-background-color': 'rgba(0, 0, 255, 0.5)',
         '--terra-avatar-border': '0.07143rem solid rgb(0, 0, 255)',
@@ -40,7 +40,7 @@ describe('Avatar', () => {
 
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#image-avatar',
+      selector: '[id=image-avatar]',
       properties: {
         '--terra-avatar-background-color': 'rgba(0, 0, 255, 0.5)',
         '--terra-avatar-border': '0.07143rem solid rgb(0, 0, 255)',
@@ -56,7 +56,7 @@ describe('Avatar', () => {
 
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#is-deceased-avatar',
+      selector: '[id=is-deceased-avatar]',
       properties: {
         '--terra-avatar-is-deceased-background-color': 'black',
         '--terra-avatar-image-is-deceased-opacity': '0.2',
@@ -70,7 +70,7 @@ describe('Avatar', () => {
 
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#is-deceased-initials-avatar',
+      selector: '[id=is-deceased-initials-avatar]',
       properties: {
         '--terra-avatar-is-deceased-background-color': 'black',
         '--terra-avatar-is-deceased-after-box-shadow': 'inset 0 0 0 5px black',
@@ -83,7 +83,7 @@ describe('Avatar', () => {
 
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#is-deceased-image-avatar',
+      selector: '[id=is-deceased-image-avatar]',
       properties: {
         '--terra-avatar-is-deceased-background-color': 'black',
         '--terra-avatar-image-is-deceased-opacity': '0.2',
@@ -98,7 +98,7 @@ describe('Facility', () => {
 
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#default-facility',
+      selector: '[id=default-facility]',
       properties: {
         '--terra-avatar-background-color': 'rgba(0, 0, 255, 0.5)',
         '--terra-avatar-border': '0.07143rem solid rgb(0, 0, 255)',
@@ -116,7 +116,7 @@ describe('Facility', () => {
 
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#image-facility',
+      selector: '[id=image-facility]',
       properties: {
         '--terra-avatar-background-color': 'rgba(0, 0, 255, 0.5)',
         '--terra-avatar-border': '0.07143rem solid rgb(0, 0, 255)',
@@ -135,7 +135,7 @@ describe('Shared User', () => {
 
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#shared-user',
+      selector: '[id=shared-user]',
       properties: {
         '--terra-avatar-background-color': 'rgba(0, 0, 255, 0.5)',
         '--terra-avatar-border': '0.07143rem solid rgb(0, 0, 255)',

--- a/packages/terra-badge/tests/wdio/badge-spec.js
+++ b/packages/terra-badge/tests/wdio/badge-spec.js
@@ -5,10 +5,10 @@ describe('Badge', () => {
     before(() => browser.url('/#/raw/tests/terra-badge/badge/badge-default'));
 
     Terra.should.beAccessible({ viewports });
-    Terra.should.matchScreenshot({ viewports, selector: '#default-badge' });
+    Terra.should.matchScreenshot({ viewports, selector: '[id=default-badge]' });
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#default-badge',
+      selector: '[id=default-badge]',
       properties: {
         '--terra-badge-border-radius': '20px',
         '--terra-badge-display': 'block',

--- a/packages/terra-base/tests/wdio/base-spec.js
+++ b/packages/terra-base/tests/wdio/base-spec.js
@@ -6,12 +6,12 @@ describe('Base', () => {
   describe('Switching Locales', () => {
     before(() => browser.url('/#/raw/tests/terra-base/base/switch-locale-base'));
     it('Displays a default en locale message', () => {
-      expect(browser.getText('#message')).to.equal('en');
+      expect(browser.getText('[id=message]')).to.equal('en');
     });
 
     it('Displays a customized en-US locale message', () => {
-      browser.click('#switch');
-      expect(browser.getText('#message')).to.equal('en-US');
+      browser.click('[id=switch]');
+      expect(browser.getText('[id=message]')).to.equal('en-US');
     });
   });
 

--- a/packages/terra-base/tests/wdio/theme/base-theme-spec.js
+++ b/packages/terra-base/tests/wdio/theme/base-theme-spec.js
@@ -5,7 +5,7 @@ describe('Base theme', () => {
     before(() => browser.url('/#/raw/tests/terra-base/base/default-base'));
 
     Terra.should.themeEachCustomProperty(
-      '#root',
+      '[id=root]',
       {
         '--terra-base-background-color': 'red',
       },
@@ -24,13 +24,13 @@ describe('Base theme', () => {
         '--terra-base-background-position': 'top 70px left 45px',
         '--terra-base-background-attachment': 'fixed',
       },
-      selector: '#root',
+      selector: '[id=root]',
     });
 
     it('should scroll to the bottom', () => {
-      browser.moveToObject('#bottom');
+      browser.moveToObject('[id=bottom]');
     });
 
-    Terra.should.matchScreenshot('scrolled down', { selector: '#bottom-section' });
+    Terra.should.matchScreenshot('scrolled down', { selector: '[id=bottom-section]' });
   });
 });

--- a/packages/terra-button-group/tests/wdio/button-group-spec.js
+++ b/packages/terra-button-group/tests/wdio/button-group-spec.js
@@ -4,7 +4,7 @@ describe('Button Group', () => {
   describe('Text Button', () => {
     beforeEach(() => browser.url('/#/raw/tests/terra-button-group/button-group/button-group-text'));
     Terra.should.beAccessible();
-    Terra.should.matchScreenshot({ selector: '#button-group-text' });
+    Terra.should.matchScreenshot({ selector: '[id=button-group-text]' });
   });
 
   describe('Button Group Wrapping', () => {
@@ -22,25 +22,25 @@ describe('Button Group', () => {
   describe('Long Text Button', () => {
     before(() => browser.url('/#/raw/tests/terra-button-group/button-group/button-group-long-text'));
     Terra.should.beAccessible();
-    Terra.should.matchScreenshot({ selector: '#button-group-text' });
+    Terra.should.matchScreenshot({ selector: '[id=button-group-text]' });
   });
 
   describe('Icon Button', () => {
     before(() => browser.url('/#/raw/tests/terra-button-group/button-group/button-group-icon'));
     Terra.should.beAccessible();
-    Terra.should.matchScreenshot({ selector: '#button-group-icon' });
+    Terra.should.matchScreenshot({ selector: '[id=button-group-icon]' });
   });
 
   describe('Not Selectable', () => {
     before(() => browser.url('/#/raw/tests/terra-button-group/button-group/button-group-not-selectable'));
     Terra.should.beAccessible();
-    Terra.should.matchScreenshot({ selector: '#button-group-not-selectable' });
+    Terra.should.matchScreenshot({ selector: '[id=button-group-not-selectable]' });
   });
 
   describe('Disabled Buttons', () => {
     before(() => browser.url('/#/raw/tests/terra-button-group/button-group/button-group-disabled-buttons'));
     Terra.should.beAccessible();
-    Terra.should.matchScreenshot({ selector: '#button-group-not-selectable' });
+    Terra.should.matchScreenshot({ selector: '[id=button-group-not-selectable]' });
   });
 
   describe('Single-Select', () => {
@@ -48,7 +48,7 @@ describe('Button Group', () => {
     it('should select the first button', () => {
       browser.keys('Tab');
       browser.keys('Space');
-      expect(browser.getText('#selected-key')).to.equal('1');
+      expect(browser.getText('[id=selected-key]')).to.equal('1');
     });
 
     Terra.should.beAccessible();
@@ -57,7 +57,7 @@ describe('Button Group', () => {
     it('should select the second button', () => {
       browser.keys('Tab');
       browser.keys('Space');
-      expect(browser.getText('#selected-key')).to.equal('2');
+      expect(browser.getText('[id=selected-key]')).to.equal('2');
     });
 
     Terra.should.beAccessible();
@@ -67,7 +67,7 @@ describe('Button Group', () => {
       browser.keys('Tab');
       browser.keys('Tab');
       browser.keys('Space');
-      expect(browser.getText('#selected-key')).to.equal('4');
+      expect(browser.getText('[id=selected-key]')).to.equal('4');
     });
 
     Terra.should.beAccessible();
@@ -79,7 +79,7 @@ describe('Button Group', () => {
     it('should select the first button', () => {
       browser.keys('Tab');
       browser.keys('Space');
-      expect(browser.getText('#selected-keys')).to.equal('1');
+      expect(browser.getText('[id=selected-keys]')).to.equal('1');
     });
 
     Terra.should.beAccessible();
@@ -87,7 +87,7 @@ describe('Button Group', () => {
 
     it('should unselect the first button', () => {
       browser.keys('Space');
-      expect(browser.getText('#selected-keys')).to.equal('');
+      expect(browser.getText('[id=selected-keys]')).to.equal('');
     });
 
     Terra.should.beAccessible();
@@ -96,7 +96,7 @@ describe('Button Group', () => {
     it('should select the second button', () => {
       browser.keys('Tab');
       browser.keys('Space');
-      expect(browser.getText('#selected-keys')).to.equal('2');
+      expect(browser.getText('[id=selected-keys]')).to.equal('2');
     });
 
     Terra.should.beAccessible();
@@ -105,7 +105,7 @@ describe('Button Group', () => {
     it('should select the third button', () => {
       browser.keys('Tab');
       browser.keys('Space');
-      expect(browser.getText('#selected-keys')).to.equal('2, 3');
+      expect(browser.getText('[id=selected-keys]')).to.equal('2, 3');
     });
 
     Terra.should.beAccessible();
@@ -113,7 +113,7 @@ describe('Button Group', () => {
 
     it('should unselect the third button', () => {
       browser.keys('Space');
-      expect(browser.getText('#selected-keys')).to.equal('2');
+      expect(browser.getText('[id=selected-keys]')).to.equal('2');
     });
 
     Terra.should.beAccessible();

--- a/packages/terra-button/tests/wdio/button-spec.js
+++ b/packages/terra-button/tests/wdio/button-spec.js
@@ -4,12 +4,12 @@ describe('Button', () => {
   describe('Neutral', () => {
     before(() => browser.url('/#/raw/tests/terra-button/button/variants/neutral-button'));
 
-    Terra.should.beAccessible({ context: '#neutral' });
-    Terra.should.matchScreenshot({ selector: '#neutral' });
+    Terra.should.beAccessible({ context: '[id=neutral]' });
+    Terra.should.matchScreenshot({ selector: '[id=neutral]' });
 
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#neutral',
+      selector: '[id=neutral]',
       properties: {
         // Button Vars that apply to all buttons
         '--terra-button-border-radius': '50px',
@@ -30,15 +30,15 @@ describe('Button', () => {
     describe('Neutral-Hovered', () => {
       before(() => {
         browser.url('/#/raw/tests/terra-button/button/variants/neutral-button');
-        browser.moveToObject('#neutralButton');
+        browser.moveToObject('[id=neutralButton]');
       });
 
-      Terra.should.beAccessible({ context: '#neutral' });
-      Terra.should.matchScreenshot({ selector: '#neutral' });
+      Terra.should.beAccessible({ context: '[id=neutral]' });
+      Terra.should.matchScreenshot({ selector: '[id=neutral]' });
 
       Terra.should.themeCombinationOfCustomProperties({
         testName: 'themed',
-        selector: '#neutral',
+        selector: '[id=neutral]',
         properties: {
           '--terra-button-hover-background-color-neutral': 'green',
           '--terra-button-hover-color-neutral': 'purple',
@@ -52,12 +52,12 @@ describe('Button', () => {
         browser.keys('Tab');
       });
 
-      Terra.should.beAccessible({ context: '#neutral' });
-      Terra.should.matchScreenshot({ selector: '#neutral' });
+      Terra.should.beAccessible({ context: '[id=neutral]' });
+      Terra.should.matchScreenshot({ selector: '[id=neutral]' });
 
       Terra.should.themeCombinationOfCustomProperties({
         testName: 'themed',
-        selector: '#neutral',
+        selector: '[id=neutral]',
         properties: {
           '--terra-button-focus-background-color-neutral': 'purple',
           '--terra-button-focus-border-color-neutral': 'red',
@@ -69,12 +69,12 @@ describe('Button', () => {
     describe('Neutral-Active', () => {
       before(() => browser.url('/#/raw/tests/terra-button/button/active-variant-buttons'));
 
-      Terra.should.matchScreenshot('active', { selector: '#neutralActive' });
-      Terra.should.matchScreenshot('active and focused', { selector: '#neutralActiveFocusSpan' });
+      Terra.should.matchScreenshot('active', { selector: '[id=neutralActive]' });
+      Terra.should.matchScreenshot('active and focused', { selector: '[id=neutralActiveFocusSpan]' });
 
       Terra.should.themeCombinationOfCustomProperties({
         testName: 'themed',
-        selector: '#neutral',
+        selector: '[id=neutral]',
         properties: {
           '--terra-button-active-and-focus-background-color-neutral': 'purple',
           '--terra-button-active-and-focus-border-color-neutral': 'purple',
@@ -89,114 +89,114 @@ describe('Button', () => {
   describe('Emphasis', () => {
     before(() => browser.url('/#/raw/tests/terra-button/button/variants/emphasis-button'));
 
-    Terra.should.beAccessible({ context: '#emphasis' });
-    Terra.should.matchScreenshot({ selector: '#emphasis' });
+    Terra.should.beAccessible({ context: '[id=emphasis]' });
+    Terra.should.matchScreenshot({ selector: '[id=emphasis]' });
 
     describe('Emphasis-Hovered', () => {
-      before(() => browser.moveToObject('#emphasisButton'));
+      before(() => browser.moveToObject('[id=emphasisButton]'));
 
-      Terra.should.beAccessible({ context: '#emphasis' });
-      Terra.should.matchScreenshot({ selector: '#emphasis' });
+      Terra.should.beAccessible({ context: '[id=emphasis]' });
+      Terra.should.matchScreenshot({ selector: '[id=emphasis]' });
     });
 
     describe('Emphasis-Keyboard Focus', () => {
       before(() => browser.keys('Tab'));
 
-      Terra.should.beAccessible({ context: '#emphasis' });
-      Terra.should.matchScreenshot({ selector: '#emphasis' });
+      Terra.should.beAccessible({ context: '[id=emphasis]' });
+      Terra.should.matchScreenshot({ selector: '[id=emphasis]' });
     });
 
     describe('Emphasis-Active', () => {
       before(() => browser.url('/#/raw/tests/terra-button/button/active-variant-buttons'));
 
-      Terra.should.beAccessible({ context: '#emphasisActive' });
-      Terra.should.matchScreenshot('active', { selector: '#emphasisActive' });
+      Terra.should.beAccessible({ context: '[id=emphasisActive]' });
+      Terra.should.matchScreenshot('active', { selector: '[id=emphasisActive]' });
 
-      Terra.should.beAccessible({ context: '#emphasisActiveFocus' });
-      Terra.should.matchScreenshot('active and focused', { selector: '#emphasisActiveFocusSpan' });
+      Terra.should.beAccessible({ context: '[id=emphasisActiveFocus]' });
+      Terra.should.matchScreenshot('active and focused', { selector: '[id=emphasisActiveFocusSpan]' });
     });
   });
 
   describe('De-emphasis', () => {
     before(() => browser.url('/#/raw/tests/terra-button/button/variants/deemphasis-button'));
 
-    Terra.should.beAccessible({ context: '#de-emphasis' });
-    Terra.should.matchScreenshot({ selector: '#de-emphasis' });
+    Terra.should.beAccessible({ context: '[id=de-emphasis]' });
+    Terra.should.matchScreenshot({ selector: '[id=de-emphasis]' });
 
     describe('De-emphasis-Hovered', () => {
-      before(() => browser.moveToObject('#de-emphasisButton'));
+      before(() => browser.moveToObject('[id=de-emphasisButton]'));
 
-      Terra.should.beAccessible({ context: '#de-emphasis' });
-      Terra.should.matchScreenshot({ selector: '#de-emphasis' });
+      Terra.should.beAccessible({ context: '[id=de-emphasis]' });
+      Terra.should.matchScreenshot({ selector: '[id=de-emphasis]' });
     });
 
     describe('De-emphasis-Keyboard Focus', () => {
       before(() => browser.keys('Tab'));
 
-      Terra.should.beAccessible({ context: '#de-emphasis' });
-      Terra.should.matchScreenshot({ selector: '#de-emphasis' });
+      Terra.should.beAccessible({ context: '[id=de-emphasis]' });
+      Terra.should.matchScreenshot({ selector: '[id=de-emphasis]' });
     });
 
     describe('De-emphasis-Active', () => {
       before(() => browser.url('/#/raw/tests/terra-button/button/active-variant-buttons'));
 
-      Terra.should.matchScreenshot('active', { selector: '#de-emphasisActive' });
-      Terra.should.matchScreenshot('active and focused', { selector: '#de-emphasisActiveFocusSpan' });
+      Terra.should.matchScreenshot('active', { selector: '[id=de-emphasisActive]' });
+      Terra.should.matchScreenshot('active and focused', { selector: '[id=de-emphasisActiveFocusSpan]' });
     });
   });
 
   describe('Action', () => {
     before(() => browser.url('/#/raw/tests/terra-button/button/variants/action-button'));
 
-    Terra.should.beAccessible({ context: '#action' });
-    Terra.should.matchScreenshot({ selector: '#action' });
+    Terra.should.beAccessible({ context: '[id=action]' });
+    Terra.should.matchScreenshot({ selector: '[id=action]' });
 
-    Terra.should.themeEachCustomProperty('#action', {
+    Terra.should.themeEachCustomProperty('[id=action]', {
       '--terra-button-action-border-radius': '26px',
     });
 
     describe('Action-Hovered', () => {
-      before(() => browser.moveToObject('#actionButton'));
+      before(() => browser.moveToObject('[id=actionButton]'));
 
-      Terra.should.beAccessible({ context: '#action' });
-      Terra.should.matchScreenshot({ selector: '#action' });
+      Terra.should.beAccessible({ context: '[id=action]' });
+      Terra.should.matchScreenshot({ selector: '[id=action]' });
     });
 
     describe('Action-Keyboard Focus', () => {
       before(() => browser.keys('Tab'));
 
-      Terra.should.beAccessible({ context: '#action' });
-      Terra.should.matchScreenshot({ selector: '#action' });
+      Terra.should.beAccessible({ context: '[id=action]' });
+      Terra.should.matchScreenshot({ selector: '[id=action]' });
     });
 
     describe('Action-Active', () => {
       before(() => browser.url('/#/raw/tests/terra-button/button/active-variant-buttons'));
 
-      Terra.should.matchScreenshot('active', { selector: '#actionActive' });
-      Terra.should.matchScreenshot('active and focused', { selector: '#actionActiveFocusSpan' });
+      Terra.should.matchScreenshot('active', { selector: '[id=actionActive]' });
+      Terra.should.matchScreenshot('active and focused', { selector: '[id=actionActiveFocusSpan]' });
     });
   });
 
   describe('Utility', () => {
     before(() => browser.url('/#/raw/tests/terra-button/button/variants/utility-button'));
 
-    Terra.should.beAccessible({ context: '#utility' });
-    Terra.should.matchScreenshot({ selector: '#utility' });
+    Terra.should.beAccessible({ context: '[id=utility]' });
+    Terra.should.matchScreenshot({ selector: '[id=utility]' });
 
     describe('Utility-Hovered', () => {
-      before(() => browser.moveToObject('#utilityButton'));
+      before(() => browser.moveToObject('[id=utilityButton]'));
 
-      Terra.should.beAccessible({ context: '#utility' });
-      Terra.should.matchScreenshot({ selector: '#utility' });
+      Terra.should.beAccessible({ context: '[id=utility]' });
+      Terra.should.matchScreenshot({ selector: '[id=utility]' });
     });
 
     describe('Utility-Keyboard Focus', () => {
       before(() => browser.keys('Tab'));
 
-      Terra.should.beAccessible({ context: '#utility' });
-      Terra.should.matchScreenshot({ selector: '#utility' });
+      Terra.should.beAccessible({ context: '[id=utility]' });
+      Terra.should.matchScreenshot({ selector: '[id=utility]' });
 
-      Terra.should.themeEachCustomProperty('#utility', {
+      Terra.should.themeEachCustomProperty('[id=utility]', {
         '--terra-button-utility-border-radius': '50%',
       });
     });
@@ -204,23 +204,23 @@ describe('Button', () => {
     describe('Utility-Active', () => {
       before(() => browser.url('/#/raw/tests/terra-button/button/active-variant-buttons'));
 
-      Terra.should.matchScreenshot('active', { selector: '#utilityActive' });
-      Terra.should.matchScreenshot('active and focused', { selector: '#utilityActiveFocusSpan' });
+      Terra.should.matchScreenshot('active', { selector: '[id=utilityActive]' });
+      Terra.should.matchScreenshot('active and focused', { selector: '[id=utilityActiveFocusSpan]' });
     });
   });
 
   describe('Long Text', () => {
     before(() => browser.url('/#/raw/tests/terra-button/button/long-text-button'));
 
-    Terra.should.beAccessible({ context: '#long-text' });
-    Terra.should.matchScreenshot({ selector: '#long-text' });
+    Terra.should.beAccessible({ context: '[id=long-text]' });
+    Terra.should.matchScreenshot({ selector: '[id=long-text]' });
   });
 
   describe('Block', () => {
     before(() => browser.url('/#/raw/tests/terra-button/button/long-text-button'));
 
-    Terra.should.beAccessible({ context: '#long-text-block' });
-    Terra.should.matchScreenshot({ selector: '#long-text-block' });
+    Terra.should.beAccessible({ context: '[id=long-text-block]' });
+    Terra.should.matchScreenshot({ selector: '[id=long-text-block]' });
   });
 
   describe('Button Types', () => {
@@ -229,17 +229,17 @@ describe('Button', () => {
     Terra.should.beAccessible();
 
     describe('Type reset', () => {
-      Terra.should.matchScreenshot({ selector: '#buttonWithTypeReset' });
+      Terra.should.matchScreenshot({ selector: '[id=buttonWithTypeReset]' });
     });
 
     describe('Type submit', () => {
-      Terra.should.matchScreenshot({ selector: '#buttonWithTypeSubmit' });
+      Terra.should.matchScreenshot({ selector: '[id=buttonWithTypeSubmit]' });
     });
 
     describe('Type button', () => {
-      Terra.should.matchScreenshot({ selector: '#buttonWithTypeButton' });
+      Terra.should.matchScreenshot({ selector: '[id=buttonWithTypeButton]' });
 
-      Terra.should.themeEachCustomProperty('#buttonWithTypeButton', {
+      Terra.should.themeEachCustomProperty('[id=buttonWithTypeButton]', {
         '--terra-button-text-only-horizontal-margin': '20px',
       });
     });
@@ -251,11 +251,11 @@ describe('Button', () => {
     Terra.should.beAccessible();
 
     describe('Icon and Text', () => {
-      Terra.should.matchScreenshot({ selector: '#iconNeutralButton' });
+      Terra.should.matchScreenshot({ selector: '[id=iconNeutralButton]' });
 
       Terra.should.themeCombinationOfCustomProperties({
         testName: 'themed',
-        selector: '#iconNeutralButton',
+        selector: '[id=iconNeutralButton]',
         properties: {
           '--terra-button-text-and-icon-horizontal-margin': '20px',
           '--terra-button-text-and-icon-margin-between': '20px',
@@ -266,15 +266,15 @@ describe('Button', () => {
     describe('Icon and Text Reversed', () => {
       before(() => browser.url('/#/raw/tests/terra-button/button/icon-button'));
 
-      Terra.should.matchScreenshot({ selector: '#iconReversedButton' });
+      Terra.should.matchScreenshot({ selector: '[id=iconReversedButton]' });
     });
 
     describe('Icon only', () => {
-      Terra.should.matchScreenshot({ selector: '#iconOnlyButton' });
+      Terra.should.matchScreenshot({ selector: '[id=iconOnlyButton]' });
 
       Terra.should.themeCombinationOfCustomProperties({
         testName: 'themed',
-        selector: '#iconOnlyButton',
+        selector: '[id=iconOnlyButton]',
         properties: {
           '--terra-button-icon-only-horizontal-margin': '20px',
           '--terra-button-icon-height': '10px',
@@ -288,6 +288,6 @@ describe('Button', () => {
     before(() => browser.url('/#/raw/tests/terra-button/button/compact-button'));
 
     Terra.should.beAccessible();
-    Terra.should.matchScreenshot({ selector: '#compactButton' });
+    Terra.should.matchScreenshot({ selector: '[id=compactButton]' });
   });
 });

--- a/packages/terra-collapsible-menu-view/tests/wdio/collapsible-menu-view-spec.js
+++ b/packages/terra-collapsible-menu-view/tests/wdio/collapsible-menu-view-spec.js
@@ -35,7 +35,7 @@ describe('Collapsible Menu View', () => {
         browser.click('[data-collapsible-menu-toggle]');
       });
 
-      Terra.should.matchScreenshot({ selector: '#root' });
+      Terra.should.matchScreenshot({ selector: '[id=root]' });
       Terra.should.beAccessible();
     });
   });

--- a/packages/terra-date-time-picker/tests/wdio/date-time-picker-spec.js
+++ b/packages/terra-date-time-picker/tests/wdio/date-time-picker-spec.js
@@ -134,7 +134,7 @@ describe('DateTimePicker', () => {
       browser.click('input[name="terra-time-minute-input"]');
       browser.waitForVisible('[class*="time-clarification"]');
       browser.click('[class*="button-daylight"]');
-      browser.click('#date-time-picker-toggler');
+      browser.click('[id=date-time-picker-toggler]');
     });
 
     const ignoredDisabledAlly = Object.assign({ 'color-contrast': { enabled: false } }, ignoredA11y);

--- a/packages/terra-dialog/tests/wdio/dialog-spec.js
+++ b/packages/terra-dialog/tests/wdio/dialog-spec.js
@@ -3,7 +3,7 @@ const viewports = Terra.viewports('tiny', 'large');
 describe('Dialog', () => {
   describe('Default', () => {
     before(() => browser.url('/#/raw/tests/terra-dialog/dialog/default-dialog'));
-    Terra.should.matchScreenshot({ viewports, selector: '#dialog' });
+    Terra.should.matchScreenshot({ viewports, selector: '[id=dialog]' });
     Terra.should.beAccessible({ viewports });
   });
 });

--- a/packages/terra-doc-template/tests/wdio/doc-template-spec.js
+++ b/packages/terra-doc-template/tests/wdio/doc-template-spec.js
@@ -4,9 +4,9 @@ describe('DocTemplate', () => {
   describe('Fully filled out doc', () => {
     before(() => browser.url('/#/raw/tests/terra-doc-template/doc-template/default-doc-template'));
 
-    Terra.should.matchScreenshot('Readme', { selector: '#DocTemplateContainer > div:first-child > div:first-child > div:nth-child(2)' });
-    Terra.should.matchScreenshot('Example 1', { selector: '#DocTemplateContainer > div > div:nth-child(3)' });
-    Terra.should.matchScreenshot('PropsTable 1', { selector: '#DocTemplateContainer > div > div:nth-child(5) > div:first-child', viewports: [{ width: 1000, height: 1000 }] });
+    Terra.should.matchScreenshot('Readme', { selector: '[id=DocTemplateContainer] > div:first-child > div:first-child > div:nth-child(2)' });
+    Terra.should.matchScreenshot('Example 1', { selector: '[id=DocTemplateContainer] > div > div:nth-child(3)' });
+    Terra.should.matchScreenshot('PropsTable 1', { selector: '[id=DocTemplateContainer] > div > div:nth-child(5) > div:first-child', viewports: [{ width: 1000, height: 1000 }] });
     Terra.should.beAccessible({ viewports: Terra.viewports('huge') });
   });
 
@@ -21,7 +21,7 @@ describe('DocTemplate', () => {
       // Give time for the animation to complete
       browser.pause(250);
 
-      const screenshots = browser.checkElement('#DocTemplateContainer > div > div:nth-child(3)', { viewports: Terra.viewports('huge') });
+      const screenshots = browser.checkElement('[id=DocTemplateContainer] > div > div:nth-child(3)', { viewports: Terra.viewports('huge') });
       expect(screenshots).to.matchReference('withinTolerance');
     });
 
@@ -32,7 +32,7 @@ describe('DocTemplate', () => {
 
       browser.pause(250);
 
-      const screenshots = browser.checkElement('#DocTemplateContainer > div > div:nth-child(3)', { viewports: Terra.viewports('huge') });
+      const screenshots = browser.checkElement('[id=DocTemplateContainer] > div > div:nth-child(3)', { viewports: Terra.viewports('huge') });
       expect(screenshots).to.matchReference('withinTolerance');
     });
   });

--- a/packages/terra-form-checkbox/tests/wdio/form-checkbox-field-spec.js
+++ b/packages/terra-form-checkbox/tests/wdio/form-checkbox-field-spec.js
@@ -39,7 +39,7 @@ describe('CheckboxField', () => {
   describe('CheckboxField Interactions - Valid State', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-form-checkbox/form-checkbox/checkbox-field/controlled-checkbox-field');
-      browser.waitForVisible('#testing-checkbox-field');
+      browser.waitForVisible('[id=testing-checkbox-field]');
       browser.click('[for="website-dept"]');
       browser.click('[for="ux-dept"]');
     });
@@ -50,7 +50,7 @@ describe('CheckboxField', () => {
   describe('CheckboxField Interactions - Invalid State', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-form-checkbox/form-checkbox/checkbox-field/controlled-checkbox-field');
-      browser.waitForVisible('#testing-checkbox-field');
+      browser.waitForVisible('[id=testing-checkbox-field]');
       browser.click('[for="website-dept"]');
       browser.click('[for="ux-dept"]');
       browser.click('[for="website-dept"]');
@@ -63,7 +63,7 @@ describe('CheckboxField', () => {
   describe('CheckboxField Interactions - Valid State with hideRequired', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-form-checkbox/form-checkbox/checkbox-field/hide-required-invalid-checkbox-field');
-      browser.waitForVisible('#testing-checkbox-field');
+      browser.waitForVisible('[id=testing-checkbox-field]');
       browser.click('[for="website-dept"]');
       browser.click('[for="ux-dept"]');
     });
@@ -74,7 +74,7 @@ describe('CheckboxField', () => {
   describe('CheckboxField Interactions - Invalid State with hideRequired', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-form-checkbox/form-checkbox/checkbox-field/hide-required-invalid-checkbox-field');
-      browser.waitForVisible('#testing-checkbox-field');
+      browser.waitForVisible('[id=testing-checkbox-field]');
       browser.click('[for="website-dept"]');
       browser.click('[for="ux-dept"]');
       browser.click('[for="website-dept"]');

--- a/packages/terra-form-checkbox/tests/wdio/form-checkbox-spec.js
+++ b/packages/terra-form-checkbox/tests/wdio/form-checkbox-spec.js
@@ -88,8 +88,8 @@ describe('Checkbox', () => {
 
     describe('Hover', () => {
       beforeEach(() => {
-        browser.waitForVisible('#default');
-        browser.moveToObject('#default');
+        browser.waitForVisible('[id=default]');
+        browser.moveToObject('[id=default]');
       });
 
       Terra.should.matchScreenshot();
@@ -102,9 +102,9 @@ describe('Checkbox', () => {
 
     describe('Checked', () => {
       beforeEach(() => {
-        browser.waitForVisible('#default');
+        browser.waitForVisible('[id=default]');
         browser.click('[for="default"]');
-        browser.click('#site');
+        browser.click('[id=site]');
       });
 
       Terra.should.matchScreenshot();
@@ -117,7 +117,7 @@ describe('Checkbox', () => {
 
     describe('Focus', () => {
       beforeEach(() => {
-        browser.waitForVisible('#default');
+        browser.waitForVisible('[id=default]');
         browser.keys('Tab');
       });
 
@@ -152,8 +152,8 @@ describe('Checkbox', () => {
 
     describe('Disabled Hover', () => {
       beforeEach(() => {
-        browser.waitForVisible('#disabled');
-        browser.moveToObject('#disabled');
+        browser.waitForVisible('[id=disabled]');
+        browser.moveToObject('[id=disabled]');
       });
 
       Terra.should.beAccessible();

--- a/packages/terra-form-input/tests/wdio/form-input-spec.js
+++ b/packages/terra-form-input/tests/wdio/form-input-spec.js
@@ -225,7 +225,7 @@ describe('Form-Input', () => {
     describe('Invalid InputField', () => {
       before(() => {
         browser.url('/#/raw/tests/terra-form-input/form-input/input-field');
-        browser.click('#validity-toggle');
+        browser.click('[id=validity-toggle]');
       });
 
       Terra.should.matchScreenshot({ viewports });

--- a/packages/terra-form-radio/tests/wdio/form-radio-field-spec.js
+++ b/packages/terra-form-radio/tests/wdio/form-radio-field-spec.js
@@ -39,7 +39,7 @@ describe('RadioField', () => {
   describe('RadioField Interactions - Valid State', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-form-radio/form-radio/field/controlled-radio-field');
-      browser.waitForVisible('#testing-radio-field');
+      browser.waitForVisible('[id=testing-radio-field]');
       browser.click('[for="website-dept"]');
       browser.click('[for="ux-dept"]');
       browser.click('[for="website-dept"]');
@@ -52,7 +52,7 @@ describe('RadioField', () => {
   describe('RadioField Interactions - Valid State with hideRequired', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-form-radio/form-radio/field/hide-required-invalid-radio-field');
-      browser.waitForVisible('#testing-radio-field');
+      browser.waitForVisible('[id=testing-radio-field]');
       browser.click('[for="website-dept"]');
       browser.click('[for="ux-dept"]');
     });
@@ -63,7 +63,7 @@ describe('RadioField', () => {
   describe('RadioField Interactions - Invalid State with hideRequired', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-form-radio/form-radio/field/hide-required-invalid-radio-field');
-      browser.waitForVisible('#testing-radio-field');
+      browser.waitForVisible('[id=testing-radio-field]');
       browser.click('[for="website-dept"]');
       browser.click('[for="ux-dept"]');
       browser.click('[for="website-dept"]');

--- a/packages/terra-form-radio/tests/wdio/form-radio-spec.js
+++ b/packages/terra-form-radio/tests/wdio/form-radio-spec.js
@@ -102,8 +102,8 @@ describe('Radio', () => {
 
     describe('Hover', () => {
       beforeEach(() => {
-        browser.waitForVisible('#default');
-        browser.moveToObject('#default');
+        browser.waitForVisible('[id=default]');
+        browser.moveToObject('[id=default]');
       });
 
       Terra.should.matchScreenshot();
@@ -116,9 +116,9 @@ describe('Radio', () => {
 
     describe('Checked', () => {
       beforeEach(() => {
-        browser.waitForVisible('#default');
+        browser.waitForVisible('[id=default]');
         browser.click('[for="default"]');
-        browser.click('#site');
+        browser.click('[id=site]');
       });
 
       Terra.should.matchScreenshot();
@@ -131,7 +131,7 @@ describe('Radio', () => {
 
     describe('Focus', () => {
       beforeEach(() => {
-        browser.waitForVisible('#default');
+        browser.waitForVisible('[id=default]');
         browser.keys('Tab');
       });
 

--- a/packages/terra-form-select/tests/wdio/select-field-spec.js
+++ b/packages/terra-form-select/tests/wdio/select-field-spec.js
@@ -8,14 +8,14 @@ describe('Select Field', () => {
     Terra.should.matchScreenshot({ viewports });
 
     it('should open the dropdown by clicking the toggle', () => {
-      browser.click('#select-field:last-child');
+      browser.click('[id=select-field]:last-child');
     });
 
     Terra.should.beAccessible();
-    Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+    Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
     it('should select the first option', () => {
-      browser.click('#terra-select-option-xSmall');
+      browser.click('[id=terra-select-option-xSmall]');
     });
 
     Terra.should.beAccessible();
@@ -29,11 +29,11 @@ describe('Select Field', () => {
     Terra.should.matchScreenshot({ viewports });
 
     it('should open the dropdown by clicking the toggle', () => {
-      browser.click('#select-field:last-child');
+      browser.click('[id=select-field]:last-child');
     });
 
     Terra.should.beAccessible();
-    Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+    Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
     it('should select the first option by pressing enter', () => {
       browser.keys('ArrowUp');

--- a/packages/terra-form-select/tests/wdio/select-spec.js
+++ b/packages/terra-form-select/tests/wdio/select-spec.js
@@ -9,14 +9,14 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('default should open the dropdown by clicking the toggle', () => {
-        browser.click('#default:last-child');
+        browser.click('[id=default]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('default should select the first option', () => {
-        browser.click('#terra-select-option-blue');
+        browser.click('[id=terra-select-option-blue]');
       });
 
       Terra.should.beAccessible();
@@ -30,11 +30,11 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('default should open the dropdown by clicking the toggle', () => {
-        browser.click('#default:last-child');
+        browser.click('[id=default]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('default should select the first option by pressing enter', () => {
         browser.keys('Enter');
@@ -51,14 +51,14 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('default controlled should open the dropdown by clicking the toggle', () => {
-        browser.click('#default:last-child');
+        browser.click('[id=default]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('default controlled should select the first option', () => {
-        browser.click('#terra-select-option-green');
+        browser.click('[id=terra-select-option-green]');
       });
 
       Terra.should.beAccessible();
@@ -72,11 +72,11 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('default should open the dropdown by clicking the toggle', () => {
-        browser.click('#default:last-child');
+        browser.click('[id=default]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
     });
 
     describe('should render an empty placeholder', () => {
@@ -92,11 +92,11 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('default should open the dropdown by clicking the toggle', () => {
-        browser.click('#maxHeight:last-child');
+        browser.click('[id=maxHeight]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown-max-height', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown-max-height', { viewports, selector: '[id=root]' });
     });
   });
 
@@ -114,14 +114,14 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('combobox should open the dropdown by clicking the toggle', () => {
-        browser.click('#combobox:last-child');
+        browser.click('[id=combobox]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('combobox should select the first option', () => {
-        browser.click('#terra-select-option-blue');
+        browser.click('[id=terra-select-option-blue]');
       });
 
       Terra.should.beAccessible();
@@ -141,11 +141,11 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('combobox should open the dropdown by clicking the toggle', () => {
-        browser.click('#combobox:last-child');
+        browser.click('[id=combobox]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('combobox should select the first option by pressing enter', () => {
         browser.keys('Enter');
@@ -168,14 +168,14 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('combobox controlled should open the dropdown by clicking the toggle', () => {
-        browser.click('#combobox:last-child');
+        browser.click('[id=combobox]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('combobox controlled should select the first option', () => {
-        browser.click('#terra-select-option-blue');
+        browser.click('[id=terra-select-option-blue]');
       });
 
       Terra.should.beAccessible();
@@ -195,11 +195,11 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('combobox should open the dropdown by clicking the toggle', () => {
-        browser.click('#combobox:last-child');
+        browser.click('[id=combobox]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('combobox should enter a free text entry', () => {
         browser.keys(['T', 'a', 'g']);
@@ -228,14 +228,14 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('multiple should open the dropdown by clicking the toggle', () => {
-        browser.click('#multiple:last-child');
+        browser.click('[id=multiple]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('multiple should select the first option', () => {
-        browser.click('#terra-select-option-blue');
+        browser.click('[id=terra-select-option-blue]');
       });
 
       Terra.should.beAccessible();
@@ -255,11 +255,11 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('multiple should open the dropdown by clicking the toggle', () => {
-        browser.click('#multiple:last-child');
+        browser.click('[id=multiple]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('multiple should select the first option by pressing enter', () => {
         browser.keys('Enter');
@@ -282,14 +282,14 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('multiple controlled should open the dropdown by clicking the toggle', () => {
-        browser.click('#multiple:last-child');
+        browser.click('[id=multiple]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('multiple controlled should select the first option', () => {
-        browser.click('#terra-select-option-blue');
+        browser.click('[id=terra-select-option-blue]');
       });
 
       Terra.should.beAccessible();
@@ -311,14 +311,14 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('search should open the dropdown by clicking the toggle', () => {
-        browser.click('#search:last-child');
+        browser.click('[id=search]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('search should select the first option', () => {
-        browser.click('#terra-select-option-blue');
+        browser.click('[id=terra-select-option-blue]');
       });
 
       Terra.should.beAccessible();
@@ -338,11 +338,11 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('search should open the dropdown by clicking the toggle', () => {
-        browser.click('#search:last-child');
+        browser.click('[id=search]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('search should select the first option by pressing enter', () => {
         browser.keys('Enter');
@@ -365,14 +365,14 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('search constrolled should open the dropdown by clicking the toggle', () => {
-        browser.click('#search:last-child');
+        browser.click('[id=search]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('search constrolled should select the first option', () => {
-        browser.click('#terra-select-option-blue');
+        browser.click('[id=terra-select-option-blue]');
       });
 
       Terra.should.beAccessible();
@@ -394,14 +394,14 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('tag should open the dropdown by clicking the toggle', () => {
-        browser.click('#tag:last-child');
+        browser.click('[id=tag]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('tag should select the first option', () => {
-        browser.click('#terra-select-option-blue');
+        browser.click('[id=terra-select-option-blue]');
       });
 
       Terra.should.beAccessible();
@@ -421,11 +421,11 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('tag should open the dropdown by clicking the toggle', () => {
-        browser.click('#tag:last-child');
+        browser.click('[id=tag]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('tag should select the first option by pressing enter', () => {
         browser.keys('Enter');
@@ -448,14 +448,14 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('tag controlled should open the dropdown by clicking the toggle', () => {
-        browser.click('#tag:last-child');
+        browser.click('[id=tag]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('tag controlled should select the first option', () => {
-        browser.click('#terra-select-option-blue');
+        browser.click('[id=terra-select-option-blue]');
       });
 
       Terra.should.beAccessible();
@@ -475,11 +475,11 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('tag should open the dropdown by clicking the toggle', () => {
-        browser.click('#tag:last-child');
+        browser.click('[id=tag]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('tag should enter a free text entry', () => {
         browser.keys(['T', 'a', 'g']);
@@ -502,14 +502,14 @@ describe('Select', () => {
       Terra.should.matchScreenshot({ viewports });
 
       it('should open the dropdown by clicking the toggle', () => {
-        browser.click('#opt-group:last-child');
+        browser.click('[id=opt-group]:last-child');
       });
 
       Terra.should.beAccessible();
-      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '#root' });
+      Terra.should.matchScreenshot('open-dropdown', { viewports, selector: '[id=root]' });
 
       it('should select the first option', () => {
-        browser.click('#terra-select-option-blue');
+        browser.click('[id=terra-select-option-blue]');
       });
 
       Terra.should.beAccessible();

--- a/packages/terra-form-textarea/tests/wdio/form-textarea-spec.js
+++ b/packages/terra-form-textarea/tests/wdio/form-textarea-spec.js
@@ -394,7 +394,7 @@ describe('Form-Textarea', () => {
     describe('Invalid TextareaField', () => {
       before(() => {
         browser.url('/#/raw/tests/terra-form-textarea/form-textarea/textarea-field');
-        browser.click('#validity-toggle');
+        browser.click('[id=validity-toggle]');
       });
 
       Terra.should.matchScreenshot({ viewports });

--- a/packages/terra-image/tests/wdio/image-spec.js
+++ b/packages/terra-image/tests/wdio/image-spec.js
@@ -12,29 +12,29 @@ describe('Image', () => {
     before(() => browser.url('/#/raw/tests/terra-image/image/image-non-fluid'));
 
     Terra.should.beAccessible();
-    Terra.should.matchScreenshot('smaller than container', { selector: '#smaller' });
-    Terra.should.matchScreenshot('height smaller than container', { selector: '#height-smaller' });
-    Terra.should.matchScreenshot('width smaller than container', { selector: '#width-smaller' });
+    Terra.should.matchScreenshot('smaller than container', { selector: '[id=smaller]' });
+    Terra.should.matchScreenshot('height smaller than container', { selector: '[id=height-smaller]' });
+    Terra.should.matchScreenshot('width smaller than container', { selector: '[id=width-smaller]' });
   });
 
   describe('Fluid', () => {
     before(() => browser.url('/#/raw/tests/terra-image/image/image-fluid'));
 
     Terra.should.beAccessible();
-    Terra.should.matchScreenshot('smaller than container', { selector: '#smaller' });
-    Terra.should.matchScreenshot('height smaller than container', { selector: '#height-smaller' });
-    Terra.should.matchScreenshot('width smaller than container', { selector: '#width-smaller' });
+    Terra.should.matchScreenshot('smaller than container', { selector: '[id=smaller]' });
+    Terra.should.matchScreenshot('height smaller than container', { selector: '[id=height-smaller]' });
+    Terra.should.matchScreenshot('width smaller than container', { selector: '[id=width-smaller]' });
   });
 
   describe('Loading', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-image/image/image-loading');
-      browser.waitForExist('#loadedImage');
-      browser.waitForExist('#errorImage');
+      browser.waitForExist('[id=loadedImage]');
+      browser.waitForExist('[id=errorImage]');
     });
 
     Terra.should.beAccessible();
-    Terra.should.matchScreenshot('successful load', { selector: '#loadedImage' });
-    Terra.should.matchScreenshot('failed load', { selector: '#errorImage' });
+    Terra.should.matchScreenshot('successful load', { selector: '[id=loadedImage]' });
+    Terra.should.matchScreenshot('failed load', { selector: '[id=errorImage]' });
   });
 });

--- a/packages/terra-menu/tests/wdio/menu-item-spec.js
+++ b/packages/terra-menu/tests/wdio/menu-item-spec.js
@@ -107,21 +107,21 @@ describe('Menu Item-Triggers onClick Function', () => {
   before(() => browser.url('/#/raw/tests/terra-menu/menu/menu-item/menu-item-on-click'));
 
   it('starts with click number of 0', () => {
-    expect(browser.getText('#clickNumber')).to.contain('0');
+    expect(browser.getText('[id=clickNumber]')).to.contain('0');
   });
 
   it('increments on Click', () => {
     browser.click('.TestOnClickItem');
-    expect(browser.getText('#clickNumber')).to.contain('1');
+    expect(browser.getText('[id=clickNumber]')).to.contain('1');
   });
 
   it('increments on Enter', () => {
     browser.keys('Enter');
-    expect(browser.getText('#clickNumber')).to.contain('2');
+    expect(browser.getText('[id=clickNumber]')).to.contain('2');
   });
 
   it('increments on Space', () => {
     browser.keys('Space');
-    expect(browser.getText('#clickNumber')).to.contain('3');
+    expect(browser.getText('[id=clickNumber]')).to.contain('3');
   });
 });

--- a/packages/terra-menu/tests/wdio/menu-spec.js
+++ b/packages/terra-menu/tests/wdio/menu-spec.js
@@ -9,18 +9,18 @@ describe('Menu', () => {
   describe('Menu-Default', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-menu/menu/menu/default-menu');
-      browser.click('#default-button');
+      browser.click('[id=default-button]');
       browser.hasFocus('[class*="content"][aria-modal="true"][role="dialog"]');
     });
 
-    Terra.should.matchScreenshot({ selector: '#root' });
+    Terra.should.matchScreenshot({ selector: '[id=root]' });
     Terra.should.beAccessible();
   });
 
   describe('Menu-Bounded', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-menu/menu/menu/bounded-menu');
-      browser.click('#bounded-button');
+      browser.click('[id=bounded-button]');
       browser.hasFocus('[class*="content"][aria-modal="true"][role="dialog"]');
     });
 
@@ -31,102 +31,102 @@ describe('Menu', () => {
       browser.click('.TestNestedMenu');
       browser.hasFocus('[role="button"][aria-label="Back"]');
     });
-    Terra.should.matchScreenshot('submenu', { selector: '#root' });
+    Terra.should.matchScreenshot('submenu', { selector: '[id=root]' });
     Terra.should.beAccessible({ rules: ignoredA11y });
   });
 
   describe('Menu-Small Height', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-menu/menu/menu/small-menu');
-      browser.click('#small-menu-button');
+      browser.click('[id=small-menu-button]');
     });
 
-    Terra.should.matchScreenshot({ selector: '#root' });
+    Terra.should.matchScreenshot({ selector: '[id=root]' });
     Terra.should.beAccessible();
   });
 
   describe('Menu-Medium Height', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-menu/menu/menu/medium-menu');
-      browser.click('#medium-menu-button');
+      browser.click('[id=medium-menu-button]');
     });
 
-    Terra.should.matchScreenshot({ selector: '#root' });
+    Terra.should.matchScreenshot({ selector: '[id=root]' });
     Terra.should.beAccessible();
   });
 
   describe('Menu-Large Height', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-menu/menu/menu/large-menu');
-      browser.click('#large-menu-button');
+      browser.click('[id=large-menu-button]');
     });
 
-    Terra.should.matchScreenshot({ selector: '#root' });
+    Terra.should.matchScreenshot({ selector: '[id=root]' });
     Terra.should.beAccessible();
   });
 
   describe('Menu-Non-Selectable', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-menu/menu/menu/non-selectable-menu');
-      browser.click('#non-selectable-menu-button');
+      browser.click('[id=non-selectable-menu-button]');
     });
 
-    Terra.should.matchScreenshot({ selector: '#root' });
+    Terra.should.matchScreenshot({ selector: '[id=root]' });
     Terra.should.beAccessible();
   });
 
   describe('Menu-Selectable', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-menu/menu/menu/selectable-menu');
-      browser.click('#selectable-menu-button');
+      browser.click('[id=selectable-menu-button]');
       browser.hasFocus('[class*="content"][aria-modal="true"][role="dialog"]');
       browser.click('.TestGroupItem3');
       browser.hasFocus('li:last-child[aria-selected="true"][role="menuitemradio"]');
     });
 
-    Terra.should.matchScreenshot({ selector: '#root' });
+    Terra.should.matchScreenshot({ selector: '[id=root]' });
     Terra.should.beAccessible();
   });
 
   describe('Menu-Selectable with Varying Items', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-menu/menu/menu/selectable-and-unselectable-items-menu');
-      browser.click('#default-button');
+      browser.click('[id=default-button]');
     });
 
-    Terra.should.matchScreenshot({ selector: '#root' });
+    Terra.should.matchScreenshot({ selector: '[id=root]' });
     Terra.should.beAccessible();
 
     it('selects an item and maintains selection after menu has been reopened', () => {
       browser.click('.TestSelectableItem');
-      browser.hasFocus('#default-button');
-      browser.click('#default-button');
+      browser.hasFocus('[id=default-button]');
+      browser.click('[id=default-button]');
       browser.hasFocus('[class*="content"][aria-modal="true"][role="dialog"]');
     });
-    Terra.should.matchScreenshot('maintained selection after reopen', { selector: '#root' });
+    Terra.should.matchScreenshot('maintained selection after reopen', { selector: '[id=root]' });
   });
 
   describe('Menu with a submenu', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-menu/menu/menu/sub-menu');
-      browser.click('#sub-menu-button');
+      browser.click('[id=sub-menu-button]');
       browser.hasFocus('[class*="content"][aria-modal="true"][role="dialog"]');
     });
 
-    Terra.should.matchScreenshot('main menu', { selector: '#root' });
+    Terra.should.matchScreenshot('main menu', { selector: '[id=root]' });
     Terra.should.beAccessible();
 
     it('displays the submenu', () => {
       browser.click('.TestNestedMenu');
       browser.hasFocus('[role="button"][aria-label="Back"]');
     });
-    Terra.should.matchScreenshot('submenu', { selector: '#root' });
+    Terra.should.matchScreenshot('submenu', { selector: '[id=root]' });
   });
 
   describe('Menu Keyboard Navigation-Arrow Keys', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-menu/menu/menu/sub-menu');
-      browser.click('#sub-menu-button');
+      browser.click('[id=sub-menu-button]');
       browser.hasFocus('[class*="content"][aria-modal="true"][role="dialog"]');
     });
 
@@ -134,25 +134,25 @@ describe('Menu', () => {
       browser.keys(['Tab', 'ArrowLeft']);
       browser.hasFocus('li:first-child[class*="item"][role="menuitem"]');
     });
-    Terra.should.matchScreenshot('main menu remains open', { selector: '#root' });
+    Terra.should.matchScreenshot('main menu remains open', { selector: '[id=root]' });
 
     it('displays the submenu on right arrow', () => {
       browser.keys(['ArrowDown', 'ArrowRight']);
       browser.hasFocus('[role="button"][aria-label="Back"]');
     });
-    Terra.should.matchScreenshot('navigated to submenu', { selector: '#root' });
+    Terra.should.matchScreenshot('navigated to submenu', { selector: '[id=root]' });
 
     it('returns to the main menu on left arrow', () => {
       browser.keys(['ArrowLeft']);
       browser.hasFocus('[class*="content"][aria-modal="true"][role="dialog"]');
     });
-    Terra.should.matchScreenshot('returned to main menu', { selector: '#root' });
+    Terra.should.matchScreenshot('returned to main menu', { selector: '[id=root]' });
   });
 
   describe('Menu Keyboard Navigation-Enter Key', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-menu/menu/menu/sub-menu');
-      browser.click('#sub-menu-button');
+      browser.click('[id=sub-menu-button]');
       browser.hasFocus('[class*="content"][aria-modal="true"][role="dialog"]');
     });
 
@@ -160,12 +160,12 @@ describe('Menu', () => {
       browser.keys(['Tab', 'ArrowDown', 'Enter']);
       browser.hasFocus('[role="button"][aria-label="Back"]');
     });
-    Terra.should.matchScreenshot('navigated to submenu', { selector: '#root' });
+    Terra.should.matchScreenshot('navigated to submenu', { selector: '[id=root]' });
 
     it('returns to the main menu on enter', () => {
       browser.keys(['Enter']);
       browser.hasFocus('[class*="content"][aria-modal="true"][role="dialog"]');
     });
-    Terra.should.matchScreenshot('returned to main menu', { selector: '#root' });
+    Terra.should.matchScreenshot('returned to main menu', { selector: '[id=root]' });
   });
 });

--- a/packages/terra-overlay/tests/wdio/loading-overlay-spec.js
+++ b/packages/terra-overlay/tests/wdio/loading-overlay-spec.js
@@ -2,44 +2,44 @@ describe('Loading Overlay', () => {
   describe('Loading Overlay Default', () => {
     before(() => browser.url('/#/raw/tests/terra-overlay/overlay/loading-overlay/default-loading-overlay'));
 
-    Terra.should.beAccessible({ selector: '#terra-LoadingOverlay' });
-    Terra.should.matchScreenshot({ selector: '#terra-LoadingOverlay' });
+    Terra.should.beAccessible({ selector: '[id=terra-LoadingOverlay]' });
+    Terra.should.matchScreenshot({ selector: '[id=terra-LoadingOverlay]' });
 
     it('Expect default to have full screen', () => {
-      expect(browser.getAttribute('#terra-LoadingOverlay', 'class')).contains('fullscreen');
+      expect(browser.getAttribute('[id=terra-LoadingOverlay]', 'class')).contains('fullscreen');
     });
   });
 
   describe('Loading Overlay Container', () => {
     before(() => browser.url('/#/raw/tests/terra-overlay/overlay/loading-overlay/container-loading-overlay'));
 
-    Terra.should.beAccessible({ selector: '#terra-LoadingOverlay' });
-    Terra.should.matchScreenshot({ selector: '#terra-LoadingOverlay' });
+    Terra.should.beAccessible({ selector: '[id=terra-LoadingOverlay]' });
+    Terra.should.matchScreenshot({ selector: '[id=terra-LoadingOverlay]' });
   });
 
   describe('Loading Custom Message', () => {
     before(() => browser.url('/#/raw/tests/terra-overlay/overlay/loading-overlay/custom-message-loading-overlay'));
 
-    Terra.should.beAccessible({ selector: '#terra-LoadingOverlay' });
-    Terra.should.matchScreenshot({ selector: '#terra-LoadingOverlay' });
+    Terra.should.beAccessible({ selector: '[id=terra-LoadingOverlay]' });
+    Terra.should.matchScreenshot({ selector: '[id=terra-LoadingOverlay]' });
   });
 
   describe('Animated', () => {
     before(() => browser.url('/#/raw/tests/terra-overlay/overlay/loading-overlay/animated-loading-overlay'));
 
     it('Expect Icon to be animated', () => {
-      expect(browser.getAttribute('#terra-LoadingOverlay div svg', 'class')).contains('is-spin');
+      expect(browser.getAttribute('[id=terra-LoadingOverlay] div svg', 'class')).contains('is-spin');
     });
   });
 
   describe('Light Loading Theme', () => {
     before(() => browser.url('/#/raw/tests/terra-overlay/overlay/loading-overlay/light-loading-overlay'));
 
-    Terra.should.beAccessible({ selector: '#terra-LoadingOverlay' });
-    Terra.should.matchScreenshot({ selector: '#terra-LoadingOverlay' });
+    Terra.should.beAccessible({ selector: '[id=terra-LoadingOverlay]' });
+    Terra.should.matchScreenshot({ selector: '[id=terra-LoadingOverlay]' });
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#terra-LoadingOverlay',
+      selector: '[id=terra-LoadingOverlay]',
       properties: {
         '--terra-overlay-light-background-color': 'green',
         '--terra-overlay-light-background-image': 'linear-gradient(red, green)',
@@ -51,11 +51,11 @@ describe('Loading Overlay', () => {
   describe('Dark Loading Overlay Theme', () => {
     before(() => browser.url('/#/raw/tests/terra-overlay/overlay/loading-overlay/dark-loading-overlay'));
 
-    Terra.should.beAccessible({ selector: '#terra-LoadingOverlay' });
-    Terra.should.matchScreenshot({ selector: '#terra-LoadingOverlay' });
+    Terra.should.beAccessible({ selector: '[id=terra-LoadingOverlay]' });
+    Terra.should.matchScreenshot({ selector: '[id=terra-LoadingOverlay]' });
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#terra-LoadingOverlay',
+      selector: '[id=terra-LoadingOverlay]',
       properties: {
         '--terra-overlay-dark-background-color': 'blue',
         '--terra-overlay-dark-background-image': 'linear-gradient(blue, green)',
@@ -67,11 +67,11 @@ describe('Loading Overlay', () => {
   describe('Clear Loading Overlay Theme', () => {
     before(() => browser.url('/#/raw/tests/terra-overlay/overlay/loading-overlay/clear-loading-overlay'));
 
-    Terra.should.beAccessible({ selector: '#terra-LoadingOverlay' });
-    Terra.should.matchScreenshot({ selector: '#terra-LoadingOverlay' });
+    Terra.should.beAccessible({ selector: '[id=terra-LoadingOverlay]' });
+    Terra.should.matchScreenshot({ selector: '[id=terra-LoadingOverlay]' });
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#terra-LoadingOverlay',
+      selector: '[id=terra-LoadingOverlay]',
       properties: {
         '--terra-overlay-content-color': 'red',
         '--terra-overlay-content-padding-bottom': '500px',

--- a/packages/terra-overlay/tests/wdio/overlay-container-spec.js
+++ b/packages/terra-overlay/tests/wdio/overlay-container-spec.js
@@ -5,6 +5,6 @@ describe('Overlay Container Default', () => {
   Terra.should.matchScreenshot();
 
   it('Check for tabindex value', () => {
-    expect(browser.getAttribute('#terra-OverlayContainer', 'tabIndex')).to.equal('-1');
+    expect(browser.getAttribute('[id=terra-OverlayContainer]', 'tabIndex')).to.equal('-1');
   });
 });

--- a/packages/terra-overlay/tests/wdio/overlay-spec.js
+++ b/packages/terra-overlay/tests/wdio/overlay-spec.js
@@ -2,29 +2,29 @@ describe('Overlay', () => {
   describe('Default', () => {
     before(() => browser.url('/#/raw/tests/terra-overlay/overlay/overlay/default-overlay'));
 
-    Terra.should.beAccessible({ selector: '#default-overlay' });
-    Terra.should.matchScreenshot({ selector: '#default-overlay' });
+    Terra.should.beAccessible({ selector: '[id=default-overlay]' });
+    Terra.should.matchScreenshot({ selector: '[id=default-overlay]' });
   });
 
   describe('Overlay container', () => {
     before(() => browser.url('/#/raw/tests/terra-overlay/overlay/overlay/container-overlay'));
 
-    Terra.should.beAccessible({ selector: '#overlay-container' });
-    Terra.should.matchScreenshot({ selector: '#overlay-container' });
+    Terra.should.beAccessible({ selector: '[id=overlay-container]' });
+    Terra.should.matchScreenshot({ selector: '[id=overlay-container]' });
   });
 
   describe('Scrollable Full Screen Overlay', () => {
     beforeEach(() => browser.url('/#/raw/tests/terra-overlay/overlay/overlay/fullscreen-scrollable-overlay'));
 
-    Terra.should.beAccessible({ selector: '#scrollable-overlay' });
-    Terra.should.matchScreenshot({ selector: '#scrollable-overlay' });
+    Terra.should.beAccessible({ selector: '[id=scrollable-overlay]' });
+    Terra.should.matchScreenshot({ selector: '[id=scrollable-overlay]' });
   });
 
   describe('Scrollable relative container overlay', () => {
     beforeEach(() => browser.url('/#/raw/tests/terra-overlay/overlay/overlay/container-scrollable-overlay'));
 
-    Terra.should.beAccessible({ selector: '#overlay-container' });
-    Terra.should.matchScreenshot({ selector: '#overlay-container' });
+    Terra.should.beAccessible({ selector: '[id=overlay-container]' });
+    Terra.should.matchScreenshot({ selector: '[id=overlay-container]' });
   });
 
   describe('Overlay on Request-Close', () => {
@@ -37,27 +37,27 @@ describe('Overlay', () => {
       Terra.should.matchScreenshot('Before');
 
       it('Clicks on the Full screen overlay button', () => {
-        browser.click('#trigger_fullscreen');
+        browser.click('[id=trigger_fullscreen]');
       });
 
-      Terra.should.beAccessible({ selector: '#terra-Overlay--fullscreen' });
-      Terra.should.matchScreenshot('After', { selector: '#terra-Overlay--fullscreen' });
+      Terra.should.beAccessible({ selector: '[id=terra-Overlay--fullscreen]' });
+      Terra.should.matchScreenshot('After', { selector: '[id=terra-Overlay--fullscreen]' });
     });
 
     it('Background does not scroll when a fullscreen Overlay is open', () => {
       browser.url('/#/raw/tests/terra-overlay/overlay/overlay/on-request-close-overlay');
-      browser.click('#trigger_fullscreen');
+      browser.click('[id=trigger_fullscreen]');
       expect(browser.getAttribute('html', 'style')).contains('overflow: hidden');
     });
 
     describe('Full Screen Overlay- Triggers an onRequestClose on escape keydown', () => {
       before(() => {
         browser.url('/#/raw/tests/terra-overlay/overlay/overlay/on-request-close-overlay');
-        browser.click('#trigger_fullscreen');
+        browser.click('[id=trigger_fullscreen]');
       });
 
-      Terra.should.beAccessible({ selector: '#terra-Overlay--fullscreen' });
-      Terra.should.matchScreenshot('Before', { selector: '#terra-Overlay--fullscreen' });
+      Terra.should.beAccessible({ selector: '[id=terra-Overlay--fullscreen]' });
+      Terra.should.matchScreenshot('Before', { selector: '[id=terra-Overlay--fullscreen]' });
 
       it('Escape key press', () => {
         browser.keys('Escape');
@@ -70,14 +70,14 @@ describe('Overlay', () => {
     describe('Full Screen Overlay- Triggers an onRequestClose on click inside of the Overlay', () => {
       before(() => {
         browser.url('/#/raw/tests/terra-overlay/overlay/overlay/on-request-close-overlay');
-        browser.click('#trigger_fullscreen');
+        browser.click('[id=trigger_fullscreen]');
       });
 
-      Terra.should.beAccessible({ selector: '#terra-Overlay--fullscreen' });
-      Terra.should.matchScreenshot('Before', { selector: '#terra-Overlay--fullscreen' });
+      Terra.should.beAccessible({ selector: '[id=terra-Overlay--fullscreen]' });
+      Terra.should.matchScreenshot('Before', { selector: '[id=terra-Overlay--fullscreen]' });
 
       it('Click inside of the overlay', () => {
-        browser.click('#terra-Overlay--fullscreen');
+        browser.click('[id=terra-Overlay--fullscreen]');
       });
 
       Terra.should.beAccessible();
@@ -93,27 +93,27 @@ describe('Overlay', () => {
       Terra.should.matchScreenshot('Before');
 
       it('Clicks on Container Overlay', () => {
-        browser.click('#trigger_container');
+        browser.click('[id=trigger_container]');
       });
 
-      Terra.should.beAccessible({ selector: '#terra-Overlay--container' });
-      Terra.should.matchScreenshot('After', { selector: '#terra-Overlay--container' });
+      Terra.should.beAccessible({ selector: '[id=terra-Overlay--container]' });
+      Terra.should.matchScreenshot('After', { selector: '[id=terra-Overlay--container]' });
     });
 
     it('Container Overlay- Background can scroll when Overlay relative to contianer is open', () => {
       browser.url('/#/raw/tests/terra-overlay/overlay/overlay/on-request-close-overlay');
-      browser.click('#trigger_container');
+      browser.click('[id=trigger_container]');
       expect(browser.getAttribute('html', 'style')).contains('');
     });
 
     describe('Container Overlay- Triggers an onRequestClose on escape keydown', () => {
       before(() => {
         browser.url('/#/raw/tests/terra-overlay/overlay/overlay/on-request-close-overlay');
-        browser.click('#trigger_container');
+        browser.click('[id=trigger_container]');
       });
 
-      Terra.should.beAccessible({ selector: '#terra-Overlay--container' });
-      Terra.should.matchScreenshot('Before', { selector: '#terra-Overlay--container' });
+      Terra.should.beAccessible({ selector: '[id=terra-Overlay--container]' });
+      Terra.should.matchScreenshot('Before', { selector: '[id=terra-Overlay--container]' });
 
       it('Escape key press', () => {
         browser.keys('Escape');
@@ -126,14 +126,14 @@ describe('Overlay', () => {
     describe('Container Overlay-Triggers an onRequestClose on click inside of the Overlay', () => {
       before(() => {
         browser.url('/#/raw/tests/terra-overlay/overlay/overlay/on-request-close-overlay');
-        browser.click('#trigger_container');
+        browser.click('[id=trigger_container]');
       });
 
-      Terra.should.beAccessible({ selector: '#terra-Overlay--container' });
-      Terra.should.matchScreenshot('Before', { selector: '#terra-Overlay--container' });
+      Terra.should.beAccessible({ selector: '[id=terra-Overlay--container]' });
+      Terra.should.matchScreenshot('Before', { selector: '[id=terra-Overlay--container]' });
 
       it('Clicks on the inside of Overlay', () => {
-        browser.click('#terra-Overlay--container');
+        browser.click('[id=terra-Overlay--container]');
       });
 
       Terra.should.beAccessible();
@@ -144,7 +144,7 @@ describe('Overlay', () => {
   describe('Custom Content', () => {
     const random = function random() {
       try {
-        browser.click('#random_button');
+        browser.click('[id=random_button]');
       } catch (error) {
         if (error.message.contains('is not clickable')) {
           throw error;
@@ -155,43 +155,43 @@ describe('Overlay', () => {
     describe('Full Screen Custom Content', () => {
       before(() => {
         browser.url('/#/raw/tests/terra-overlay/overlay/overlay/custom-content-overlay');
-        browser.click('#trigger_fullscreen');
+        browser.click('[id=trigger_fullscreen]');
       });
-      Terra.should.beAccessible({ selector: '#terra-Overlay--fullscreen' });
-      Terra.should.matchScreenshot({ selector: '#terra-Overlay--fullscreen' });
+      Terra.should.beAccessible({ selector: '[id=terra-Overlay--fullscreen]' });
+      Terra.should.matchScreenshot({ selector: '[id=terra-Overlay--fullscreen]' });
     });
 
     it('Custom Content under overlay is not clickable when Overlay is open', () => {
       browser.url('/#/raw/tests/terra-overlay/overlay/overlay/custom-content-overlay');
-      browser.click('#trigger_fullscreen');
+      browser.click('[id=trigger_fullscreen]');
       expect(random).to.throw();
     });
 
     describe('Container Custom Content', () => {
       before(() => {
         browser.url('/#/raw/tests/terra-overlay/overlay/overlay/custom-content-overlay');
-        browser.click('#trigger_container');
+        browser.click('[id=trigger_container]');
       });
-      Terra.should.beAccessible({ selector: '#custom-content-example' });
-      Terra.should.matchScreenshot({ selector: '#custom-content-example' });
+      Terra.should.beAccessible({ selector: '[id=custom-content-example]' });
+      Terra.should.matchScreenshot({ selector: '[id=custom-content-example]' });
     });
 
     describe('Custom Content under overlay container is clickable when overlaycontainer is open', () => {
       before(() => {
         browser.url('/#/raw/tests/terra-overlay/overlay/overlay/custom-content-overlay');
-        browser.click('#trigger_container');
-        browser.click('#random_button');
+        browser.click('[id=trigger_container]');
+        browser.click('[id=random_button]');
       });
 
-      Terra.should.beAccessible({ selector: '#custom-content-example' });
-      Terra.should.matchScreenshot({ selector: '#custom-content-example' });
+      Terra.should.beAccessible({ selector: '[id=custom-content-example]' });
+      Terra.should.matchScreenshot({ selector: '[id=custom-content-example]' });
     });
   });
 
   describe('Overlay unmounted', () => {
     it('Background scrolling is restored after overlay is unmounted', () => {
       browser.url('/#/raw/tests/terra-overlay/overlay/overlay/removed-overlay');
-      browser.click('#fullscreen_overlay');
+      browser.click('[id=fullscreen_overlay]');
       expect(browser.getAttribute('html', 'style')).to.not.include('overflow: hidden');
     });
   });
@@ -200,10 +200,10 @@ describe('Overlay', () => {
     before(() => browser.url('/#/raw/tests/terra-overlay/overlay/overlay/light-overlay'));
 
     Terra.should.beAccessible();
-    Terra.should.matchScreenshot({ selector: '#light-overlay' });
+    Terra.should.matchScreenshot({ selector: '[id=light-overlay]' });
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#light-overlay',
+      selector: '[id=light-overlay]',
       properties: {
         '--terra-overlay-light-background-color': 'green',
         '--terra-overlay-light-background-image': 'linear-gradient(red, green)',
@@ -216,10 +216,10 @@ describe('Overlay', () => {
     before(() => browser.url('/#/raw/tests/terra-overlay/overlay/overlay/dark-overlay'));
 
     Terra.should.beAccessible();
-    Terra.should.matchScreenshot({ selector: '#dark-overlay' });
+    Terra.should.matchScreenshot({ selector: '[id=dark-overlay]' });
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#dark-overlay',
+      selector: '[id=dark-overlay]',
       properties: {
         '--terra-overlay-dark-background-color': 'blue',
         '--terra-overlay-dark-background-image': 'linear-gradient(blue, green)',
@@ -232,10 +232,10 @@ describe('Overlay', () => {
     before(() => browser.url('/#/raw/tests/terra-overlay/overlay/overlay/clear-overlay'));
 
     Terra.should.beAccessible();
-    Terra.should.matchScreenshot({ selector: '#clear-overlay' });
+    Terra.should.matchScreenshot({ selector: '[id=clear-overlay]' });
     Terra.should.themeCombinationOfCustomProperties({
       testName: 'themed',
-      selector: '#clear-overlay',
+      selector: '[id=clear-overlay]',
       properties: {
         '--terra-overlay-content-color': 'red',
         '--terra-overlay-content-padding-bottom': '500px',

--- a/packages/terra-paginator/tests/wdio/paginator-spec.js
+++ b/packages/terra-paginator/tests/wdio/paginator-spec.js
@@ -64,7 +64,7 @@ describe('Paginator', () => {
     Terra.should.matchScreenshot('0');
 
     it('should toggle page change when the props are updated', () => {
-      browser.click('#button-9');
+      browser.click('[id=button-9]');
     });
 
     Terra.should.matchScreenshot('1');
@@ -88,7 +88,7 @@ describe('Paginator', () => {
     Terra.should.matchScreenshot('0');
 
     it('should toggle page change when the props are updated', () => {
-      browser.click('#button-9');
+      browser.click('[id=button-9]');
     });
 
     Terra.should.matchScreenshot('1');

--- a/packages/terra-props-table/tests/wdio/props-table-spec.js
+++ b/packages/terra-props-table/tests/wdio/props-table-spec.js
@@ -7,34 +7,34 @@ describe('Props Table', () => {
       browser.setViewportSize(Terra.viewports('medium')[0]);
     });
 
-    Terra.should.matchScreenshot('should display a string prop', { selector: '#PropsTable > tbody > tr:nth-child(1)' });
+    Terra.should.matchScreenshot('should display a string prop', { selector: '[id=PropsTable] > tbody > tr:nth-child(1)' });
 
-    Terra.should.matchScreenshot('should display a number prop', { selector: '#PropsTable > tbody > tr:nth-child(2)' });
+    Terra.should.matchScreenshot('should display a number prop', { selector: '[id=PropsTable] > tbody > tr:nth-child(2)' });
 
-    Terra.should.matchScreenshot('should display a boolean prop', { selector: '#PropsTable > tbody > tr:nth-child(3)' });
+    Terra.should.matchScreenshot('should display a boolean prop', { selector: '[id=PropsTable] > tbody > tr:nth-child(3)' });
 
-    Terra.should.matchScreenshot('should display an element prop', { selector: '#PropsTable > tbody > tr:nth-child(4)' });
+    Terra.should.matchScreenshot('should display an element prop', { selector: '[id=PropsTable] > tbody > tr:nth-child(4)' });
 
     // Need to manually scroll down so screenshots of the remaining rows can be taken
     it('needs to scroll down', () => {
       browser.click('td=arrayOfShapes');
     });
 
-    Terra.should.matchScreenshot('should display a node prop', { selector: '#PropsTable > tbody > tr:nth-child(5)' });
+    Terra.should.matchScreenshot('should display a node prop', { selector: '[id=PropsTable] > tbody > tr:nth-child(5)' });
 
-    Terra.should.matchScreenshot('should display an array prop', { selector: '#PropsTable > tbody > tr:nth-child(6)' });
+    Terra.should.matchScreenshot('should display an array prop', { selector: '[id=PropsTable] > tbody > tr:nth-child(6)' });
 
-    Terra.should.matchScreenshot('should display a default arrayOf prop', { selector: '#PropsTable > tbody > tr:nth-child(7)' });
+    Terra.should.matchScreenshot('should display a default arrayOf prop', { selector: '[id=PropsTable] > tbody > tr:nth-child(7)' });
 
     it('needs to scroll down even more', () => {
       browser.click('[data-terra-bottom-scroll-marker]');
     });
 
-    Terra.should.matchScreenshot('should display an arrayOf(shapes) prop', { selector: '#PropsTable > tbody > tr:nth-child(8)' });
+    Terra.should.matchScreenshot('should display an arrayOf(shapes) prop', { selector: '[id=PropsTable] > tbody > tr:nth-child(8)' });
 
-    Terra.should.matchScreenshot('should display a oneOfType prop', { selector: '#PropsTable > tbody > tr:nth-child(9)' });
+    Terra.should.matchScreenshot('should display a oneOfType prop', { selector: '[id=PropsTable] > tbody > tr:nth-child(9)' });
 
-    Terra.should.matchScreenshot('should display a shape prop', { selector: '#PropsTable > tbody > tr:nth-child(10)' });
+    Terra.should.matchScreenshot('should display a shape prop', { selector: '[id=PropsTable] > tbody > tr:nth-child(10)' });
 
     Terra.should.beAccessible({ viewports });
   });

--- a/packages/terra-responsive-element/tests/wdio/responsive-element-spec.js
+++ b/packages/terra-responsive-element/tests/wdio/responsive-element-spec.js
@@ -19,6 +19,6 @@ describe('Responsive Element', () => {
     before(() => browser.url('/#/raw/tests/terra-responsive-element/responsive-element/all-breakpoints-small-parent'));
 
     Terra.should.beAccessible({ viewports });
-    Terra.should.matchScreenshot({ viewports, selector: '#root' });
+    Terra.should.matchScreenshot({ viewports, selector: '[id=root]' });
   });
 });

--- a/packages/terra-scroll/tests/wdio/scroll-spec.js
+++ b/packages/terra-scroll/tests/wdio/scroll-spec.js
@@ -3,12 +3,12 @@ describe('Scroll', () => {
     browser.url('/#/raw/tests/terra-scroll/scroll/default');
   });
 
-  Terra.should.beAccessible({ context: '#scroll-test' });
-  Terra.should.matchScreenshot('before-click', { selector: '#scroll-test' });
+  Terra.should.beAccessible({ context: '[id=scroll-test]' });
+  Terra.should.matchScreenshot('before-click', { selector: '[id=scroll-test]' });
 
   it('scroll the view', () => {
-    browser.click('#scroll');
+    browser.click('[id=scroll]');
   });
 
-  Terra.should.matchScreenshot('after-click', { selector: '#scroll-test' });
+  Terra.should.matchScreenshot('after-click', { selector: '[id=scroll-test]' });
 });

--- a/packages/terra-search-field/tests/wdio/search-field-spec.js
+++ b/packages/terra-search-field/tests/wdio/search-field-spec.js
@@ -153,7 +153,7 @@ describe('Search Field', () => {
     it('should not search with the button', () => {
       browser.click('button');
       // Ensure button on hover styling is disabled
-      browser.click('#search-callback-text');
+      browser.click('[id=search-callback-text]');
     });
 
     Terra.should.matchScreenshot('with too short text after button press');
@@ -257,12 +257,12 @@ describe('Search Field', () => {
     Terra.should.matchScreenshot('empty');
 
     it('should click button to focus search field', () => {
-      browser.waitForVisible('#search-field-focus-button');
+      browser.waitForVisible('[id=search-field-focus-button]');
       browser.execute(() => {
         // Removes the blinking cursor to prevent screenshot mismatches.
         document.querySelector('input').style.caretColor = 'transparent';
       });
-      browser.click('#search-field-focus-button');
+      browser.click('[id=search-field-focus-button]');
     });
 
     Terra.should.matchScreenshot('with focus');

--- a/packages/terra-signature/tests/wdio/signature-spec.js
+++ b/packages/terra-signature/tests/wdio/signature-spec.js
@@ -11,11 +11,11 @@ describe('Signature', () => {
   describe('Drawing Lines', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-signature/signature/signature-default');
-      browser.waitForVisible('#drawline');
+      browser.waitForVisible('[id=drawline]');
 
-      browser.moveToObject('#drawline', 0, 0);
+      browser.moveToObject('[id=drawline]', 0, 0);
       browser.buttonDown(0);
-      browser.moveToObject('#drawline', 90, 90);
+      browser.moveToObject('[id=drawline]', 90, 90);
       browser.buttonUp(0);
     });
 
@@ -26,13 +26,13 @@ describe('Signature', () => {
   describe('Themed Drawing Lines', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-signature/signature/signature-default');
-      browser.waitForVisible('#drawline');
+      browser.waitForVisible('[id=drawline]');
       // Theme variables need to be set before drawing on canvas for theme test
       browser.execute('document.documentElement.style.setProperty("--terra-signature-background-color", "#a7dc9e")');
       browser.execute('document.documentElement.style.setProperty("--terra-signature-line-color", "#8b0a0a")');
-      browser.moveToObject('#drawline', 0, 0);
+      browser.moveToObject('[id=drawline]', 0, 0);
       browser.buttonDown(0);
-      browser.moveToObject('#drawline', 90, 90);
+      browser.moveToObject('[id=drawline]', 90, 90);
       browser.buttonUp(0);
     });
 
@@ -42,11 +42,11 @@ describe('Signature', () => {
   describe('Right Click does not draw lines', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-signature/signature/signature-default');
-      browser.waitForVisible('#drawline');
+      browser.waitForVisible('[id=drawline]');
 
-      browser.moveToObject('#drawline', 0, 0);
+      browser.moveToObject('[id=drawline]', 0, 0);
       browser.buttonDown(2);
-      browser.moveToObject('#drawline', 90, 90);
+      browser.moveToObject('[id=drawline]', 90, 90);
       browser.buttonUp(2);
     });
 
@@ -57,11 +57,11 @@ describe('Signature', () => {
   describe('Middle Click does not draw lines', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-signature/signature/signature-default');
-      browser.waitForVisible('#drawline');
+      browser.waitForVisible('[id=drawline]');
 
-      browser.moveToObject('#drawline', 0, 0);
+      browser.moveToObject('[id=drawline]', 0, 0);
       browser.buttonDown(1);
-      browser.moveToObject('#drawline', 90, 90);
+      browser.moveToObject('[id=drawline]', 90, 90);
       browser.buttonUp(1);
     });
 

--- a/packages/terra-tabs/tests/wdio/tab-pane-spec.js
+++ b/packages/terra-tabs/tests/wdio/tab-pane-spec.js
@@ -41,7 +41,7 @@ describe('TabPane', () => {
 
   describe('Long text', () => {
     before(() => browser.url('/#/raw/tests/terra-tabs/tabs/tab-pane/long-text-tab-pane'));
-    Terra.should.matchScreenshot({ selector: '#longText' });
+    Terra.should.matchScreenshot({ selector: '[id=longText]' });
     Terra.should.beAccessible();
   });
 });

--- a/packages/terra-tabs/tests/wdio/tabs-spec.js
+++ b/packages/terra-tabs/tests/wdio/tabs-spec.js
@@ -46,11 +46,11 @@ describe('Tabs - Responsive', () => {
         browser.click('[data-terra-tabs-menu]');
       });
 
-      Terra.should.matchScreenshot('0', { selector: '#root' });
+      Terra.should.matchScreenshot('0', { selector: '[id=root]' });
       Terra.should.beAccessible({ rules: ignoredA11y });
 
       it('should close menu when tab is selected', () => {
-        browser.click('#tab12');
+        browser.click('[id=tab12]');
       });
 
       Terra.should.beAccessible({ rules: ignoredA11y });
@@ -118,8 +118,8 @@ describe('Tabs - Responsive', () => {
 
       describe('Collapsible hover', () => {
         beforeEach(() => {
-          browser.waitForVisible('#tab2');
-          browser.moveToObject('#tab2');
+          browser.waitForVisible('[id=tab2]');
+          browser.moveToObject('[id=tab2]');
         });
 
         Terra.should.matchScreenshot();
@@ -138,8 +138,8 @@ describe('Tabs - Responsive', () => {
 
       describe('Collapsible active focus', () => {
         beforeEach(() => {
-          browser.waitForVisible('#tab2');
-          browser.click('#tab2');
+          browser.waitForVisible('[id=tab2]');
+          browser.click('[id=tab2]');
         });
 
         Terra.should.matchScreenshot();

--- a/packages/terra-toggle/tests/wdio/toggle-spec.js
+++ b/packages/terra-toggle/tests/wdio/toggle-spec.js
@@ -8,7 +8,7 @@ describe('Toggle', () => {
     Terra.should.matchScreenshot('closed');
 
     it('expands', () => {
-      browser.click('#trigger-toggle'); // Open toggle
+      browser.click('[id=trigger-toggle]'); // Open toggle
     });
 
     Terra.should.matchScreenshot('opened');
@@ -25,13 +25,13 @@ describe('Toggle', () => {
     before(() => browser.url('/#/raw/tests/terra-toggle/toggle/animated-toggle'));
 
     it('disables focusable elements when closed', () => {
-      expect(browser.getCssProperty('#toggle', 'visibility').value).to.equal('hidden');
+      expect(browser.getCssProperty('[id=toggle]', 'visibility').value).to.equal('hidden');
     });
 
     it('enables focusable elements when opened', () => {
-      browser.click('#trigger-toggle'); // Open toggle
-      browser.waitForVisible('#toggle');
-      expect(browser.getCssProperty('#toggle', 'visibility').value).to.equal('visible');
+      browser.click('[id=trigger-toggle]'); // Open toggle
+      browser.waitForVisible('[id=toggle]');
+      expect(browser.getCssProperty('[id=toggle]', 'visibility').value).to.equal('visible');
     });
   });
 });


### PR DESCRIPTION
### Summary
Update test selectors to use attribute id selector syntax instead of css id selector syntax. All updates were auto-fixed via eslint.