### PR TITLE
Fix Issue With Corner Styling in Form Select

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Updated Frame to remove isAbove styling when selecting item in single select list
 
 5.0.0 - (January 8, 2019)
 ------------------

--- a/packages/terra-form-select/src/_Frame.jsx
+++ b/packages/terra-form-select/src/_Frame.jsx
@@ -322,19 +322,17 @@ class Frame extends React.Component {
    * @param {ReactNode} option - The option that was selected.
    */
   handleSelect(value, option) {
+    const { isAbove } = this.state;
+    const isOpen = Util.allowsMultipleSelections(this.props);
+
     this.setState({
       searchValue: '',
       hasSearchChanged: false,
-      isOpen: Util.allowsMultipleSelections(this.props),
+      isOpen,
+      isAbove: isOpen ? isAbove : false,
     });
 
     if (this.props.onSelect) {
-      if (!Util.allowsMultipleSelections(this.props)) {
-        this.setState({
-          isAbove: false,
-        });
-      }
-
       this.props.onSelect(value, option);
     }
   }

--- a/packages/terra-form-select/src/_Frame.jsx
+++ b/packages/terra-form-select/src/_Frame.jsx
@@ -329,6 +329,12 @@ class Frame extends React.Component {
     });
 
     if (this.props.onSelect) {
+      if (!Util.allowsMultipleSelections(this.props)) {
+        this.setState({
+          isAbove: false,
+        });
+      }
+
       this.props.onSelect(value, option);
     }
   }


### PR DESCRIPTION
### Summary
Resolves an issue with form-select where lists opened above the select box would not clear styling from the select box upper corners when an item is selected. Does not apply to multi-select lists.

Closes [#2090](https://github.com/cerner/terra-core/issues/2090)