### PR TITLE
Fixes issue #2074 DatetimePicker throws NPE if manually entered valid datetime is outside of allotted datetime range

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -78,6 +78,7 @@ Cerner Corporation
 - Jeremy Fuksa [@jeremyfuksa]
 - Dillon Lustick [@celvro]
 - Ryan Rickard [@RLRickard]
+- Akarsh Shetty [@ShettyAkarsh]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -158,3 +159,4 @@ Cerner Corporation
 [@jeremyfuksa]: https://github.com/jeremyfuksa
 [@celvro]: https://github.com/celvro
 [@RLRickard]: https://github.com/RLRickard
+[@ShettyAkarsh]: https://github.com/ShettyAkarsh

--- a/packages/terra-date-time-picker/CHANGELOG.md
+++ b/packages/terra-date-time-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Throws NPE if manually entered valid date is outside of allotted datetime range.
 
 3.0.0 - (January 8, 2019)
 ------------------

--- a/packages/terra-date-time-picker/src/DateTimePicker.jsx
+++ b/packages/terra-date-time-picker/src/DateTimePicker.jsx
@@ -230,7 +230,7 @@ class DateTimePicker extends React.Component {
 
   handleTimeChange(event, time) {
     this.timeValue = time;
-    const validDate = DateTimeUtils.isValidDate(this.dateValue, this.state.dateFormat);
+    const validDate = DateTimeUtils.isValidDate(this.dateValue, this.state.dateFormat) && this.isDateTimeWithinRange(this.convertDateTimeStringToMomentObject(this.dateValue, this.timeValue));
     const validTime = DateTimeUtils.isValidTime(this.timeValue);
     const previousDateTime = this.state.dateTime ? this.state.dateTime.clone() : null;
 
@@ -305,13 +305,17 @@ class DateTimePicker extends React.Component {
   }
 
   validateDefaultDate() {
+    return this.isDateTimeWithinRange(this.state.dateTime);
+  }
+
+  isDateTimeWithinRange(newDateTime) {
     let isAcceptable = true;
 
-    if (DateUtil.isDateOutOfRange(this.state.dateTime, DateUtil.createSafeDate(this.props.minDateTime), DateUtil.createSafeDate(this.props.maxDateTime))) {
+    if (DateUtil.isDateOutOfRange(newDateTime, DateUtil.createSafeDate(this.props.minDateTime), DateUtil.createSafeDate(this.props.maxDateTime))) {
       isAcceptable = false;
     }
 
-    if (DateUtil.isDateExcluded(this.state.dateTime, this.props.excludeDates)) {
+    if (DateUtil.isDateExcluded(newDateTime, this.props.excludeDates)) {
       isAcceptable = false;
     }
 
@@ -344,6 +348,10 @@ class DateTimePicker extends React.Component {
 
   handleOnRequestClose() {
     this.setState({ isTimeClarificationOpen: false });
+  }
+
+  convertDateTimeStringToMomentObject(date, time) {
+    return DateTimeUtils.updateTime(DateUtil.createSafeDate(DateUtil.convertToISO8601(date, this.state.dateFormat)), time);
   }
 
   renderTimeClarification() {


### PR DESCRIPTION
### Summary
Resolves the NPE error when user tries to enter time along with valid date outside of the allotted datetime range.

The fix is to validate whether the date entered is within the datetime range after the date value is validated.

Resolves #2074