### PR TITLE
Added a11y/VoiceOver clarity to not-selectable Button Group

### DIFF
--- a/packages/terra-button-group/CHANGELOG.md
+++ b/packages/terra-button-group/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Added a11y clarity to not-selectable button group
 
 3.5.0 - (February 12, 2019)
 ------------------

--- a/packages/terra-button-group/src/ButtonGroup.jsx
+++ b/packages/terra-button-group/src/ButtonGroup.jsx
@@ -80,7 +80,7 @@ class ButtonGroup extends React.Component {
       const cloneChild = React.cloneElement(child, {
         onClick: this.wrapOnClick(child),
         className: cx([{ 'is-selected': isSelected }, child.props.className]),
-        'aria-pressed': isSelected,
+        'aria-pressed': isSelected ? isSelected : null,
       });
       allButtons.push(cloneChild);
     });

--- a/packages/terra-button-group/src/ButtonGroup.jsx
+++ b/packages/terra-button-group/src/ButtonGroup.jsx
@@ -80,7 +80,7 @@ class ButtonGroup extends React.Component {
       const cloneChild = React.cloneElement(child, {
         onClick: this.wrapOnClick(child),
         className: cx([{ 'is-selected': isSelected }, child.props.className]),
-        'aria-pressed': isSelected ? isSelected : null,
+        'aria-pressed': isSelected || null,
       });
       allButtons.push(cloneChild);
     });

--- a/packages/terra-button-group/tests/jest/__snapshots__/ButtonGroup.test.jsx.snap
+++ b/packages/terra-button-group/tests/jest/__snapshots__/ButtonGroup.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`should render a block button group with children 1`] = `
   className="button-group is-block"
 >
   <ButtonGroupButton
-    aria-pressed={false}
+    aria-pressed={null}
     className=""
     isDisabled={false}
     key="1"
@@ -13,7 +13,7 @@ exports[`should render a block button group with children 1`] = `
     text="Button 1"
   />
   <ButtonGroupButton
-    aria-pressed={false}
+    aria-pressed={null}
     className=""
     isDisabled={false}
     key="2"
@@ -21,7 +21,7 @@ exports[`should render a block button group with children 1`] = `
     text="Button 2"
   />
   <ButtonGroupButton
-    aria-pressed={false}
+    aria-pressed={null}
     className=""
     isDisabled={false}
     key="3"
@@ -36,7 +36,7 @@ exports[`should render a button group with children 1`] = `
   className="button-group"
 >
   <ButtonGroupButton
-    aria-pressed={false}
+    aria-pressed={null}
     className=""
     isDisabled={false}
     key="1"
@@ -59,7 +59,7 @@ exports[`should render a button group with children selected 1`] = `
     text="Button 1"
   />
   <ButtonGroupButton
-    aria-pressed={false}
+    aria-pressed={null}
     className=""
     isDisabled={false}
     key="2"
@@ -80,7 +80,7 @@ exports[`should select a button 1`] = `
   className="button-group"
 >
   <ButtonGroupButton
-    aria-pressed={false}
+    aria-pressed={null}
     className=""
     isDisabled={false}
     key="1"
@@ -88,7 +88,7 @@ exports[`should select a button 1`] = `
     text="Button 1"
   />
   <ButtonGroupButton
-    aria-pressed={false}
+    aria-pressed={null}
     className=""
     isDisabled={false}
     key="2"
@@ -103,7 +103,7 @@ exports[`should select a button 2`] = `
   className="button-group"
 >
   <ButtonGroupButton
-    aria-pressed={false}
+    aria-pressed={null}
     className=""
     isDisabled={false}
     key="1"
@@ -111,7 +111,7 @@ exports[`should select a button 2`] = `
     text="Button 1"
   />
   <ButtonGroupButton
-    aria-pressed={false}
+    aria-pressed={null}
     className=""
     isDisabled={false}
     key="2"


### PR DESCRIPTION
### Summary
Added clarity to not-selectable buttons when using IOS VoiceOver. The buttons now convey that they are not selectable.

Before: "${textOfButton}, toggle button, not pressed, double tap to toggle setting" 
After:    "${textOfButton}, button"

Resolves: [#1895](https://github.com/cerner/terra-core/issues/1895)