### PR TITLE
[terra-form-select] Fix broken jest test

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed a Select Menu jest test that was broken with the release of enzyme-3.9.0
 
 5.6.0 - (February 12, 2019)
 ------------------

--- a/packages/terra-form-select/tests/jest/Menu.test.jsx
+++ b/packages/terra-form-select/tests/jest/Menu.test.jsx
@@ -40,7 +40,7 @@ describe('Menu', () => {
     const mockIntl = { formatMessage: id => (`No Results for ${id.id}`) };
 
     const menu = (
-      <Menu onSelect={() => {}} visuallyHiddenComponent={liveRegion} intl={mockIntl} variant="default" value="value" searchValue="asdfasdf">
+      <Menu onSelect={() => {}} visuallyHiddenComponent={liveRegion} intl={mockIntl} variant="default" value="value" searchValue="asdf">
         <Option value="value" display="display" />
       </Menu>
     );
@@ -49,7 +49,7 @@ describe('Menu', () => {
 
     jest.useFakeTimers();
 
-    wrapper.setProps({ searchValue: 'asdf' });
+    wrapper.setState({ hasNoResults: true });
 
     jest.advanceTimersByTime(500);
 


### PR DESCRIPTION
### Summary
The Select Menu jest test is now failing with the new release of [Enzyme-3.9.0](https://github.com/airbnb/enzyme/releases/tag/enzyme%403.9.0). With enzyme-3.9.0, `componentDidUpdate` is no longer called when updating a prop. This change updates the test to update the state, which trigger `componentDidUpdate` to update the liveRegion with the correct text.

Thanks for contributing to Terra. 
@cerner/terra
