### PR TITLE
Fix Race Condition caused by Timeout

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Race condition where timeout would update after the component is not mounted
 
 5.7.0 - (February 26, 2019)
 ------------------

--- a/packages/terra-form-select/src/_Menu.jsx
+++ b/packages/terra-form-select/src/_Menu.jsx
@@ -158,6 +158,11 @@ class Menu extends React.Component {
         intl,
       } = this.context;
 
+      // Race condition can occur between calling timeout and unmounting this component.
+      if (!visuallyHiddenComponent || !visuallyHiddenComponent.current) {
+        return;
+      }
+
       if (hasNoResults && searchValue) {
         visuallyHiddenComponent.current.innerText = intl.formatMessage({ id: 'Terra.form.select.noResults' }, { text: searchValue });
       } else {

--- a/packages/terra-form-select/tests/jest/Menu.test.jsx
+++ b/packages/terra-form-select/tests/jest/Menu.test.jsx
@@ -56,4 +56,43 @@ describe('Menu', () => {
     expect(wrapper).toMatchSnapshot();
     expect(liveRegion.current.innerText).toEqual('No matching results for "asdf"');
   });
+
+  it('should not error when visuallyHiddenComponent is not provided', () => {
+    const mockIntl = { formatMessage: id => (`No Results for ${id.id}`) };
+
+    const menu = (
+      <Menu onSelect={() => {}} intl={mockIntl} variant="default" value="value" searchValue="asdf">
+        <Option value="value" display="display" />
+      </Menu>
+    );
+
+    const wrapper = shallow(menu, intlContexts.shallowContext);
+
+    jest.useFakeTimers();
+
+    wrapper.setState({ hasNoResults: true });
+
+    jest.advanceTimersByTime(500);
+    expect(true).toEqual(true);
+  });
+
+  it('should not error when visuallyHiddenComponent has null for current', () => {
+    const liveRegion = { current: null };
+    const mockIntl = { formatMessage: id => (`No Results for ${id.id}`) };
+
+    const menu = (
+      <Menu onSelect={() => {}} intl={mockIntl} visuallyHiddenComponent={liveRegion} variant="default" value="value" searchValue="asdf">
+        <Option value="value" display="display" />
+      </Menu>
+    );
+
+    const wrapper = shallow(menu, intlContexts.shallowContext);
+
+    jest.useFakeTimers();
+
+    wrapper.setState({ hasNoResults: true });
+
+    jest.advanceTimersByTime(500);
+    expect(true).toEqual(true);
+  });
 });


### PR DESCRIPTION
### Summary
Fixes #2246

There was a race condition with the select in which the timeout for updating the visually component was called after the component was unmounted. To resolve this, we do safe checking on the visuallyHiddenComponent before updating the text inside it.
