### PR TITLE
[terra-form-select] disable react-onclickoutside

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -82,6 +82,7 @@ Cerner Corporation
 - Chandrakanth Dudela [@ChanduDudela]
 - Lauren Stephenson [@CompSciLauren]
 - Shetty Akarsh [@ShettyAkarsh]
+- Andrew Givens [@agivens96]
 
 
 
@@ -168,3 +169,4 @@ Cerner Corporation
 [@ChanduDudela]: https://github.com/ChanduDudela
 [@CompSciLauren]: https://github.com/CompSciLauren
 [@ShettyAkarsh]: https://github.com/ShettyAkarsh
+[@agivens96]: https://github.com/agivens96

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Fixed
 * Race condition where timeout would update after the component is not mounted
+* 'Unable to get property 'getInstance' of undefined or null reference' error in IE
 
 5.7.0 - (February 26, 2019)
 ------------------

--- a/packages/terra-form-select/src/_Dropdown.jsx
+++ b/packages/terra-form-select/src/_Dropdown.jsx
@@ -76,6 +76,7 @@ const Dropdown = ({
     >
       <Hookshot.Content
         {...customProps}
+        disableOnClickOutside
         className={dropdownClasses}
         onResize={onResize}
         onMouseDown={preventDefault}


### PR DESCRIPTION
### Summary
This will disable the react-onclickoutside hoc, used inside terra-hookshot's Content component, for terra-form-select. This will remove the error being thrown in ie by react-onoutsideclick mention in the issue https://github.com/cerner/terra-ui/issues/153

### Additional Details
My fork is deployed with gh-pages and can be tested here: https://agivens96.github.io/terra-core/#/components/terra-form-select/form-select/select

Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
