### PR TITLE
Remove terra base peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,8 +91,5 @@
     "terra-toolkit": "^4.16.1",
     "terra-enzyme-intl": "^3.0.0",
     "webpack-merge": "^4.1.2"
-  },
-  "dependencies": {
-    "replace-in-file": "^3.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -91,5 +91,8 @@
     "terra-toolkit": "^4.16.1",
     "terra-enzyme-intl": "^3.0.0",
     "webpack-merge": "^4.1.2"
+  },
+  "dependencies": {
+    "replace-in-file": "^3.4.4"
   }
 }

--- a/packages/terra-action-footer/CHANGELOG.md
+++ b/packages/terra-action-footer/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.5.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-action-footer/package.json
+++ b/packages/terra-action-footer/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-action-footer/src/ActionFooter.jsx
+++ b/packages/terra-action-footer/src/ActionFooter.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import BlockActionFooter from './BlockActionFooter';
 import styles from './ActionFooter.module.scss';
 

--- a/packages/terra-action-footer/src/BlockActionFooter.jsx
+++ b/packages/terra-action-footer/src/BlockActionFooter.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './BlockActionFooter.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-action-footer/src/CenteredActionFooter.jsx
+++ b/packages/terra-action-footer/src/CenteredActionFooter.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import BlockActionFooter from './BlockActionFooter';
 import styles from './CenteredActionFooter.module.scss';
 

--- a/packages/terra-action-header/CHANGELOG.md
+++ b/packages/terra-action-header/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.8.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-action-header/package.json
+++ b/packages/terra-action-header/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-action-header/src/ActionHeader.jsx
+++ b/packages/terra-action-header/src/ActionHeader.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import Button from 'terra-button';
 import ButtonGroup from 'terra-button-group';
-import 'terra-base/lib/baseStyles';
 import ActionHeaderContainer from './_ActionHeaderContainer';
 import styles from './ActionHeader.module.scss';
 

--- a/packages/terra-action-header/src/_ActionHeaderContainer.jsx
+++ b/packages/terra-action-header/src/_ActionHeaderContainer.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './ActionHeaderContainer.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-alert/CHANGELOG.md
+++ b/packages/terra-alert/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.9.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-alert/package.json
+++ b/packages/terra-alert/package.json
@@ -20,13 +20,10 @@
     "url": "https://github.com/cerner/terra-core/issues"
   },
   "homepage": "https://github.com/cerner/terra-core#readme",
-  "devDependencies": {
-    "react-intl": "^2.4.0"
-  },
   "peerDependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-intl": "^2.8.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-alert/src/Alert.jsx
+++ b/packages/terra-alert/src/Alert.jsx
@@ -8,7 +8,6 @@ import IconWarning from 'terra-icon/lib/icon/IconWarning';
 import IconInformation from 'terra-icon/lib/icon/IconInformation';
 import IconSuccess from 'terra-icon/lib/icon/IconSuccess';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Alert.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-arrange/CHANGELOG.md
+++ b/packages/terra-arrange/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.5.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-arrange/package.json
+++ b/packages/terra-arrange/package.json
@@ -33,8 +33,7 @@
   },
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-arrange/src/Arrange.jsx
+++ b/packages/terra-arrange/src/Arrange.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Arrange.module.scss';
 
 const AlignmentTypes = {

--- a/packages/terra-avatar/CHANGELOG.md
+++ b/packages/terra-avatar/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.11.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-avatar/package.json
+++ b/packages/terra-avatar/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-avatar/src/variants/Avatar.jsx
+++ b/packages/terra-avatar/src/variants/Avatar.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from '../common/Avatar.module.scss';
 import {
   AVATAR_VARIANTS, generateImagePlaceholder, generateImage, setColor,

--- a/packages/terra-avatar/src/variants/Facility.jsx
+++ b/packages/terra-avatar/src/variants/Facility.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from '../common/Avatar.module.scss';
 import {
   AVATAR_VARIANTS, generateImagePlaceholder, generateImage, setColor,

--- a/packages/terra-avatar/src/variants/SharedUser.jsx
+++ b/packages/terra-avatar/src/variants/SharedUser.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from '../common/Avatar.module.scss';
 import {
   AVATAR_VARIANTS, setColor,

--- a/packages/terra-badge/CHANGELOG.md
+++ b/packages/terra-badge/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.7.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-badge/package.json
+++ b/packages/terra-badge/package.json
@@ -33,8 +33,7 @@
   },
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-badge/src/Badge.jsx
+++ b/packages/terra-badge/src/Badge.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import VisuallyHiddenText from 'terra-visually-hidden-text';
 import styles from './Badge.module.scss';
 

--- a/packages/terra-button-group/CHANGELOG.md
+++ b/packages/terra-button-group/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.7.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-button-group/package.json
+++ b/packages/terra-button-group/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-button-group/src/ButtonGroup.jsx
+++ b/packages/terra-button-group/src/ButtonGroup.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import ButtonGroupButton from './ButtonGroupButton';
 import ButtonGroupUtils from './ButtonGroupUtils';
 import styles from './ButtonGroup.module.scss';

--- a/packages/terra-button-group/src/ButtonGroupButton.jsx
+++ b/packages/terra-button-group/src/ButtonGroupButton.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Button from 'terra-button';
 import classNames from 'classnames/bind';
 import KeyCode from 'keycode-js';
-import 'terra-base/lib/baseStyles';
 import styles from './ButtonGroup.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-button/CHANGELOG.md
+++ b/packages/terra-button/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.7.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-button/package.json
+++ b/packages/terra-button/package.json
@@ -33,8 +33,7 @@
   },
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-button/src/Button.jsx
+++ b/packages/terra-button/src/Button.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import KeyCode from 'keycode-js';
-import 'terra-base/lib/baseStyles';
 import styles from './Button.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-card/CHANGELOG.md
+++ b/packages/terra-card/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.4.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-card/package.json
+++ b/packages/terra-card/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-card/src/Card.jsx
+++ b/packages/terra-card/src/Card.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import VisuallyHiddenText from 'terra-visually-hidden-text';
 import styles from './Card.module.scss';
 import CardBody from './CardBody';

--- a/packages/terra-card/src/CardBody.jsx
+++ b/packages/terra-card/src/CardBody.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './CardBody.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-content-container/CHANGELOG.md
+++ b/packages/terra-content-container/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.4.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-content-container/package.json
+++ b/packages/terra-content-container/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-content-container/src/ContentContainer.jsx
+++ b/packages/terra-content-container/src/ContentContainer.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import Scroll from 'terra-scroll';
 import styles from './ContentContainer.module.scss';
 

--- a/packages/terra-demographics-banner/CHANGELOG.md
+++ b/packages/terra-demographics-banner/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.6.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-demographics-banner/package.json
+++ b/packages/terra-demographics-banner/package.json
@@ -20,13 +20,10 @@
     "url": "https://github.com/cerner/terra-core/issues"
   },
   "homepage": "https://github.com/cerner/terra-core#readme",
-  "devDependencies": {
-    "react-intl": "^2.4.0"
-  },
   "peerDependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-intl": "^2.8.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-demographics-banner/src/DemographicsBanner.jsx
+++ b/packages/terra-demographics-banner/src/DemographicsBanner.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import 'terra-base/lib/baseStyles';
 import DemographicsBannerDisplay from './DemographicsBannerDisplay';
 
 const propTypes = {

--- a/packages/terra-demographics-banner/src/DemographicsBannerDisplay.jsx
+++ b/packages/terra-demographics-banner/src/DemographicsBannerDisplay.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ResponsiveElement from 'terra-responsive-element';
-import 'terra-base/lib/baseStyles';
 
 import './DemographicsBanner.module.scss';
 import SmallDemographicsBannerDisplay from './_SmallDemographicsBannerDisplay';

--- a/packages/terra-dialog/CHANGELOG.md
+++ b/packages/terra-dialog/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.7.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-dialog/package.json
+++ b/packages/terra-dialog/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-dialog/src/Dialog.jsx
+++ b/packages/terra-dialog/src/Dialog.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import Button from 'terra-button';
 import ContentContainer from 'terra-content-container';
 import styles from './Dialog.module.scss';

--- a/packages/terra-divider/CHANGELOG.md
+++ b/packages/terra-divider/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.4.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-divider/package.json
+++ b/packages/terra-divider/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-divider/src/Divider.jsx
+++ b/packages/terra-divider/src/Divider.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Divider.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-doc-template/package.json
+++ b/packages/terra-doc-template/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-dynamic-grid/CHANGELOG.md
+++ b/packages/terra-dynamic-grid/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.4.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-dynamic-grid/package.json
+++ b/packages/terra-dynamic-grid/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "aphrodite": "^2.2.2",

--- a/packages/terra-dynamic-grid/src/DynamicGrid.jsx
+++ b/packages/terra-dynamic-grid/src/DynamicGrid.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { StyleSheet, css } from 'aphrodite';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import 'terra-base/lib/baseStyles';
 import { grid } from './styles';
 import Region from './Region';
 import styles from './DynamicGrid.module.scss';

--- a/packages/terra-dynamic-grid/src/Region.jsx
+++ b/packages/terra-dynamic-grid/src/Region.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, css } from 'aphrodite';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './DynamicGrid.module.scss';
 import style from './Region.module.scss';
 import { region } from './styles';

--- a/packages/terra-form-checkbox/CHANGELOG.md
+++ b/packages/terra-form-checkbox/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.6.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-form-checkbox/package.json
+++ b/packages/terra-form-checkbox/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-form-checkbox/src/Checkbox.jsx
+++ b/packages/terra-form-checkbox/src/Checkbox.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Checkbox.module.scss';
 import CheckboxUtil from './CheckboxUtil';
 

--- a/packages/terra-form-checkbox/src/CheckboxField.jsx
+++ b/packages/terra-form-checkbox/src/CheckboxField.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './CheckboxField.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-form-field/CHANGELOG.md
+++ b/packages/terra-form-field/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.5.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-form-field/package.json
+++ b/packages/terra-form-field/package.json
@@ -20,13 +20,10 @@
     "url": "https://github.com/cerner/terra-core/issues"
   },
   "homepage": "https://github.com/cerner/terra-core#readme",
-  "devDependencies": {
-    "react-intl": "^2.4.0"
-  },
   "peerDependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-intl": "^2.8.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-form-field/src/Field.jsx
+++ b/packages/terra-form-field/src/Field.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import IconError from 'terra-icon/lib/icon/IconError';
-import 'terra-base/lib/baseStyles';
 import styles from './Field.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-form-fieldset/CHANGELOG.md
+++ b/packages/terra-form-fieldset/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.8.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-form-fieldset/package.json
+++ b/packages/terra-form-fieldset/package.json
@@ -20,13 +20,10 @@
     "url": "https://github.com/cerner/terra-core/issues"
   },
   "homepage": "https://github.com/cerner/terra-core#readme",
-  "devDependencies": {
-    "react-intl": "^2.4.0"
-  },
   "peerDependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-intl": "^2.8.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-form-fieldset/src/Fieldset.jsx
+++ b/packages/terra-form-fieldset/src/Fieldset.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 
-import 'terra-base/lib/baseStyles';
 import styles from './Fieldset.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-form-input/CHANGELOG.md
+++ b/packages/terra-form-input/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.7.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-form-input/package.json
+++ b/packages/terra-form-input/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-form-input/src/Input.jsx
+++ b/packages/terra-form-input/src/Input.jsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Input.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-form-radio/CHANGELOG.md
+++ b/packages/terra-form-radio/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.7.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-form-radio/package.json
+++ b/packages/terra-form-radio/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-form-radio/src/Radio.jsx
+++ b/packages/terra-form-radio/src/Radio.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Radio.module.scss';
 import RadioUtil from './_RadioUtil';
 

--- a/packages/terra-form-radio/src/RadioField.jsx
+++ b/packages/terra-form-radio/src/RadioField.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './RadioField.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 5.10.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-form-select/package.json
+++ b/packages/terra-form-select/package.json
@@ -21,13 +21,10 @@
     "url": "https://github.com/cerner/terra-core/issues"
   },
   "homepage": "https://github.com/cerner/terra-core#readme",
-  "devDependencies": {
-    "react-intl": "^2.4.0"
-  },
   "peerDependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-intl": "^2.8.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-form-select/src/_Frame.jsx
+++ b/packages/terra-form-select/src/_Frame.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import KeyCode from 'keycode-js';
 import Variants from './_constants';
 import Dropdown from './_Dropdown';

--- a/packages/terra-form-select/src/_Menu.jsx
+++ b/packages/terra-form-select/src/_Menu.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { polyfill } from 'react-lifecycles-compat';
-import 'terra-base/lib/baseStyles';
 import KeyCode from 'keycode-js';
 import Variants from './_constants';
 import AddOption from './_AddOption';

--- a/packages/terra-form-select/src/_OptGroup.jsx
+++ b/packages/terra-form-select/src/_OptGroup.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './_OptGroup.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-form-select/src/_Option.jsx
+++ b/packages/terra-form-select/src/_Option.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './_Option.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-form-textarea/CHANGELOG.md
+++ b/packages/terra-form-textarea/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.7.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-form-textarea/package.json
+++ b/packages/terra-form-textarea/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-form-textarea/src/Textarea.jsx
+++ b/packages/terra-form-textarea/src/Textarea.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 
 import styles from './Textarea.module.scss';
 

--- a/packages/terra-grid/CHANGELOG.md
+++ b/packages/terra-grid/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 5.6.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-grid/package.json
+++ b/packages/terra-grid/package.json
@@ -33,8 +33,7 @@
   },
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-grid/src/Grid.jsx
+++ b/packages/terra-grid/src/Grid.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import 'terra-base/lib/baseStyles';
 import GridRow from './GridRow';
 import GridColumn from './GridColumn';
 

--- a/packages/terra-grid/src/GridColumn.jsx
+++ b/packages/terra-grid/src/GridColumn.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Grid.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-grid/src/GridRow.jsx
+++ b/packages/terra-grid/src/GridRow.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Grid.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-heading/CHANGELOG.md
+++ b/packages/terra-heading/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 4.1.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-heading/package.json
+++ b/packages/terra-heading/package.json
@@ -23,8 +23,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-heading/src/Heading.jsx
+++ b/packages/terra-heading/src/Heading.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Heading.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-hyperlink/CHANGELOG.md
+++ b/packages/terra-hyperlink/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.6.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-hyperlink/package.json
+++ b/packages/terra-hyperlink/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-hyperlink/src/Hyperlink.jsx
+++ b/packages/terra-hyperlink/src/Hyperlink.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import KeyCode from 'keycode-js';
-import 'terra-base/lib/baseStyles';
 import styles from './Hyperlink.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-i18n/package.json
+++ b/packages/terra-i18n/package.json
@@ -39,7 +39,7 @@
     "intl": "^1.2.5",
     "lodash.startcase": "^4.4.0",
     "prop-types": "^15.5.8",
-    "react-intl": "^2.4.0",
+    "react-intl": "^2.8.0",
     "terra-doc-template": "^2.6.0"
   },
   "scripts": {

--- a/packages/terra-icon/CHANGELOG.md
+++ b/packages/terra-icon/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.5.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-icon/package.json
+++ b/packages/terra-icon/package.json
@@ -28,8 +28,7 @@
   },
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-icon/src/IconBase.jsx
+++ b/packages/terra-icon/src/IconBase.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 
 // eslint-disable-next-line import/no-unresolved, import/no-webpack-loader-syntax
 import styles from './Icon.module.scss';

--- a/packages/terra-image/CHANGELOG.md
+++ b/packages/terra-image/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.4.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-image/package.json
+++ b/packages/terra-image/package.json
@@ -33,8 +33,7 @@
   },
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-image/src/Image.jsx
+++ b/packages/terra-image/src/Image.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Image.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 4.2.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-list/package.json
+++ b/packages/terra-list/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-list/src/List.jsx
+++ b/packages/terra-list/src/List.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './List.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-list/src/ListItem.jsx
+++ b/packages/terra-list/src/ListItem.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import ChevronRight from 'terra-icon/lib/icon/IconChevronRight';
 import ListUtils from './ListUtils';
 import styles from './List.module.scss';

--- a/packages/terra-list/src/ListSection.jsx
+++ b/packages/terra-list/src/ListSection.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import 'terra-base/lib/baseStyles';
 import SectionHeader from './ListSectionHeader';
 
 const propTypes = {

--- a/packages/terra-list/src/ListSectionHeader.jsx
+++ b/packages/terra-list/src/ListSectionHeader.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import ListUtils from './ListUtils';
 import styles from './ListSectionHeader.module.scss';
 

--- a/packages/terra-list/src/ListSubsection.jsx
+++ b/packages/terra-list/src/ListSubsection.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import 'terra-base/lib/baseStyles';
 import SubsectionHeader from './ListSubsectionHeader';
 
 const propTypes = {

--- a/packages/terra-list/src/ListSubsectionHeader.jsx
+++ b/packages/terra-list/src/ListSubsectionHeader.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import ListUtils from './ListUtils';
 import styles from './ListSubsectionHeader.module.scss';
 

--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.7.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-overlay/package.json
+++ b/packages/terra-overlay/package.json
@@ -20,13 +20,10 @@
     "url": "https://github.com/cerner/terra-core/issues"
   },
   "homepage": "https://github.com/cerner/terra-core#readme",
-  "devDependencies": {
-    "react-intl": "^2.4.0"
-  },
   "peerDependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-intl": "^2.8.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-overlay/src/LoadingOverlay.jsx
+++ b/packages/terra-overlay/src/LoadingOverlay.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import IconSpinner from 'terra-icon/lib/icon/IconSpinner';
-import 'terra-base/lib/baseStyles';
 
 import Overlay from './Overlay';
 import styles from './Overlay.module.scss';

--- a/packages/terra-overlay/src/Overlay.jsx
+++ b/packages/terra-overlay/src/Overlay.jsx
@@ -4,7 +4,6 @@ import classNames from 'classnames/bind';
 import FocusTrap from 'focus-trap-react';
 import { Portal } from 'react-portal';
 import KeyCode from 'keycode-js';
-import 'terra-base/lib/baseStyles';
 import styles from './Overlay.module.scss';
 import Container from './OverlayContainer';
 

--- a/packages/terra-overlay/src/OverlayContainer.jsx
+++ b/packages/terra-overlay/src/OverlayContainer.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Overlay.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-paginator/CHANGELOG.md
+++ b/packages/terra-paginator/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.8.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-paginator/package.json
+++ b/packages/terra-paginator/package.json
@@ -25,8 +25,7 @@
   },
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-paginator/src/ControlledPaginator.jsx
+++ b/packages/terra-paginator/src/ControlledPaginator.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import ResponsiveElement from 'terra-responsive-element';
-import 'terra-base/lib/baseStyles';
 import KeyCode from 'keycode-js';
 import styles from './Paginator.module.scss';
 import { calculatePages, pageSet } from './_paginationUtils';

--- a/packages/terra-paginator/src/ControlledProgressivePaginator.jsx
+++ b/packages/terra-paginator/src/ControlledProgressivePaginator.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import ResponsiveElement from 'terra-responsive-element';
-import 'terra-base/lib/baseStyles';
 import KeyCode from 'keycode-js';
 import styles from './Paginator.module.scss';
 import { calculatePages } from './_paginationUtils';

--- a/packages/terra-paginator/src/Paginator.jsx
+++ b/packages/terra-paginator/src/Paginator.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import ResponsiveElement from 'terra-responsive-element';
-import 'terra-base/lib/baseStyles';
 import KeyCode from 'keycode-js';
 import styles from './Paginator.module.scss';
 import { calculatePages, pageSet } from './_paginationUtils';

--- a/packages/terra-paginator/src/ProgressivePaginator.jsx
+++ b/packages/terra-paginator/src/ProgressivePaginator.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import ResponsiveElement from 'terra-responsive-element';
-import 'terra-base/lib/baseStyles';
 import KeyCode from 'keycode-js';
 import styles from './Paginator.module.scss';
 

--- a/packages/terra-profile-image/CHANGELOG.md
+++ b/packages/terra-profile-image/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.4.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-profile-image/package.json
+++ b/packages/terra-profile-image/package.json
@@ -33,8 +33,7 @@
   },
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-profile-image/src/ProfileImage.jsx
+++ b/packages/terra-profile-image/src/ProfileImage.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import TerraImage from 'terra-image';
 import styles from './ProfileImage.module.scss';
 

--- a/packages/terra-progress-bar/CHANGELOG.md
+++ b/packages/terra-progress-bar/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 4.1.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-progress-bar/package.json
+++ b/packages/terra-progress-bar/package.json
@@ -34,7 +34,6 @@
   "peerDependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0",
     "terra-markdown": "^2.20.0"
   },
   "dependencies": {

--- a/packages/terra-progress-bar/src/ProgressBar.jsx
+++ b/packages/terra-progress-bar/src/ProgressBar.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './ProgressBar.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-responsive-element/CHANGELOG.md
+++ b/packages/terra-responsive-element/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 4.4.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-responsive-element/package.json
+++ b/packages/terra-responsive-element/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "prop-types": "^15.5.8",

--- a/packages/terra-responsive-element/src/ResponsiveElement.jsx
+++ b/packages/terra-responsive-element/src/ResponsiveElement.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ResizeObserver from 'resize-observer-polyfill';
-import 'terra-base/lib/baseStyles';
 import breakpoints from './breakpoints.module.scss';
 
 const DependentViewport = {

--- a/packages/terra-scroll/CHANGELOG.md
+++ b/packages/terra-scroll/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.5.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-scroll/package.json
+++ b/packages/terra-scroll/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-scroll/src/Scroll.jsx
+++ b/packages/terra-scroll/src/Scroll.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Scroll.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-search-field/CHANGELOG.md
+++ b/packages/terra-search-field/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.7.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-search-field/package.json
+++ b/packages/terra-search-field/package.json
@@ -20,13 +20,10 @@
     "url": "https://github.com/cerner/terra-core/issues"
   },
   "homepage": "https://github.com/cerner/terra-core#readme",
-  "devDependencies": {
-    "react-intl": "^2.3.0"
-  },
   "peerDependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-intl": "^2.8.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-search-field/src/SearchField.jsx
+++ b/packages/terra-search-field/src/SearchField.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import Button from 'terra-button';
 import KeyCode from 'keycode-js';
 import IconSearch from 'terra-icon/lib/icon/IconSearch';

--- a/packages/terra-section-header/CHANGELOG.md
+++ b/packages/terra-section-header/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.7.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-section-header/package.json
+++ b/packages/terra-section-header/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-section-header/src/SectionHeader.jsx
+++ b/packages/terra-section-header/src/SectionHeader.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import KeyCode from 'keycode-js';
-import 'terra-base/lib/baseStyles';
 import Arrange from 'terra-arrange';
 import styles from './SectionHeader.module.scss';
 

--- a/packages/terra-show-hide/CHANGELOG.md
+++ b/packages/terra-show-hide/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Import `injectIntl` and `intlShape` from react-intl instead of terra-base
+
 ### Removed
 * Removed peer dependency on terra-base
 * Removed baseStyles import from terra-base

--- a/packages/terra-show-hide/CHANGELOG.md
+++ b/packages/terra-show-hide/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.6.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-show-hide/package.json
+++ b/packages/terra-show-hide/package.json
@@ -21,13 +21,12 @@
   },
   "homepage": "https://github.com/cerner/terra-core#readme",
   "devDependencies": {
-    "react-intl": "^2.4.0",
     "react-test-renderer": "^16.5.2"
   },
   "peerDependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-intl": "^2.8.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-show-hide/src/ShowHide.jsx
+++ b/packages/terra-show-hide/src/ShowHide.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Toggle from 'terra-toggle';
-import { injectIntl, intlShape } from 'terra-base';
+import { injectIntl, intlShape } from 'react-intl';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './ShowHide.module.scss';
 import Button from './_ShowHideButton';
 

--- a/packages/terra-show-hide/src/_ShowHideButton.jsx
+++ b/packages/terra-show-hide/src/_ShowHideButton.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import KeyCode from 'keycode-js';
-import 'terra-base/lib/baseStyles';
 import styles from './_ShowHideButton.module.scss';
 
 

--- a/packages/terra-signature/CHANGELOG.md
+++ b/packages/terra-signature/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.8.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-signature/package.json
+++ b/packages/terra-signature/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-signature/src/Signature.jsx
+++ b/packages/terra-signature/src/Signature.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import 'terra-base/lib/baseStyles';
 import styles from './Signature.module.scss';
 
 const LINEWIDTHS = {

--- a/packages/terra-spacer/CHANGELOG.md
+++ b/packages/terra-spacer/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.5.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-spacer/package.json
+++ b/packages/terra-spacer/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-spacer/src/Spacer.jsx
+++ b/packages/terra-spacer/src/Spacer.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Spacer.module.scss';
 
 import { mapShorthandToObject, shorthandValidator } from './_spacerShorthandUtils';

--- a/packages/terra-status-view/CHANGELOG.md
+++ b/packages/terra-status-view/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.7.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-status-view/package.json
+++ b/packages/terra-status-view/package.json
@@ -34,10 +34,7 @@
   "peerDependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
-  },
-  "devDependencies": {
-    "react-intl": "^2.3.0"
+    "react-intl": "^2.8.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-status-view/src/StatusView.jsx
+++ b/packages/terra-status-view/src/StatusView.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import Divider from 'terra-divider';
 import styles from './StatusView.module.scss';
 

--- a/packages/terra-status/CHANGELOG.md
+++ b/packages/terra-status/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 4.1.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-status/package.json
+++ b/packages/terra-status/package.json
@@ -33,8 +33,7 @@
   },
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-status/src/Status.jsx
+++ b/packages/terra-status/src/Status.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import VisuallyHiddenText from 'terra-visually-hidden-text';
-import 'terra-base/lib/baseStyles';
 import styles from './Status.module.scss';
 
 

--- a/packages/terra-table/CHANGELOG.md
+++ b/packages/terra-table/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.7.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-table/package.json
+++ b/packages/terra-table/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-table/src/MultiSelectableRows.jsx
+++ b/packages/terra-table/src/MultiSelectableRows.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import 'terra-base/lib/baseStyles';
 import SelectableTableRows from './SelectableTableRows';
 
 const propTypes = {

--- a/packages/terra-table/src/SelectableTableRows.jsx
+++ b/packages/terra-table/src/SelectableTableRows.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import KeyCode from 'keycode-js';
-import 'terra-base/lib/baseStyles';
 import TableRows from './TableRows';
 import TableRow from './TableRow';
 import TableHeader from './TableHeader';

--- a/packages/terra-table/src/SingleSelectableRows.jsx
+++ b/packages/terra-table/src/SingleSelectableRows.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import 'terra-base/lib/baseStyles';
 import SelectableTableRows from './SelectableTableRows';
 
 const propTypes = {

--- a/packages/terra-table/src/Table.jsx
+++ b/packages/terra-table/src/Table.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import TableHeader from './TableHeader';
 import TableHeaderCell from './TableHeaderCell';
 import TableRows from './TableRows';

--- a/packages/terra-table/src/TableCell.jsx
+++ b/packages/terra-table/src/TableCell.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import 'terra-base/lib/baseStyles';
 
 const propTypes = {
   /**

--- a/packages/terra-table/src/TableHeader.jsx
+++ b/packages/terra-table/src/TableHeader.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import 'terra-base/lib/baseStyles';
 
 const propTypes = {
   /**

--- a/packages/terra-table/src/TableHeaderCell.jsx
+++ b/packages/terra-table/src/TableHeaderCell.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import IconDown from 'terra-icon/lib/icon/IconCaretDown';
 import IconUp from 'terra-icon/lib/icon/IconCaretUp';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Table.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-table/src/TableRow.jsx
+++ b/packages/terra-table/src/TableRow.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Table.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-table/src/TableRows.jsx
+++ b/packages/terra-table/src/TableRows.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import 'terra-base/lib/baseStyles';
 import TableRow from './TableRow';
 import TableSubheader from './TableSubheader';
 

--- a/packages/terra-table/src/TableSubheader.jsx
+++ b/packages/terra-table/src/TableSubheader.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Table.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-tag/CHANGELOG.md
+++ b/packages/terra-tag/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.7.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-tag/package.json
+++ b/packages/terra-tag/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-tag/src/Tag.jsx
+++ b/packages/terra-tag/src/Tag.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import KeyCode from 'keycode-js';
-import 'terra-base/lib/baseStyles';
 import styles from './Tag.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-text/CHANGELOG.md
+++ b/packages/terra-text/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 4.1.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-text/package.json
+++ b/packages/terra-text/package.json
@@ -23,8 +23,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-text/src/Text.jsx
+++ b/packages/terra-text/src/Text.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './Text.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-toggle-button/CHANGELOG.md
+++ b/packages/terra-toggle-button/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.5.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-toggle-button/package.json
+++ b/packages/terra-toggle-button/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-toggle-button/src/ToggleButton.jsx
+++ b/packages/terra-toggle-button/src/ToggleButton.jsx
@@ -4,7 +4,6 @@ import classNames from 'classnames/bind';
 import Button from 'terra-button';
 import IconChevronRight from 'terra-icon/lib/icon/IconChevronRight';
 import Toggle from 'terra-toggle';
-import 'terra-base/lib/baseStyles';
 import styles from './ToggleButton.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-toggle-section-header/CHANGELOG.md
+++ b/packages/terra-toggle-section-header/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.5.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-toggle-section-header/package.json
+++ b/packages/terra-toggle-section-header/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-toggle-section-header/src/ToggleSectionHeader.jsx
+++ b/packages/terra-toggle-section-header/src/ToggleSectionHeader.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import 'terra-base/lib/baseStyles';
 import SectionHeader from 'terra-section-header';
 import Toggle from 'terra-toggle';
 

--- a/packages/terra-toggle/CHANGELOG.md
+++ b/packages/terra-toggle/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 3.5.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-toggle/package.json
+++ b/packages/terra-toggle/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-toggle/src/Toggle.jsx
+++ b/packages/terra-toggle/src/Toggle.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import AnimateHeight from 'react-animate-height';
-import 'terra-base/lib/baseStyles';
 import styles from './Toggle.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-visually-hidden-text/CHANGELOG.md
+++ b/packages/terra-visually-hidden-text/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed peer dependency on terra-base
+* Removed baseStyles import from terra-base
 
 2.4.0 - (March 21, 2019)
 ------------------

--- a/packages/terra-visually-hidden-text/package.json
+++ b/packages/terra-visually-hidden-text/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/terra-visually-hidden-text/src/VisuallyHiddenText.jsx
+++ b/packages/terra-visually-hidden-text/src/VisuallyHiddenText.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './VisuallyHiddenText.module.scss';
 
 const cx = classNames.bind(styles);


### PR DESCRIPTION
### Summary
Resolves #2291 

* Removes terra-base as a peer dependency across all packages
* Removes import of baseStyles across all packages except terra-base
* Moves react-intl to peerDependency in packages where it was listed as a devDependency
* Normalize react-intl peerDependency version to be consistent across packages: `^2.8.0`