### PR TITLE
Show browser-native tooltip upon hovering over a icon-only button.

### DIFF
--- a/packages/terra-button/CHANGELOG.md
+++ b/packages/terra-button/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ----------
 
+### Added
+* Added `title` attribute to the icon-only button to show browser-native tooltip.
+
 ### Fixed
 * Reset default margin in Safari.
 

--- a/packages/terra-button/src/Button.jsx
+++ b/packages/terra-button/src/Button.jsx
@@ -77,6 +77,7 @@ const propTypes = {
   refCallback: PropTypes.func,
   /**
    * Sets the button text. If the button `isIconOnly` or of variant `utility`, this text is set as the aria-label for accessibility.
+   * It is also used to reveal the label to the user via the browser-native tooltip upon hovering over a `isIconOnly` button.
    */
   text: PropTypes.string.isRequired,
   /**
@@ -233,6 +234,7 @@ class Button extends React.Component {
         onKeyDown={this.handleKeyDown}
         onKeyUp={this.handleKeyUp}
         onBlur={this.handleOnBlur}
+        title={isIconOnly ? text : null}
         onClick={onClick}
         onFocus={onFocus}
         href={href}

--- a/packages/terra-button/tests/jest/__snapshots__/Button.test.jsx.snap
+++ b/packages/terra-button/tests/jest/__snapshots__/Button.test.jsx.snap
@@ -48,6 +48,7 @@ exports[`should pass in refCallback as the ref prop of the input element 1`] = `
     onBlur={[Function]}
     onKeyDown={[Function]}
     onKeyUp={[Function]}
+    title={null}
     type="button"
   >
     <span
@@ -78,6 +79,7 @@ exports[`should render a Button with merged attributes 1`] = `
       "height": "100px",
     }
   }
+  title={null}
   type="button"
 >
   <span
@@ -101,6 +103,7 @@ exports[`should render a button with type equal to button 1`] = `
   onBlur={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
+  title={null}
   type="button"
 >
   <span
@@ -124,6 +127,7 @@ exports[`should render a button with type equal to reset 1`] = `
   onBlur={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
+  title={null}
   type="reset"
 >
   <span
@@ -147,6 +151,7 @@ exports[`should render a button with type equal to submit 1`] = `
   onBlur={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
+  title={null}
   type="submit"
 >
   <span
@@ -170,6 +175,7 @@ exports[`should render a de-emphasis button 1`] = `
   onBlur={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
+  title={null}
   type="button"
 >
   <span
@@ -193,6 +199,7 @@ exports[`should render a emphasis button 1`] = `
   onBlur={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
+  title={null}
   type="button"
 >
   <span
@@ -216,6 +223,7 @@ exports[`should render a neutral button 1`] = `
   onBlur={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
+  title={null}
   type="button"
 >
   <span
@@ -239,6 +247,7 @@ exports[`should render a utility button 1`] = `
   onBlur={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
+  title={null}
   type="button"
 >
   <span
@@ -256,6 +265,7 @@ exports[`should render an action button 1`] = `
   onBlur={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
+  title={null}
   type="button"
 >
   <span
@@ -279,6 +289,7 @@ exports[`should render an icon 1`] = `
   onBlur={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
+  title="isIconOnly"
   type="button"
 >
   <span
@@ -305,6 +316,7 @@ exports[`should render an icon and a text 1`] = `
   onBlur={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
+  title={null}
   type="button"
 >
   <span
@@ -337,6 +349,7 @@ exports[`should render as an anchor when provided an href 1`] = `
   onBlur={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
+  title={null}
   type="button"
 >
   <span
@@ -361,6 +374,7 @@ exports[`should render as disabled when set 1`] = `
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   tabIndex="-1"
+  title={null}
   type="button"
 >
   <span
@@ -384,6 +398,7 @@ exports[`should render text then an icon when reversed 1`] = `
   onBlur={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
+  title={null}
   type="button"
 >
   <span

--- a/packages/terra-search-field/tests/jest/__snapshots__/SearchField.test.jsx.snap
+++ b/packages/terra-search-field/tests/jest/__snapshots__/SearchField.test.jsx.snap
@@ -164,6 +164,7 @@ exports[`Snapshots passes in inputRefCallback as the refCallback prop of the Inp
         onClick={[Function]}
         onKeyDown={[Function]}
         onKeyUp={[Function]}
+        title="Terra.searchField.submit-search"
         type="button"
       >
         <span

--- a/packages/terra-status-view/tests/jest/__snapshots__/StatusView.test.jsx.snap
+++ b/packages/terra-status-view/tests/jest/__snapshots__/StatusView.test.jsx.snap
@@ -120,6 +120,7 @@ exports[`should render a single child element 1`] = `
             onBlur={[Function]}
             onKeyDown={[Function]}
             onKeyUp={[Function]}
+            title={null}
             type="button"
           >
             <span
@@ -569,6 +570,7 @@ exports[`should render an image with a no-data status view with all message prop
             onBlur={[Function]}
             onKeyDown={[Function]}
             onKeyUp={[Function]}
+            title={null}
             type="button"
           >
             <span
@@ -601,6 +603,7 @@ exports[`should render an image with a no-data status view with all message prop
             onBlur={[Function]}
             onKeyDown={[Function]}
             onKeyUp={[Function]}
+            title={null}
             type="button"
           >
             <span

--- a/packages/terra-toggle-button/tests/jest/__snapshots__/ToggleButton.test.jsx.snap
+++ b/packages/terra-toggle-button/tests/jest/__snapshots__/ToggleButton.test.jsx.snap
@@ -117,6 +117,7 @@ exports[`ToggleButton should render an icon only toggle-button 1`] = `
     aria-expanded="false"
     aria-label="Show"
     class="button neutral"
+    title="Show"
     type="button"
   >
     <span
@@ -259,6 +260,7 @@ exports[`ToggleButton should render an open toggle-button when clicked 1`] = `
         onClick={[Function]}
         onKeyDown={[Function]}
         onKeyUp={[Function]}
+        title={null}
         type="button"
       >
         <span


### PR DESCRIPTION
### Summary
Resolves #2304.

