### PR TITLE
Allow `hover` styles to apply over a list-item only on non-touch devices.

### DIFF
--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ----------
 
+### Added
+* Added an interaction media query to apply `hover` styles over a list-item only on non-touch devices.
+
 4.4.0 - (April 9, 2019)
 ------------------
 ### Changed

--- a/packages/terra-list/src/List.module.scss
+++ b/packages/terra-list/src/List.module.scss
@@ -92,7 +92,13 @@
     cursor: pointer;
     outline: var(--terra-list-item-focus-outline, none);
 
-    &:hover,
+    // Allow hover over a list-item _only_ when the primary input is a fine pointer device such as a mouse or stylus.
+    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none), (hover: hover) and (pointer: fine) {
+      &:hover {
+        background-color: var(--terra-list-item-hover-active-background-color, lighten(#ebf6fd, 2%));
+      }
+    }
+
     &:active {
       background-color: var(--terra-list-item-hover-active-background-color, lighten(#ebf6fd, 2%));
     }
@@ -107,8 +113,11 @@
       }
     }
 
-    &.selected:hover {
-      background-color: var(--terra-list-item-selected-hover-background-color, darken(#ebf6fd, 7%)) !important;
+    // Allow hover over a selected list-item _only_ when the primary input is a fine pointer device such as a mouse or stylus.
+    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none), (hover: hover) and (pointer: fine) {
+      &.selected:hover {
+        background-color: var(--terra-list-item-selected-hover-background-color, darken(#ebf6fd, 7%)) !important;
+      }
     }
   }
 


### PR DESCRIPTION
### Summary

Mobile WebKit makes the `:hover` CSS pseudo-selector 'sticky' (i.e. the hover styles remain on the tapped item until the user taps elsewhere). This PR resolves the issue by making use of `hover` and `pointer` interaction media features introduced in Media Queries Level 4 so that the hover styles are applied only on non-touch devices whose primary input is a fine pointer device such as a mouse or a stylus.

Resolves #2076. 

### Additional Details
References: 
- https://blog.usejournal.com/finally-a-css-only-solution-to-hover-on-touchscreens-c498af39c31c
- http://www.javascriptkit.com/dhtmltutors/sticky-hover-issue-solutions.shtml
- https://bugs.chromium.org/p/chromium/issues/detail?id=370155
- https://bugs.webkit.org/show_bug.cgi?id=158517

Note that the interaction media features `hover` and `pointer` are not supported on IE and it has been addressed by making use of `-ms-high-contrast`. 

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
