### PR TITLE
Added IE Specific Prefix style rule to fix Placeholder color

### DIFF
--- a/packages/terra-form-input/CHANGELOG.md
+++ b/packages/terra-form-input/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Fixed
-* Fixed Placeholder color for IE by adding vendor specific style rule
+* Faded the placeholder text on IE11 by adding vendor specific style rule.
 
 2.11.0 - (April 16, 2019)
 ------------------

--- a/packages/terra-form-input/CHANGELOG.md
+++ b/packages/terra-form-input/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed Placeholder color for IE by adding vendor specific style rule
 
 2.11.0 - (April 16, 2019)
 ------------------

--- a/packages/terra-form-input/CHANGELOG.md
+++ b/packages/terra-form-input/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Fixed
-* Faded the placeholder text on IE11 by adding vendor specific style rule.
+* Add vendor style rule for IE11 to fade placeholder text.
 
 2.11.0 - (April 16, 2019)
 ------------------

--- a/packages/terra-form-input/src/Input.module.scss
+++ b/packages/terra-form-input/src/Input.module.scss
@@ -28,11 +28,13 @@
     }
 
     /* TODO: Remove vendor prefix once we update to autoprefixer v9 */
+    /* Issue logged for updating Autoprefixer in Toolkit : https://github.com/cerner/terra-toolkit/issues/161 */
     /* stylelint-disable selector-no-vendor-prefix */
     &:-ms-input-placeholder {
       color: var(--terra-form-input-placeholder-color, #70787c);
       font-style: var(--terra-form-input-placeholder-font-style);
     }
+    /* stylelint-enable selector-no-vendor-prefix */
     /* End of vendor prefix */
 
     &:hover {

--- a/packages/terra-form-input/src/Input.module.scss
+++ b/packages/terra-form-input/src/Input.module.scss
@@ -26,12 +26,11 @@
       color: var(--terra-form-input-placeholder-color, #70787c);
       font-style: var(--terra-form-input-placeholder-font-style);
     }
-    
+
     /* TODO: Remove vendor prefix once we update to autoprefixer v9 */
-    /* stylelint-disable declaration-colon-space-after */
     /* stylelint-disable selector-no-vendor-prefix */
     &:-ms-input-placeholder {
-      color:var(--terra-form-input-placeholder-color, #70787c);
+      color: var(--terra-form-input-placeholder-color, #70787c);
       font-style: var(--terra-form-input-placeholder-font-style);
     }
     /* End of vendor prefix */

--- a/packages/terra-form-input/src/Input.module.scss
+++ b/packages/terra-form-input/src/Input.module.scss
@@ -26,6 +26,15 @@
       color: var(--terra-form-input-placeholder-color, #70787c);
       font-style: var(--terra-form-input-placeholder-font-style);
     }
+    
+    /* TODO: Remove vendor prefix once we update to autoprefixer v9 */
+    /* stylelint-disable declaration-colon-space-after */
+    /* stylelint-disable selector-no-vendor-prefix */
+    &:-ms-input-placeholder {
+      color:var(--terra-form-input-placeholder-color, #70787c);
+      font-style: var(--terra-form-input-placeholder-font-style);
+    }
+    /* End of vendor prefix */
 
     &:hover {
       background-color: var(--terra-form-input-hover-background-color, #fff);

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Fixed
-* Faded the placeholder text on IE11 by adding vendor specific style rule.
+* Add vendor style rule for IE11 to fade placeholder text.
 
 5.14.0 - (April 16, 2019)
 ------------------

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed Placeholder color for IE by adding vendor specific style rule
 
 5.14.0 - (April 16, 2019)
 ------------------

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Fixed
-* Fixed Placeholder color for IE by adding vendor specific style rule
+* Faded the placeholder text on IE11 by adding vendor specific style rule.
 
 5.14.0 - (April 16, 2019)
 ------------------

--- a/packages/terra-form-select/src/_Frame.module.scss
+++ b/packages/terra-form-select/src/_Frame.module.scss
@@ -231,7 +231,6 @@
   }
 
   /* TODO: Remove vendor prefix once we update to autoprefixer v9 */
-  /* stylelint-disable declaration-colon-space-after */
   /* stylelint-disable selector-no-vendor-prefix */
   .search-input,
   .placeholder,

--- a/packages/terra-form-select/src/_Frame.module.scss
+++ b/packages/terra-form-select/src/_Frame.module.scss
@@ -230,6 +230,21 @@
     white-space: nowrap;
   }
 
+  /* TODO: Remove vendor prefix once we update to autoprefixer v9 */
+  /* stylelint-disable declaration-colon-space-after */
+  /* stylelint-disable selector-no-vendor-prefix */
+  .search-input,
+  .placeholder,
+  :-ms-input-placeholder {
+    color: var(--terra-form-select-search-placeholder-color, #70787c);
+    font-size: var(--terra-form-select-search-placeholder-font-size, 1.143rem);
+    font-style: var(--terra-form-select-search-placeholder-font-style);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  /* End of vendor prefix */
+
   .tag,
   .search,
   .combobox,

--- a/packages/terra-form-select/src/_Frame.module.scss
+++ b/packages/terra-form-select/src/_Frame.module.scss
@@ -231,6 +231,7 @@
   }
 
   /* TODO: Remove vendor prefix once we update to autoprefixer v9 */
+  /* Issue loggedd for updating Autoprefixer in Toolkit : https://github.com/cerner/terra-toolkit/issues/161 */
   /* stylelint-disable selector-no-vendor-prefix */
   .search-input,
   .placeholder,
@@ -242,6 +243,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+  /* stylelint-enable selector-no-vendor-prefix */
   /* End of vendor prefix */
 
   .tag,

--- a/packages/terra-form-textarea/CHANGELOG.md
+++ b/packages/terra-form-textarea/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Fixed
-* Fixed Placeholder color for IE by adding vendor specific style rule
+* Faded the placeholder text on IE11 by adding vendor specific style rule.
 
 3.11.0 - (April 16, 2019)
 ------------------

--- a/packages/terra-form-textarea/CHANGELOG.md
+++ b/packages/terra-form-textarea/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed Placeholder color for IE by adding vendor specific style rule
 
 3.11.0 - (April 16, 2019)
 ------------------

--- a/packages/terra-form-textarea/CHANGELOG.md
+++ b/packages/terra-form-textarea/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Fixed
-* Faded the placeholder text on IE11 by adding vendor specific style rule.
+* Add vendor style rule for IE11 to fade placeholder text.
 
 3.11.0 - (April 16, 2019)
 ------------------

--- a/packages/terra-form-textarea/src/Textarea.module.scss
+++ b/packages/terra-form-textarea/src/Textarea.module.scss
@@ -38,6 +38,15 @@
       font-style: var(--terra-form-textarea-placeholder-font-style);
     }
 
+    /* TODO: Remove vendor prefix once we update to autoprefixer v9 */
+    /* stylelint-disable declaration-colon-space-after */
+    /* stylelint-disable selector-no-vendor-prefix */
+    &:-ms-input-placeholder {
+      color: var(--terra-form-textarea-placeholder-color, #70787c);
+      font-style: var(--terra-form-textarea-placeholder-font-style);
+    }
+    /* End of vendor prefix */
+
     &[required] {
       box-shadow: unset;
     }

--- a/packages/terra-form-textarea/src/Textarea.module.scss
+++ b/packages/terra-form-textarea/src/Textarea.module.scss
@@ -39,7 +39,6 @@
     }
 
     /* TODO: Remove vendor prefix once we update to autoprefixer v9 */
-    /* stylelint-disable declaration-colon-space-after */
     /* stylelint-disable selector-no-vendor-prefix */
     &:-ms-input-placeholder {
       color: var(--terra-form-textarea-placeholder-color, #70787c);

--- a/packages/terra-form-textarea/src/Textarea.module.scss
+++ b/packages/terra-form-textarea/src/Textarea.module.scss
@@ -39,11 +39,13 @@
     }
 
     /* TODO: Remove vendor prefix once we update to autoprefixer v9 */
+    /* Issue logged for updating Autoprefixer in Toolkit : https://github.com/cerner/terra-toolkit/issues/161 */
     /* stylelint-disable selector-no-vendor-prefix */
     &:-ms-input-placeholder {
       color: var(--terra-form-textarea-placeholder-color, #70787c);
       font-style: var(--terra-form-textarea-placeholder-font-style);
     }
+    /* stylelint-enable selector-no-vendor-prefix */
     /* End of vendor prefix */
 
     &[required] {


### PR DESCRIPTION
### Summary
Autoprefixer V8.5.2 is not providing vendor specific code for psuedo elements in IE. So added  vendor specific code to fix the placeholder color issue until the Autoprefixer v9 or above is available in terra-toolkit

Resolves : #2198 

Thanks for contributing to Terra. 
@cerner/terra
