### PR TITLE
Update gh-pages DevDep Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "enzyme-to-json": "^3.2.2",
     "eslint": "^5.0.0",
     "eslint-config-terra": "^2.0.0",
-    "gh-pages": "^1.1.0",
+    "gh-pages": "^2.0.1",
     "glob": "^7.1.2",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^23.1.0",


### PR DESCRIPTION
### Summary
This updated the gh-pages devDependency to ^2.0.1. 

Closes [#2275](https://github.com/cerner/terra-core/issues/2275)