### PR TITLE
[terra-table] Exclude subheader from zebra row styles.

### DIFF
--- a/packages/terra-table/CHANGELOG.md
+++ b/packages/terra-table/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Exclude subheader from zebra row styles.
 
 3.11.0 - (May 1, 2019)
 ------------------

--- a/packages/terra-table/src/Table.module.scss
+++ b/packages/terra-table/src/Table.module.scss
@@ -142,7 +142,7 @@
   }
 
   .striped {
-    tbody tr {
+    tbody tr:not([data-terra-table-subheader-row]){
       &:nth-of-type(even) {
         background-color: var(--terra-table-row-striped-background-color, #f4f4f4);
       }

--- a/packages/terra-table/src/Table.module.scss
+++ b/packages/terra-table/src/Table.module.scss
@@ -142,7 +142,7 @@
   }
 
   .striped {
-    tbody tr:not([data-terra-table-subheader-row]){
+    tbody tr:not([data-terra-table-subheader-row]) {
       &:nth-of-type(even) {
         background-color: var(--terra-table-row-striped-background-color, #f4f4f4);
       }


### PR DESCRIPTION
### Summary
Closes https://github.com/cerner/terra-core/issues/2376. 

With this change, subheaders will not receive stripe row styles.
