### PR TITLE
[terra-demographics-banner] Set background-clip to border-box

### DIFF
--- a/packages/terra-demographics-banner/CHANGELOG.md
+++ b/packages/terra-demographics-banner/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Update background-clip to border-box
 
 3.10.0 - (May 1, 2019)
 ------------------

--- a/packages/terra-demographics-banner/src/DemographicsBanner.module.scss
+++ b/packages/terra-demographics-banner/src/DemographicsBanner.module.scss
@@ -1,6 +1,6 @@
 :local {
   .demographics-banner {
-    background-clip: padding-box;
+    background-clip: border-box;
     background-color: var(--terra-demographics-banner-background-color, #004c76);
     background-image: var(--terra-demographics-banner-background-image);
     box-shadow: var(--terra-demographics-banner-box-shadow);
@@ -58,7 +58,7 @@
   }
 
   .deceased {
-    background-clip: padding-box;
+    background-clip: border-box;
     background-color: var(--terra-demographics-banner-deceased-background-color, #1c1f21);
     background-image: var(--terra-demographics-banner-deceased-background-image);
     color: var(--terra-demographics-banner-deceased-color, #fff);


### PR DESCRIPTION
### Summary
Closes https://github.com/cerner/terra-core/issues/2079

Chrome has sub pixel rendering issues. Setting `background-clip: border-box` allows the background-image to extend to the border and fully mask the background-color.
