### PR TITLE
Add visually hidden dropdown to help improve navigation experience on iOS VoiceOver

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added visually hidden dropdown to help make gesture navigation while using VoiceOver on iOS more intuitive when using select variants that allow text entry
 
 5.15.0 - (May 1, 2019)
 ------------------

--- a/packages/terra-form-select/src/_Dropdown.jsx
+++ b/packages/terra-form-select/src/_Dropdown.jsx
@@ -98,7 +98,9 @@ const Dropdown = ({
           onMouseDown={preventDefault}
           refCallback={refCallback}
         >
-          {children}
+          <div aria-hidden="true">
+            {children}
+          </div>
         </Hookshot.Content>
       </Hookshot>
     </React.Fragment>

--- a/packages/terra-form-select/src/_Dropdown.jsx
+++ b/packages/terra-form-select/src/_Dropdown.jsx
@@ -79,6 +79,18 @@ const Dropdown = ({
     );
   }
 
+  /**
+   * Visual dropdown rendered in portal to avoid overflow clipping issues with overflow:hidden ancestor styles
+   */
+  let visualDropdown = (<div>{children}</div>);
+  if (SharedUtil.isSafari() && ('ontouchstart' in window)) {
+    visualDropdown = (
+      <div aria-hidden="true">
+        {children}
+      </div>
+    );
+  }
+
   return (
     <React.Fragment>
       {visuallyHiddenDropdown}
@@ -98,9 +110,7 @@ const Dropdown = ({
           onMouseDown={preventDefault}
           refCallback={refCallback}
         >
-          <div aria-hidden="true">
-            {children}
-          </div>
+          {visualDropdown}
         </Hookshot.Content>
       </Hookshot>
     </React.Fragment>

--- a/packages/terra-form-select/src/_Dropdown.jsx
+++ b/packages/terra-form-select/src/_Dropdown.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Hookshot from 'terra-hookshot';
 import classNames from 'classnames/bind';
 import styles from './_Dropdown.module.scss';
+import SharedUtil from './_SharedUtil';
 
 const cx = classNames.bind(styles);
 
@@ -65,26 +66,42 @@ const Dropdown = ({
     customProps.className,
   ]);
 
-  return (
-    <Hookshot
-      isOpen
-      isEnabled={isEnabled}
-      targetRef={() => target}
-      attachmentBehavior="none"
-      contentAttachment={isAbove ? AboveAttachment : BelowAttachment}
-      targetAttachment={isAbove ? BelowAttachment : AboveAttachment}
-    >
-      <Hookshot.Content
-        {...customProps}
-        disableOnClickOutside
-        className={dropdownClasses}
-        onResize={onResize}
-        onMouseDown={preventDefault}
-        refCallback={refCallback}
-      >
+  /**
+   * Visually hidden dropdown allows for more intuitive dropdown navigation when using gestures to navigate
+   * the dropdown options while using VoiceOver on iOS.
+   */
+  let visuallyHiddenDropdown;
+  if (SharedUtil.isSafari() && ('ontouchstart' in window)) {
+    visuallyHiddenDropdown = (
+      <div className={styles['visually-hidden-dropdown']}>
         {children}
-      </Hookshot.Content>
-    </Hookshot>
+      </div>
+    );
+  }
+
+  return (
+    <React.Fragment>
+      {visuallyHiddenDropdown}
+      <Hookshot
+        isOpen
+        isEnabled={isEnabled}
+        targetRef={() => target}
+        attachmentBehavior="none"
+        contentAttachment={isAbove ? AboveAttachment : BelowAttachment}
+        targetAttachment={isAbove ? BelowAttachment : AboveAttachment}
+      >
+        <Hookshot.Content
+          {...customProps}
+          disableOnClickOutside
+          className={dropdownClasses}
+          onResize={onResize}
+          onMouseDown={preventDefault}
+          refCallback={refCallback}
+        >
+          {children}
+        </Hookshot.Content>
+      </Hookshot>
+    </React.Fragment>
   );
 };
 

--- a/packages/terra-form-select/src/_Dropdown.module.scss
+++ b/packages/terra-form-select/src/_Dropdown.module.scss
@@ -20,4 +20,10 @@
     border-top-right-radius: var(--terra-form-select-dropdown-border-top-right-radius, 3px);
     box-shadow: var(--terra-form-select-dropdown-above-box-shadow, 0 -3px 12px -5px rgba(0, 0, 0, 0.25));
   }
+
+  .visually-hidden-dropdown {
+    margin-top: 2.143em;
+    opacity: 0;
+    position: absolute;
+  }
 }


### PR DESCRIPTION
### Summary
When the dropdown is open, we render it in a portal. This is to allow it to be positioned easily in the DOM and avoid overflow/clipping issues that would arise if the dropdown was positioned relative to the select dropdown triggering element. 

By rendering the dropdown in a React portal, it causes some issues when it comes to navigating the select options when using gestures to navigate while using VoiceOver on iOS. To help with this, we've provided instructional text to guide users to tap on/interact with the toggle (chevron) to shift focus to  the portalled dropdown when interacting with select variants that allow text entry while using VoiceOver on iOS. 

While this works and does allow navigation of the select options, we want to make navigating to the select options more intuitive and allow navigating to the dropdown options via gesture navigation right after the user opens the dropdown when the click on the text input in the select.

To solve for this, we are now rendering a visually hidden dropdown that follows right after the select text input in the DOM. This allows for the virtual indicator to move from the text input to the list of options by double tapping on the text input to open the dropdown, then swiping right to move the virtual indicator into the dropdown option list when using VoiceOver on iOS.

Resolves: https://github.com/cerner/terra-core/issues/2383