### PR TITLE
Added a doc site example that has Auto Formatting disabled

### DIFF
--- a/packages/terra-search-field/CHANGELOG.md
+++ b/packages/terra-search-field/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Added a doc site example with AutoFormat attributes disabled
 
 3.12.0 - (May 1, 2019)
 ------------------

--- a/packages/terra-search-field/src/terra-dev-site/doc/example/SearchFieldDisableAutoFormatAttrs.jsx
+++ b/packages/terra-search-field/src/terra-dev-site/doc/example/SearchFieldDisableAutoFormatAttrs.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
+import SearchFieldExampleTemplate from 'terra-search-field/lib/terra-dev-site/doc/example/SearchFieldExampleTemplate';
+
+const SearchFieldDisabledAutoFormatting = () => (
+  <SearchFieldExampleTemplate
+    inputAttributes={{
+      autoCorrect: 'off',
+      autoComplete: 'off',
+      autoCapitalize: 'off',
+      spellCheck: 'false',
+    }}
+  />
+);
+
+export default SearchFieldDisabledAutoFormatting;

--- a/packages/terra-search-field/src/terra-dev-site/doc/search-field/SearchField.1.doc.jsx
+++ b/packages/terra-search-field/src/terra-dev-site/doc/search-field/SearchField.1.doc.jsx
@@ -20,6 +20,8 @@ import SearchFieldDefaultValue from '../example/SearchFieldDefaultValue';
 import SearchFieldDefaultValueSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/SearchFieldDefaultValue';
 import SearchFieldDisabled from '../example/SearchFieldDisabled';
 import SearchFieldDisabledSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/SearchFieldDisabled';
+import SearchFieldDisabledAutoFormatting from '../example/SearchFieldDisableAutoFormatAttrs';
+import SearchFieldDisabledAutoFormattingSrc from '../example/SearchFieldDisableAutoFormatAttrs';
 import SearchFieldBlock from '../example/SearchFieldBlock';
 import SearchFieldBlockSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/SearchFieldBlock';
 import SearchFieldDisableAutoSearch from '../example/SearchFieldDisableAutoSearch';
@@ -65,6 +67,11 @@ const DocPage = () => (
         title: 'Search Field that is Disabled',
         example: <SearchFieldDisabled />,
         source: SearchFieldDisabledSrc,
+      },
+      {
+        title: 'Search Field that has Autocomplete, Autocorrect, Autocapitalize, and Spellcheck disabled',
+        example: <SearchFieldDisabledAutoFormatting />,
+        source: SearchFieldDisabledAutoFormattingSrc,
       },
       {
         title: 'Search Field that Displays as Block Style to Fill Container',


### PR DESCRIPTION
### Summary
Created a doc site example that displays a search field example with auto correct, auto complete, auto capitalize, and spell check disabled.

Resolves [#1604](https://github.com/cerner/terra-core/issues/1604)

![image](https://user-images.githubusercontent.com/42747444/57487353-f5145000-7275-11e9-8a7c-db21915d390d.png)

Here you can see upon typing "hel" (short for hello or help), it did not attempt to fill in the word/offer suggestions, nor is there a red underline signifying a misspelling, as well as no attempt to capitalize the first letter.
