### PR TITLE
Render action header as a div

### DIFF
--- a/packages/terra-action-header/CHANGELOG.md
+++ b/packages/terra-action-header/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Now renders `<ActionHeader />` as a div instead of a header element to avoid duplicate banner landmarks in the DOM
 
 2.13.0 - (May 1, 2019)
 ------------------

--- a/packages/terra-action-header/src/_ActionHeaderContainer.jsx
+++ b/packages/terra-action-header/src/_ActionHeaderContainer.jsx
@@ -57,14 +57,14 @@ const ActionHeaderContainer = ({
   ) : undefined;
 
   return (
-    <header {...customProps} className={cx(['flex-header', customProps.className])}>
+    <div {...customProps} className={cx(['flex-header', customProps.className])}>
       {startContent && <div className={cx('flex-end')}>{startContent}</div>}
       <div className={cx('flex-fill')}>
         {titleElement}
       </div>
       {content}
       {endContent && <div className={cx('flex-end')}>{endContent}</div>}
-    </header>
+    </div>
   );
 };
 


### PR DESCRIPTION
### Summary
* Now renders `<ActionHeader />` as a div instead of a header element to avoid duplicate banner landmarks in the DOM