### PR TITLE
Update badges to point to travis-ci.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
       deploy:
         provider: pages
         skip_cleanup: true
-        github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+        github_token: $GITHUB_TOKEN # Set in travis-ci.com dashboard
         local_dir: build
         on:
           branch: master

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -23,7 +23,7 @@
 | identity-obj-proxy | ^3.0.0 | -- | an identity object using ES6 proxies |
 | jest | ^23.1.0 | -- | Delightful JavaScript Testing. |
 | lerna | ^2.1.2 | -- | Tool for managing JavaScript projects with multiple packages |
-| link-parent-bin | ^0.2.0 | -- | [![Build Status](https://travis-ci.org/nicojs/node-link-parent-bin.svg?branch=master)](https://travis-ci.org/nicojs/node-link-parent-bin) |
+| link-parent-bin | ^0.2.0 | -- | [![Build Status](https://travis-ci.com/nicojs/node-link-parent-bin.svg?branch=master)](https://travis-ci.com/nicojs/node-link-parent-bin) |
 | markdown-magic | ^0.1.25 | -- | Automatically update markdown files with content from external sources |
 | react | ^16.4.2 | -- | React is a JavaScript library for building user interfaces. |
 | react-dom | ^16.4.2 | ^16.0.0 | React package for working with the DOM. |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Cerner OSS](https://badgen.net/badge/Cerner/OSS/blue)](http://engineering.cerner.com/2014/01/cerner-and-open-source/)
 [![License](https://badgen.net/badge/license/Apache-2.0/blue)](https://github.com/cerner/terra-core/blob/master/LICENSE)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 [![devDependencies status](https://badgen.net/david/dev/cerner/terra-core)](https://david-dm.org/cerner/terra-core?type=dev)
 [![lerna](https://badgen.net/badge/maintained%20with/lerna/cc00ff)](https://lerna.js.org/)
 

--- a/packages/terra-action-footer/README.md
+++ b/packages/terra-action-footer/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-action-footer)](https://www.npmjs.org/package/terra-action-footer)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-action-footer component is a footer bar that contains sockets for placing actionable items such as buttons and hyperlinks. The default variation contains a start and end socket, while the centered variation has only a center socket. If no actions are provided, the footer bar collapses to a themeable height and maintains the top border.
 

--- a/packages/terra-action-header/README.md
+++ b/packages/terra-action-header/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-action-header)](https://www.npmjs.org/package/terra-action-header)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-action-header component is a header bar containing a title and optional actionable items such as links and buttons.
 

--- a/packages/terra-alert/README.md
+++ b/packages/terra-alert/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-alert)](https://www.npmjs.org/package/terra-alert)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The Terra Alert component is a notification banner that can be rendered in your application when there is information that you want to bring to the user's attention. The Alert component supports a number of built-in notification types that render with pre-defined colors and icons that help the user understand the severity and meaning of the notification. A custom notification type is also supported that allows your application to customize an alert that may not fit into the pre-defined types.
 

--- a/packages/terra-arrange/README.md
+++ b/packages/terra-arrange/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-arrange)](https://www.npmjs.org/package/terra-arrange)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The arrange component allows an item that has an intrinsic width, such as an icon or an image, to be offset from a group of associated content. When the group of associated content wraps, it will stay aligned next to the offset content rather than wrap below it.
 

--- a/packages/terra-avatar/README.md
+++ b/packages/terra-avatar/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-avatar)](https://www.npmjs.org/package/terra-avatar)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-avatar component displays an avatar, which can be either an image or text, in a circular frame. If neither an image or text is provided, a variant-based fallback icon is used.
 

--- a/packages/terra-badge/README.md
+++ b/packages/terra-badge/README.md
@@ -1,7 +1,7 @@
 # Terra Badge
 
 [![NPM version](https://badgen.net/npm/v/terra-badge)](https://www.npmjs.org/package/terra-badge)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-badge component displays content classification.
 

--- a/packages/terra-base/README.md
+++ b/packages/terra-base/README.md
@@ -1,7 +1,7 @@
 # Terra Base
 
 [![NPM version](https://badgen.net/npm/v/terra-base)](https://www.npmjs.org/package/terra-base)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The `terra-base` component is a core feature for any apps built with Terra UI. The base component handles two concerns, application internationalization and global styles. Read the [terra-base docs]((https://github.com/cerner/terra-core/tree/master/packages/terra-base/docs)) to learn more about the component.
 

--- a/packages/terra-breakpoints/README.md
+++ b/packages/terra-breakpoints/README.md
@@ -1,7 +1,7 @@
 # Terra Breakpoints
 
 [![NPM version](https://badgen.net/npm/v/terra-breakpoints)](https://www.npmjs.org/package/terra-breakpoints)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 `terra-breakpoints` contains components and utilities related to Terra's supported responsive breakpoints.
 

--- a/packages/terra-button-group/README.md
+++ b/packages/terra-button-group/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-button-group)](https://www.npmjs.org/package/terra-button-group)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The Terra Button Group component groups buttons and can maintain a toggle selection state. This component is intended to group buttons with similar context or to toggle content, it is not intended to be used as a form element.
 

--- a/packages/terra-button/README.md
+++ b/packages/terra-button/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-button)](https://www.npmjs.org/package/terra-button)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-button component provides users a way to trigger actions in the UI.
 It can be modified in color, size, and type, and can optionally display an icon.

--- a/packages/terra-card/README.md
+++ b/packages/terra-card/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-card)](https://www.npmjs.org/package/terra-card)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 Card is a basic container with some base styling to help separate elements with different content
 

--- a/packages/terra-content-container/README.md
+++ b/packages/terra-content-container/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-content-container)](https://www.npmjs.org/package/terra-content-container)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The Terra ContentContainer is a structural component for the purpose of arranging content with an optional header and/or footer.
 

--- a/packages/terra-demographics-banner/README.md
+++ b/packages/terra-demographics-banner/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-demographics-banner)](https://www.npmjs.org/package/terra-demographics-banner)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The demographics component is used to display demographic information about a person in a condensed, easy to read format.
 

--- a/packages/terra-dialog/README.md
+++ b/packages/terra-dialog/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-dialog)](https://www.npmjs.org/package/terra-dialog)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 Dialogs are temporary views that can be used in a myriad of ways. Dialogs have the ability to alert users to act on critical information. In doing so, Dialogs may allow users to avoid destructive decisions, and also extend user workflows without disorienting the user.
 

--- a/packages/terra-divider/README.md
+++ b/packages/terra-divider/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-divider)](https://www.npmjs.org/package/terra-divider)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The divider component is used to visually separate content on a layout.
 

--- a/packages/terra-doc-template/README.md
+++ b/packages/terra-doc-template/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-doc-template)](https://www.npmjs.org/package/terra-doc-template)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-doc-template component provides an adjustable template for documentation pages.
 

--- a/packages/terra-dynamic-grid/README.md
+++ b/packages/terra-dynamic-grid/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-dynamic-grid)](https://www.npmjs.org/package/terra-dynamic-grid)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-dynamic-grid component provides users a way to build dynamic layouts using CSS Grids.
 

--- a/packages/terra-form-checkbox/README.md
+++ b/packages/terra-form-checkbox/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-form-checkbox)](https://www.npmjs.org/package/terra-form-checkbox)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The Terra Form Checkbox is a responsive input component rendered as a box. When activated, a check mark shall appear. Focus can be activated through tabbing and the checked state can be toggled with the space bar.
 

--- a/packages/terra-form-field/README.md
+++ b/packages/terra-form-field/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-form-field)](https://www.npmjs.org/package/terra-form-field)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The Form Field component handles the layout of the label, help text and error text associated with a form element. Additionally, it provides required, optional, and invalid indicators.
 

--- a/packages/terra-form-fieldset/README.md
+++ b/packages/terra-form-fieldset/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-form-fieldset)](https://www.npmjs.org/package/terra-form-fieldset)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 Generic form fieldset component which handles the layout of a standard form fieldset including help text, legend, value and widget placement.
 

--- a/packages/terra-form-input/README.md
+++ b/packages/terra-form-input/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-form-input)](https://www.npmjs.org/package/terra-form-input)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 Generic input which represents an HTML input element directly.
 

--- a/packages/terra-form-radio/README.md
+++ b/packages/terra-form-radio/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-form-radio)](https://www.npmjs.org/package/terra-form-radio)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The Terra Form Radio is a responsive input component rendered as a radio button next to label text. When activated, a dot shall appear. Use the `name` attribute to group radio buttons together. Tabbing switches focus between radio button groups; arrow keys switch between radio buttons of the same group. The checked state can be activated with a space.
 

--- a/packages/terra-form-select/README.md
+++ b/packages/terra-form-select/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-form-select)](https://www.npmjs.org/package/terra-form-select)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The select component is a form input with a drop down list of options that allows for single selection.
 

--- a/packages/terra-form-textarea/README.md
+++ b/packages/terra-form-textarea/README.md
@@ -1,7 +1,7 @@
 # Terra Form Textarea
 
 [![NPM version](https://badgen.net/npm/v/terra-form-textarea)](https://www.npmjs.org/package/terra-form-textarea)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 Element for building out textareas in a form.
 

--- a/packages/terra-grid/README.md
+++ b/packages/terra-grid/README.md
@@ -1,7 +1,7 @@
 # Terra Grid
 
 [![NPM version](https://badgen.net/npm/v/terra-grid)](https://www.npmjs.org/package/terra-grid)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-grid component provides a flexbox based grid system.
 

--- a/packages/terra-heading/README.md
+++ b/packages/terra-heading/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-heading)](https://www.npmjs.org/package/terra-heading)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 Terra includes styling for all standard headings `h1` through `h6`, as well as styles that match the size of their respective heading.
 

--- a/packages/terra-hyperlink/README.md
+++ b/packages/terra-hyperlink/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-hyperlink)](https://www.npmjs.org/package/terra-hyperlink)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra hyperlink component allows linking to other web pages, files, locations within the same page, email addresses, or any other URL.
 

--- a/packages/terra-i18n/README.md
+++ b/packages/terra-i18n/README.md
@@ -1,7 +1,7 @@
 # Terra I18n
 
 [![NPM version](https://badgen.net/npm/v/terra-i18n)](https://www.npmjs.org/package/terra-i18n)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-i18n package provides on-demand internationalization of React components.
 

--- a/packages/terra-icon/README.md
+++ b/packages/terra-icon/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-icon)](https://www.npmjs.org/package/terra-icon)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-icon component is used to visually represent a literal or symbolic object intended to initiate an action, communicate a status, or navigate the workflow.
 

--- a/packages/terra-image/README.md
+++ b/packages/terra-image/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-image)](https://www.npmjs.org/package/terra-image)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-image component provides styling for visual imagery.
 

--- a/packages/terra-legacy-theme/README.md
+++ b/packages/terra-legacy-theme/README.md
@@ -1,7 +1,7 @@
 # Terra Legacy Theme
 
 [![NPM version](https://badgen.net/npm/v/terra-legacy-theme)](https://www.npmjs.org/package/terra-legacy-theme)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 
 - [Getting Started](#getting-started)

--- a/packages/terra-list/README.md
+++ b/packages/terra-list/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-list)](https://www.npmjs.org/package/terra-list)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The Terra List is a structural component to arrange content within list/listitems.
 

--- a/packages/terra-markdown/README.md
+++ b/packages/terra-markdown/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-markdown)](https://www.npmjs.org/package/terra-markdown)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 React component to display the content of markdown files.
 

--- a/packages/terra-mixins/README.md
+++ b/packages/terra-mixins/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-mixins)](https://www.npmjs.org/package/terra-mixins)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-mixins component supplies global mixins for use throughout the Terra ecosystem.
 

--- a/packages/terra-overlay/README.md
+++ b/packages/terra-overlay/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-overlay)](https://www.npmjs.org/package/terra-overlay)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The Terra Overlay component is a component that displays an overlay relative to the container that triggered the overlay. This component blocks interactions and fades out all elements of the triggering container.
 

--- a/packages/terra-paginator/README.md
+++ b/packages/terra-paginator/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-paginator)](https://www.npmjs.org/package/terra-paginator)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 Paginator to be used for data sets of known and unknown size. Provides first, last, previous, next, and paged functionality.
 

--- a/packages/terra-profile-image/README.md
+++ b/packages/terra-profile-image/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-profile-image)](https://www.npmjs.org/package/terra-profile-image)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-profile-image component displays an avatar image while the profile image is being loaded. If the profile image successfully loads, the avatar image is replaced with the profile image. Otherwise, the avatar image is left as is. All styling set on the profile image will be applied to the avatar image.
 

--- a/packages/terra-progress-bar/README.md
+++ b/packages/terra-progress-bar/README.md
@@ -1,7 +1,7 @@
 # Terra Progress Bar
 
 [![NPM version](https://badgen.net/npm/v/terra-progress-bar)](https://www.npmjs.org/package/terra-progress-bar)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The progress bar component provides users a way to display the progress of process or activity in a graphical manner. It can be modified in height and fill color. Its styling is set such that, the `ProgressBar` element will occupy full width of its parent element and will flex based on the width of the parent container.
 

--- a/packages/terra-props-table/README.md
+++ b/packages/terra-props-table/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-props-table)](https://www.npmjs.org/package/terra-props-table)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 React component to render a table view for the props metadata of another react component.
 

--- a/packages/terra-responsive-element/README.md
+++ b/packages/terra-responsive-element/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-responsive-element)](https://www.npmjs.org/package/terra-responsive-element)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The ResponsiveElement conditionally renders components based on viewport size.
 The viewport can be set to the immediate parent or window.

--- a/packages/terra-scroll/README.md
+++ b/packages/terra-scroll/README.md
@@ -1,7 +1,7 @@
 # Terra Scroll
 
 [![NPM version](https://badgen.net/npm/v/terra-scroll)](https://www.npmjs.org/package/terra-scroll)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-scroll is a content view that hides data accessible with scrolling and provides a refCallback.
 

--- a/packages/terra-search-field/README.md
+++ b/packages/terra-search-field/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-search-field)](https://www.npmjs.org/package/terra-search-field)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 A search component with a field that automatically performs a search callback after user input.
 

--- a/packages/terra-section-header/README.md
+++ b/packages/terra-section-header/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-section-header)](https://www.npmjs.org/package/terra-section-header)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 Section Header presentational component that provides an onClick callback.
 

--- a/packages/terra-show-hide/README.md
+++ b/packages/terra-show-hide/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-show-hide)](https://www.npmjs.org/package/terra-abstract-modal)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 Show Hide Component that will show a preview of content and then expand it with a Show More button.
 

--- a/packages/terra-signature/README.md
+++ b/packages/terra-signature/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-signature)](https://www.npmjs.org/package/terra-signature)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The terra-signature component provides users a way to define a signature with a series of line segments.
 The component can define line width, line color, and optionally display a signature if the line segments have

--- a/packages/terra-spacer/README.md
+++ b/packages/terra-spacer/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-spacer)](https://www.npmjs.org/package/terra-spacer)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 This component is used to provide margin and/or padding space between two components based on the given values.
 

--- a/packages/terra-status-view/README.md
+++ b/packages/terra-status-view/README.md
@@ -1,7 +1,7 @@
 # Terra Status View
 
 [![NPM version](https://badgen.net/npm/v/terra-status-view)](https://www.npmjs.org/package/terra-status-view)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The status view component provides a customizable icon, message, and buttons in a view.
 

--- a/packages/terra-status/README.md
+++ b/packages/terra-status/README.md
@@ -1,7 +1,7 @@
 # Terra Status
 
 [![NPM version](https://badgen.net/npm/v/terra-status)](https://www.npmjs.org/package/terra-status)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The status component provides a customizable color indictor to signify a specific condition.
 

--- a/packages/terra-table/README.md
+++ b/packages/terra-table/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-table)](https://www.npmjs.org/package/terra-table)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The Terra Table is a structural component to arrange content within table.
 

--- a/packages/terra-tag/README.md
+++ b/packages/terra-tag/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-tag)](https://www.npmjs.org/package/terra-tag)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The tag component is used for tagging and provides users a way to trigger actions in the UI. Each tag should have text.
 It can optionally display an icon along with the text.

--- a/packages/terra-text/README.md
+++ b/packages/terra-text/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-text)](https://www.npmjs.org/package/terra-text)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 The font size, font weight, font family, and font color in terra components are set to defaults in terra-base which is then inherited into all components. Components can override these base styles as needed in their specific component CSS. In some cases, you may need text that differs from the base font styles for text that doesn't go with a specific terra component.
 

--- a/packages/terra-toggle-button/README.md
+++ b/packages/terra-toggle-button/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-toggle-button)](https://www.npmjs.org/package/terra-toggle-button)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 ToggleButton component that transitions content in and out with the click on a button.
 

--- a/packages/terra-toggle-section-header/README.md
+++ b/packages/terra-toggle-section-header/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-toggle-section-header)](https://www.npmjs.org/package/terra-toggle-section-header)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 Toggle section header component that transitions content in and out with a click.
 

--- a/packages/terra-toggle/README.md
+++ b/packages/terra-toggle/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-toggle)](https://www.npmjs.org/package/terra-toggle)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 Toggle component that transitions content in and out.
 

--- a/packages/terra-visually-hidden-text/README.md
+++ b/packages/terra-visually-hidden-text/README.md
@@ -1,7 +1,7 @@
 # Terra Visually Hidden Text
 
 [![NPM version](https://badgen.net/npm/v/terra-visually-hidden-text)](https://www.npmjs.org/package/terra-visually-hidden-text)
-[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://badgen.net/travis/cerner/terra-core)](https://travis-ci.com/cerner/terra-core)
 
 Text that is designed to only be read by a screen reader.
 


### PR DESCRIPTION
### Summary
Updates travis build status badges to point to `travis-ci.com` instead of `travis-ci.org`

Closes #2409 