### PR TITLE
[terra-i18n] Fixed babel i18n runtime errrors.

### DIFF
--- a/packages/terra-i18n/src/I18n.js
+++ b/packages/terra-i18n/src/I18n.js
@@ -1,5 +1,5 @@
-import I18nProvider from './I18nProvider';
-import i18nLoader from './i18nLoader';
+const I18nProvider = require('./I18nProvider');
+const i18nLoader = require('./i18nLoader');
 
 module.exports = {
   I18nProvider,

--- a/packages/terra-i18n/src/i18nLoader.js
+++ b/packages/terra-i18n/src/i18nLoader.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
-import Intl from './intl';
-import loadIntl from './intlLoaders';
-import loadTranslations from './translationsLoaders';
+const Intl = require('./intl');
+const loadIntl = require('./intlLoaders');
+const loadTranslations = require('./translationsLoaders');
 
 let hasIntl;
 try {

--- a/packages/terra-i18n/src/intlLoaders.js
+++ b/packages/terra-i18n/src/intlLoaders.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import intlLoaders from 'intlLoaders';
+const intlLoaders = require('intlLoaders');
 
 const loadFallbackIntl = (localeContext) => {
   try {

--- a/packages/terra-i18n/src/translationsLoaders.js
+++ b/packages/terra-i18n/src/translationsLoaders.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import translationLoaders from 'translationsLoaders';
+const translationLoaders = require('translationsLoaders');
 
 const loadFallbackLocale = (localeContext, callback, scope) => {
   try {

--- a/packages/terra-table/CHANGELOG.md
+++ b/packages/terra-table/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Made required updates to consumer terra-toolkit v5 and terra-dev-site v5
+* Changed imports to requires
 
 3.14.0 - (May 22, 2019)
 ------------------


### PR DESCRIPTION
### Summary
Fixes runtime babel errors with import vs require and the usage of module.exports.

Thanks for contributing to Terra.
@cerner/terra

[CONTRIBUTORS.md]: ../CONTRIBUTORS.md
[License]: ../LICENSE
