### PR TITLE
Removed Vendor Specific Style Rules.

### DIFF
--- a/packages/terra-form-input/CHANGELOG.md
+++ b/packages/terra-form-input/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed 
+* Removed vendor style rule added to fade placeholder text. Since Autoprefixer V9 resolves vendor prefix issue.
+
 ### Changed
 * Made required updates to consumer terra-toolkit v5 and terra-dev-site v5
 

--- a/packages/terra-form-input/src/Input.module.scss
+++ b/packages/terra-form-input/src/Input.module.scss
@@ -27,16 +27,6 @@
       font-style: var(--terra-form-input-placeholder-font-style);
     }
 
-    /* TODO: Remove vendor prefix once we update to autoprefixer v9 */
-    /* Issue logged for updating Autoprefixer in Toolkit : https://github.com/cerner/terra-toolkit/issues/161 */
-    /* stylelint-disable selector-no-vendor-prefix */
-    &:-ms-input-placeholder {
-      color: var(--terra-form-input-placeholder-color, #70787c);
-      font-style: var(--terra-form-input-placeholder-font-style);
-    }
-    /* stylelint-enable selector-no-vendor-prefix */
-    /* End of vendor prefix */
-
     &:hover {
       background-color: var(--terra-form-input-hover-background-color, #fff);
       border: var(--terra-form-input-hover-border, 1px solid #dedfe0);

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed 
+* Removed vendor style rule added to fade placeholder text. Since Autoprefixer V9 resolves vendor prefix issue.
+
 ### Changed
 * Made required updates to consumer terra-toolkit v5 and terra-dev-site v5
 

--- a/packages/terra-form-select/src/_Frame.module.scss
+++ b/packages/terra-form-select/src/_Frame.module.scss
@@ -230,22 +230,6 @@
     white-space: nowrap;
   }
 
-  /* TODO: Remove vendor prefix once we update to autoprefixer v9 */
-  /* Issue loggedd for updating Autoprefixer in Toolkit : https://github.com/cerner/terra-toolkit/issues/161 */
-  /* stylelint-disable selector-no-vendor-prefix */
-  .search-input,
-  .placeholder,
-  :-ms-input-placeholder {
-    color: var(--terra-form-select-search-placeholder-color, #70787c);
-    font-size: var(--terra-form-select-search-placeholder-font-size, 1.143rem);
-    font-style: var(--terra-form-select-search-placeholder-font-style);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  /* stylelint-enable selector-no-vendor-prefix */
-  /* End of vendor prefix */
-
   .tag,
   .search,
   .combobox,

--- a/packages/terra-form-textarea/CHANGELOG.md
+++ b/packages/terra-form-textarea/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed 
+* Removed vendor style rule added to fade placeholder text. Since Autoprefixer V9 resolves vendor prefix issue.
+
 ### Changed
 * Made required updates to consumer terra-toolkit v5 and terra-dev-site v5
 

--- a/packages/terra-form-textarea/src/Textarea.module.scss
+++ b/packages/terra-form-textarea/src/Textarea.module.scss
@@ -38,16 +38,6 @@
       font-style: var(--terra-form-textarea-placeholder-font-style);
     }
 
-    /* TODO: Remove vendor prefix once we update to autoprefixer v9 */
-    /* Issue logged for updating Autoprefixer in Toolkit : https://github.com/cerner/terra-toolkit/issues/161 */
-    /* stylelint-disable selector-no-vendor-prefix */
-    &:-ms-input-placeholder {
-      color: var(--terra-form-textarea-placeholder-color, #70787c);
-      font-style: var(--terra-form-textarea-placeholder-font-style);
-    }
-    /* stylelint-enable selector-no-vendor-prefix */
-    /* End of vendor prefix */
-
     &[required] {
       box-shadow: unset;
     }


### PR DESCRIPTION
### Summary
Resolves #2432 

### Additional Details
Browser Specific styles were added for Terra-Form-Input, Terra-Form-Textarea and Terra-Form-Select. Since auto-prefixer has been updated in toolkit to [V9](https://github.com/cerner/terra-toolkit/blob/49fc5d35a288a91e3e9e2d539ef842484999bfb3/package.json#L72) . It resolves this auto-prefixing issue that were present in previous version.

