### PR TITLE
Allow numbers in package names for danger changelogs

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { danger, fail } from 'danger';
 
-const CHANGELOG_PATTERN = /^packages\/terra-([a-z-])*\/CHANGELOG\.md/i;
+const CHANGELOG_PATTERN = /^packages\/terra-([a-z-0-9])*\/CHANGELOG\.md/i;
 
 const changedFiles = danger.git.created_files.concat(danger.git.modified_files);
 


### PR DESCRIPTION
### Summary
Recent changes to the dangerfile to require a changelog for changes to any file in a package revealed an oversight that packages with numbers in their name would not be checked for changed files or changelog modifications.
