### PR TITLE
Conditionally load inert polyfill if it is not already defined

### DIFF
--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added check to only load inert polyfill if it is not already defined on the Element prototype
+
 ### Removed
 * Removed node_modules from .npmignore
 

--- a/packages/terra-overlay/src/Overlay.jsx
+++ b/packages/terra-overlay/src/Overlay.jsx
@@ -12,7 +12,9 @@ import Container from './OverlayContainer';
 // Importing WICG Inert polyfill causes Jest to crash
 // Issue logged to Jest repo: https://github.com/facebook/jest/issues/8373
 // This logic avoids importing the polyfill when running Jest tests
-if (process.env.NODE_ENV !== 'test') {
+// It also checks to make sure not to load the inert polyfill if it has already been defined
+// eslint-disable-next-line no-prototype-builtins
+if (process.env.NODE_ENV !== 'test' && !Element.prototype.hasOwnProperty('inert')) {
   // eslint-disable-next-line global-require
   require('wicg-inert');
 }


### PR DESCRIPTION
### Summary
The inert polyfill defines a [new property on the native Element object's prototype](https://github.com/WICG/inert/blob/master/src/inert.js#L691). This means that this polyfill should only be loaded once in the DOM otherwise it fill trigger a console error about not being able to redefine the property. This adds a check to make sure the polyfill is not loaded if the Element's prototype already has `inert` defined.
