### PR TITLE
Update terra-mixin import file path

### DIFF
--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Fixed accessibility issue in list item tests
+* Update mixin import to work better with codesandbox.io
 
 4.8.0 - (June 18, 2019)
 ------------------

--- a/packages/terra-list/src/ListSectionHeader.module.scss
+++ b/packages/terra-list/src/ListSectionHeader.module.scss
@@ -1,4 +1,4 @@
-@import '~terra-mixins';
+@import '~terra-mixins/lib/Mixins';
 
 // Section Header
 // ========================================================
@@ -40,7 +40,7 @@
       position: relative;
       z-index: 1;
     }
-  
+
     &.section-header:hover,
     &.section-header:active {
       background-color: var(--terra-list-section-header-hover-active-background-color, #d0d1d2);

--- a/packages/terra-list/src/ListSubsectionHeader.module.scss
+++ b/packages/terra-list/src/ListSubsectionHeader.module.scss
@@ -1,4 +1,4 @@
-@import '~terra-mixins';
+@import '~terra-mixins/lib/Mixins';
 /* stylelint-disable selector-max-compound-selectors */
 
 // Subsection Header
@@ -41,7 +41,7 @@
       position: relative;
       z-index: 1;
     }
-  
+
     &.subsection-header:hover,
     &.subsection-header:active {
       background-color: var(--terra-list-subsection-header-hover-active-background-color, #d0d1d2);


### PR DESCRIPTION
### Summary
For the most part, [we import terra-mixins with the following syntax](https://github.com/cerner/terra-core/search?l=SCSS&p=1&q=terra-mixins).
```scss
@import '~terra-mixins/lib/Mixins';
```
This allows tools like https://codesandbox.io/ to resolve the file correctly.
Some SCSS files in the list PR got lost in traffic and were not updated to the new import syntax. This PR addresses that.