### PR TITLE
[terra-responsive-element] - Update examples to use React Hooks

### DIFF
--- a/packages/terra-responsive-element/CHANGELOG.md
+++ b/packages/terra-responsive-element/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 Unreleased
 ----------
 
+### Changed
+
+* Updated examples to use React Hooks
+
 5.0.0 - (June 18, 2019)
 ------------------
 ### Breaking Changes

--- a/packages/terra-responsive-element/src/terra-dev-site/doc/example/BreakpointExample.jsx
+++ b/packages/terra-responsive-element/src/terra-dev-site/doc/example/BreakpointExample.jsx
@@ -1,29 +1,16 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import Placeholder from 'terra-doc-template/lib/Placeholder';
 import ResponsiveElement from '../../../ResponsiveElement';
 
-class BreakpointExample extends Component {
-  constructor() {
-    super();
+const BreakpointExample = () => {
+  const [breakpoint, setBreakpoint] = useState('');
 
-    this.state = { breakpoint: '' };
-    this.handleChange = this.handleChange.bind(this);
-  }
-
-  handleChange(breakpoint) {
-    this.setState({ breakpoint });
-  }
-
-  render() {
-    const { breakpoint } = this.state;
-
-    return (
-      <ResponsiveElement onChange={this.handleChange}>
-        <Placeholder title={breakpoint} />
-      </ResponsiveElement>
-    );
-  }
-}
+  return (
+    <ResponsiveElement onChange={value => setBreakpoint(value)}>
+      <Placeholder title={breakpoint} />
+    </ResponsiveElement>
+  );
+};
 
 export default BreakpointExample;

--- a/packages/terra-responsive-element/src/terra-dev-site/doc/example/ResizeExample.jsx
+++ b/packages/terra-responsive-element/src/terra-dev-site/doc/example/ResizeExample.jsx
@@ -1,29 +1,16 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import Placeholder from 'terra-doc-template/lib/Placeholder';
 import ResponsiveElement from '../../../ResponsiveElement';
 
-class BreakpointExample extends Component {
-  constructor() {
-    super();
+const ResizeExample = () => {
+  const [width, setWidth] = useState('');
 
-    this.state = { width: '' };
-    this.handleResize = this.handleResize.bind(this);
-  }
+  return (
+    <ResponsiveElement onResize={value => setWidth(value)}>
+      <Placeholder title={width} />
+    </ResponsiveElement>
+  );
+};
 
-  handleResize(width) {
-    this.setState({ width: width.toString() });
-  }
-
-  render() {
-    const { width } = this.state;
-
-    return (
-      <ResponsiveElement onResize={this.handleResize}>
-        <Placeholder title={width} />
-      </ResponsiveElement>
-    );
-  }
-}
-
-export default BreakpointExample;
+export default ResizeExample;


### PR DESCRIPTION
### Summary

Updated the Responsive Element examples to use React Hooks.

Thanks for contributing to Terra.
@cerner/terra

[CONTRIBUTORS.md]: ../CONTRIBUTORS.md
[License]: ../LICENSE
