### PR TITLE
Remove conditional logic around importing wicg-inert

### DIFF
--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Removed all inline styles from Dev-site components and implemented the same styles using external css.
+* Removed conditional logic required to import wicg-inert polyfill
 
 3.16.0 - (June 18, 2019)
 ------------------

--- a/packages/terra-overlay/package.json
+++ b/packages/terra-overlay/package.json
@@ -35,7 +35,7 @@
     "terra-button": "^3.14.0",
     "terra-doc-template": "^2.10.0",
     "terra-icon": "^3.11.0",
-    "wicg-inert": "^2.1.0"
+    "wicg-inert": "^2.1.1"
   },
   "scripts": {
     "compile": "babel --root-mode upward src --out-dir lib --copy-files",

--- a/packages/terra-overlay/src/Overlay.jsx
+++ b/packages/terra-overlay/src/Overlay.jsx
@@ -6,18 +6,9 @@ import { Portal } from 'react-portal';
 import KeyCode from 'keycode-js';
 import 'mutationobserver-shim';
 import './_matches-polyfill';
+import 'wicg-inert';
 import styles from './Overlay.module.scss';
 import Container from './OverlayContainer';
-
-// Importing WICG Inert polyfill causes Jest to crash
-// Issue logged to Jest repo: https://github.com/facebook/jest/issues/8373
-// This logic avoids importing the polyfill when running Jest tests
-// It also checks to make sure not to load the inert polyfill if it has already been defined
-// eslint-disable-next-line no-prototype-builtins
-if (process.env.NODE_ENV !== 'test' && !Element.prototype.hasOwnProperty('inert')) {
-  // eslint-disable-next-line global-require
-  require('wicg-inert');
-}
 
 const cx = classNames.bind(styles);
 


### PR DESCRIPTION
### Summary
[The wicg-inert polyfill updated to use the same logic we were using to ensure that inert is not defined on the Element prototype before it tries to define that](https://github.com/WICG/inert/pull/123). With this change, we no longer need to conditionally load it and go back to a regular import statement. This also resolved the issue we had with this import when running it through Jest.