### PR TITLE
Downgrade danger to version that doesn't use gitlab ^6 package

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "check-installed-dependencies": "^1.0.0",
     "core-js": "^3.1.3",
     "cross-env": "^5.2.0",
-    "danger": "^9.0.0",
+    "danger": "^7.0.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.2.2",


### PR DESCRIPTION
This is to resolve a bug that came up with a transitive dependency in danger. Rolling it back to a lower version that shouldn't pull in the dependency.

I've logged the following to see if we can get and update down stream for this issue: https://github.com/danger/danger-js/issues/884