### PR TITLE
[terra-search-field] Passing event object to 'handleClear'

### DIFF
--- a/packages/terra-search-field/CHANGELOG.md
+++ b/packages/terra-search-field/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Updated search field to pass event object to 'handleClear' from 'handleKeyDown'.
 
 3.16.0 - (June 28, 2019)
 ------------------

--- a/packages/terra-search-field/src/SearchField.jsx
+++ b/packages/terra-search-field/src/SearchField.jsx
@@ -173,7 +173,7 @@ class SearchField extends React.Component {
       this.handleSearch();
     }
     if (event.nativeEvent.keyCode === KeyCode.KEY_ESCAPE) {
-      this.handleClear();
+      this.handleClear(event);
     }
   }
 


### PR DESCRIPTION
### Summary
Updated SearchField to pass event object to 'handleClear' method from 'handleKeyDown' method.

Resolves #2489 