### PR TITLE
[terra-overlay] Disabled document scroll if Overlay is not relative to the triggering container.

### DIFF
--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ----------
 
+### Fixed
+* Disabled document scroll if Overlay is not relative to the triggering container.
+
 3.18.0 - (July 9, 2019)
 ------------------
 ### Fixed

--- a/packages/terra-overlay/src/Overlay.jsx
+++ b/packages/terra-overlay/src/Overlay.jsx
@@ -115,8 +115,8 @@ class Overlay extends React.Component {
         document.querySelector(selector).setAttribute('data-overlay-count', `${inert + 1}`);
         document.querySelector(selector).setAttribute('inert', '');
       }
+      document.documentElement.style.overflow = 'hidden';
     }
-    document.documentElement.style.overflow = 'hidden';
   }
 
   enableContainerChildrenFocus() {

--- a/packages/terra-overlay/tests/wdio/overlay-spec.js
+++ b/packages/terra-overlay/tests/wdio/overlay-spec.js
@@ -73,7 +73,7 @@ describe('Overlay', () => {
       });
 
       it('Container Overlay- Background can scroll when Overlay relative to container is open', () => {
-        expect(browser.getAttribute('html', 'style')).contains('');
+        expect(browser.getAttribute('html', 'style')).to.not.contain('overflow: hidden');
       });
 
       Terra.it.isAccessible();


### PR DESCRIPTION
### Summary

Fixes #2514.