### PR TITLE
Add script to automate documenting peerDeps in README.md files

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "deploy": "webpack --config webpack.config -p && gh-pages -d build",
     "dependency-markdown": "node scripts/dependency-markdown-generator/DependencyMarkdownGenerator.js",
     "docs": "node markdown.config.js",
+    "docs:peerDependencies": "node scripts/peer-dependency-generator/index.js",
     "heroku-prebuild": "npm install -g lerna@2.1.2 && lerna init",
     "heroku-postbuild": "npm install --only=dev && npm run compile:prod",
     "jest": "jest --config jestconfig.js",

--- a/packages/terra-action-footer/CHANGELOG.md
+++ b/packages/terra-action-footer/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.15.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-action-footer/README.md
+++ b/packages/terra-action-footer/README.md
@@ -14,6 +14,18 @@ The terra-action-footer component is a footer bar that contains sockets for plac
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-action-footer`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2018 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-action-footer/README.md
+++ b/packages/terra-action-footer/README.md
@@ -17,13 +17,18 @@ The terra-action-footer component is a footer bar that contains sockets for plac
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-action-footer/docs/README.md
+++ b/packages/terra-action-footer/docs/README.md
@@ -7,6 +7,18 @@ The terra-action-footer component is a footer bar that contains two sockets, sta
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-action-footer`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ### Action Footer with Start and End Actions

--- a/packages/terra-action-footer/docs/README.md
+++ b/packages/terra-action-footer/docs/README.md
@@ -10,13 +10,18 @@ The terra-action-footer component is a footer bar that contains two sockets, sta
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-action-header/CHANGELOG.md
+++ b/packages/terra-action-header/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.19.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-action-header/README.md
+++ b/packages/terra-action-header/README.md
@@ -14,6 +14,18 @@ The terra-action-header component is a header bar containing a title and optiona
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-action-header`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2018 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-action-header/README.md
+++ b/packages/terra-action-header/README.md
@@ -17,13 +17,18 @@ The terra-action-header component is a header bar containing a title and optiona
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-action-header/docs/README.md
+++ b/packages/terra-action-header/docs/README.md
@@ -10,13 +10,18 @@ The terra-action-header component is a header bar containing a title and optiona
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Implementation Notes:

--- a/packages/terra-action-header/docs/README.md
+++ b/packages/terra-action-header/docs/README.md
@@ -7,6 +7,18 @@ The terra-action-header component is a header bar containing a title and optiona
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-action-header`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Implementation Notes:
 The Action-Header component must be composed inside the [Base][1] component with a locale in order for it to load the correct translation strings.
 

--- a/packages/terra-alert/CHANGELOG.md
+++ b/packages/terra-alert/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 4.2.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-alert/README.md
+++ b/packages/terra-alert/README.md
@@ -14,6 +14,19 @@ The Terra Alert component is a notification banner that can be rendered in your 
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-alert`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-alert/README.md
+++ b/packages/terra-alert/README.md
@@ -17,7 +17,10 @@ The Terra Alert component is a notification banner that can be rendered in your 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -25,6 +28,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-alert/docs/README.md
+++ b/packages/terra-alert/docs/README.md
@@ -9,6 +9,19 @@ The Terra Alert component is a notification banner that can be rendered in your 
   - `npm install terra-alert`
   - `yarn add terra-alert`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Implementation Notes:
 The Alert component must be composed inside the [Base][1] component with a locale in order for it to load the correct translation strings.
 

--- a/packages/terra-alert/docs/README.md
+++ b/packages/terra-alert/docs/README.md
@@ -12,7 +12,10 @@ The Terra Alert component is a notification banner that can be rendered in your 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -20,6 +23,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Implementation Notes:

--- a/packages/terra-arrange/CHANGELOG.md
+++ b/packages/terra-arrange/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.14.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-arrange/README.md
+++ b/packages/terra-arrange/README.md
@@ -14,6 +14,18 @@ The arrange component allows an item that has an intrinsic width, such as an ico
 
 - Install with [npm](https://www.npmjs.com): `npm install terra-arrange`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-arrange/README.md
+++ b/packages/terra-arrange/README.md
@@ -17,13 +17,18 @@ The arrange component allows an item that has an intrinsic width, such as an ico
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-arrange/docs/README.md
+++ b/packages/terra-arrange/docs/README.md
@@ -8,6 +8,18 @@ The arrange component provides content containers with a fit (start and/or end r
   - `npm install terra-arrange`
   - `yarn add terra-arrange`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-arrange/docs/README.md
+++ b/packages/terra-arrange/docs/README.md
@@ -11,13 +11,18 @@ The arrange component provides content containers with a fit (start and/or end r
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-avatar/CHANGELOG.md
+++ b/packages/terra-avatar/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.20.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-avatar/README.md
+++ b/packages/terra-avatar/README.md
@@ -17,13 +17,18 @@ The terra-avatar component displays an avatar, which can be either an image or t
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-avatar/README.md
+++ b/packages/terra-avatar/README.md
@@ -14,6 +14,18 @@ The terra-avatar component displays an avatar, which can be either an image or t
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-avatar`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2018 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-avatar/docs/README.md
+++ b/packages/terra-avatar/docs/README.md
@@ -7,6 +7,18 @@ The `terra-avatar` package contains three components: `Avatar`, `Facility`, and 
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-avatar`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-avatar/docs/README.md
+++ b/packages/terra-avatar/docs/README.md
@@ -10,13 +10,18 @@ The `terra-avatar` package contains three components: `Avatar`, `Facility`, and 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-avatar/src/terra-dev-site/doc/avatar/About.a.doc.jsx
+++ b/packages/terra-avatar/src/terra-dev-site/doc/avatar/About.a.doc.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import DocTemplate from 'terra-doc-template';
-import ReadMe from '../../../../docs/about.md';
+import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 
 const DocPage = () => (

--- a/packages/terra-badge/CHANGELOG.md
+++ b/packages/terra-badge/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.16.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-badge/README.md
+++ b/packages/terra-badge/README.md
@@ -13,6 +13,18 @@ The terra-badge component displays content classification.
 
 - Install with [npm](https://www.npmjs.com): `npm install terra-badge`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-badge/README.md
+++ b/packages/terra-badge/README.md
@@ -16,13 +16,18 @@ The terra-badge component displays content classification.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-badge/docs/README.md
+++ b/packages/terra-badge/docs/README.md
@@ -8,6 +8,18 @@ The badge component displays content classification.
   - `npm install terra-badge`
   - `yarn add terra-badge`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-badge/docs/README.md
+++ b/packages/terra-badge/docs/README.md
@@ -11,13 +11,18 @@ The badge component displays content classification.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-base/CHANGELOG.md
+++ b/packages/terra-base/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 5.11.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-base/README.md
+++ b/packages/terra-base/README.md
@@ -17,7 +17,10 @@ The `terra-base` component is a core feature for any apps built with Terra UI. T
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -25,6 +28,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-base/README.md
+++ b/packages/terra-base/README.md
@@ -14,6 +14,19 @@ The `terra-base` component is a core feature for any apps built with Terra UI. T
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-base`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-base/docs/README.md
+++ b/packages/terra-base/docs/README.md
@@ -20,7 +20,10 @@ The terra-base component also sets minimal global base styles for the applicatio
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -28,6 +31,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-base/docs/README.md
+++ b/packages/terra-base/docs/README.md
@@ -17,6 +17,19 @@ The terra-base component also sets minimal global base styles for the applicatio
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-base`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 With custom app translations.

--- a/packages/terra-breakpoints/CHANGELOG.md
+++ b/packages/terra-breakpoints/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.11.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-breakpoints/README.md
+++ b/packages/terra-breakpoints/README.md
@@ -13,6 +13,18 @@
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-breakpoints`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2018 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-breakpoints/README.md
+++ b/packages/terra-breakpoints/README.md
@@ -16,13 +16,18 @@
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-breakpoints/docs/README.md
+++ b/packages/terra-breakpoints/docs/README.md
@@ -7,9 +7,21 @@
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-breakpoints`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
-### Breakpoints 
+### Breakpoints
 
 An object containing the named breakpoint values is the default export of the `terra-breakpoints` package. These named breakpoints are defined as minimum values.
 
@@ -124,7 +136,7 @@ const ActiveBreakpointProviderExample = () => (
   @include terra-mq-small-up {
     color: red;
   }
-  
+
   @include terra-mq-medium-up {
     color: purple;
   }

--- a/packages/terra-breakpoints/docs/README.md
+++ b/packages/terra-breakpoints/docs/README.md
@@ -10,13 +10,18 @@
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-button-group/CHANGELOG.md
+++ b/packages/terra-button-group/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.16.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-button-group/README.md
+++ b/packages/terra-button-group/README.md
@@ -17,13 +17,18 @@ The Terra Button Group component groups buttons and can maintain a toggle select
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-button-group/README.md
+++ b/packages/terra-button-group/README.md
@@ -14,6 +14,18 @@ The Terra Button Group component groups buttons and can maintain a toggle select
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-button-group`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-button-group/docs/README.md
+++ b/packages/terra-button-group/docs/README.md
@@ -8,6 +8,18 @@
   - `npm install terra-button-group`
   - `yarn add terra-button-group`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Component Features
 * [Cross-Browser Support](https://github.com/cerner/terra-ui/blob/master/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md#cross-browser-support)
 * [Responsive Support](https://github.com/cerner/terra-ui/blob/master/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md#responsive-support)

--- a/packages/terra-button-group/docs/README.md
+++ b/packages/terra-button-group/docs/README.md
@@ -11,13 +11,18 @@
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Component Features

--- a/packages/terra-button/CHANGELOG.md
+++ b/packages/terra-button/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.19.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-button/README.md
+++ b/packages/terra-button/README.md
@@ -18,13 +18,18 @@ It can be modified in color, size, and type, and can optionally display an icon.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-button/README.md
+++ b/packages/terra-button/README.md
@@ -15,6 +15,18 @@ It can be modified in color, size, and type, and can optionally display an icon.
 
 - Install with [npm](https://www.npmjs.com): `npm install terra-button`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-button/docs/README.md
+++ b/packages/terra-button/docs/README.md
@@ -12,6 +12,18 @@ The `action` variant is intended for specific solutions in which a non-inline fl
   - `npm install terra-button`
   - `yarn add terra-button`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-button/docs/README.md
+++ b/packages/terra-button/docs/README.md
@@ -15,13 +15,18 @@ The `action` variant is intended for specific solutions in which a non-inline fl
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-card/CHANGELOG.md
+++ b/packages/terra-card/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.12.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-card/README.md
+++ b/packages/terra-card/README.md
@@ -14,6 +14,18 @@ Card is a basic container with some base styling to help separate elements with 
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-card`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-card/README.md
+++ b/packages/terra-card/README.md
@@ -17,13 +17,18 @@ Card is a basic container with some base styling to help separate elements with 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-card/docs/README.md
+++ b/packages/terra-card/docs/README.md
@@ -7,6 +7,18 @@ Card is a basic container with some base styling to help separate elements with 
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-card`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-card/docs/README.md
+++ b/packages/terra-card/docs/README.md
@@ -10,13 +10,18 @@ Card is a basic container with some base styling to help separate elements with 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-content-container/CHANGELOG.md
+++ b/packages/terra-content-container/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.10.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-content-container/README.md
+++ b/packages/terra-content-container/README.md
@@ -19,13 +19,18 @@ The footer is not responsive to mobile keyboard positioning.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-content-container/README.md
+++ b/packages/terra-content-container/README.md
@@ -16,6 +16,18 @@ The footer is not responsive to mobile keyboard positioning.
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-content-container`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-content-container/docs/README.md
+++ b/packages/terra-content-container/docs/README.md
@@ -13,13 +13,18 @@ The footer is not responsive to mobile keyboard positioning.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-content-container/docs/README.md
+++ b/packages/terra-content-container/docs/README.md
@@ -10,6 +10,18 @@ The footer is not responsive to mobile keyboard positioning.
   - `npm install terra-content-container`
   - `yarn add terra-content-container`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-demographics-banner/CHANGELOG.md
+++ b/packages/terra-demographics-banner/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.16.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-demographics-banner/README.md
+++ b/packages/terra-demographics-banner/README.md
@@ -14,6 +14,19 @@ The demographics component is used to display demographic information about a pe
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-demographics-banner`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-demographics-banner/README.md
+++ b/packages/terra-demographics-banner/README.md
@@ -17,7 +17,10 @@ The demographics component is used to display demographic information about a pe
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -25,6 +28,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-demographics-banner/docs/README.md
+++ b/packages/terra-demographics-banner/docs/README.md
@@ -8,6 +8,19 @@ The demographics component is used to display demographic information about a pe
   - `npm install terra-demographics-banner`
   - `yarn add terra-demographics-banner`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Implementation Notes:
 
 The Demographics-Banner component must be composed inside the [Base][1] component with a locale in order for it to load the correct translation strings.

--- a/packages/terra-demographics-banner/docs/README.md
+++ b/packages/terra-demographics-banner/docs/README.md
@@ -11,7 +11,10 @@ The demographics component is used to display demographic information about a pe
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -19,6 +22,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Implementation Notes:

--- a/packages/terra-dialog/CHANGELOG.md
+++ b/packages/terra-dialog/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.16.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-dialog/README.md
+++ b/packages/terra-dialog/README.md
@@ -17,13 +17,18 @@ Dialogs are temporary views that can be used in a myriad of ways. Dialogs have t
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-dialog/README.md
+++ b/packages/terra-dialog/README.md
@@ -14,6 +14,18 @@ Dialogs are temporary views that can be used in a myriad of ways. Dialogs have t
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-dialog`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-dialog/docs/README.md
+++ b/packages/terra-dialog/docs/README.md
@@ -10,13 +10,18 @@ Dialogs are temporary views that can be used in a myriad of ways. Dialogs have t
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Implementation Notes:

--- a/packages/terra-dialog/docs/README.md
+++ b/packages/terra-dialog/docs/README.md
@@ -7,6 +7,18 @@ Dialogs are temporary views that can be used in a myriad of ways. Dialogs have t
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-dialog`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Implementation Notes:
 
 The Dialog component must be composed inside the [Base][1] component with a locale in order for it to load the correct translation strings.

--- a/packages/terra-divider/CHANGELOG.md
+++ b/packages/terra-divider/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.11.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-divider/README.md
+++ b/packages/terra-divider/README.md
@@ -14,6 +14,18 @@ The divider component is used to visually separate content on a layout.
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-divider`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-divider/README.md
+++ b/packages/terra-divider/README.md
@@ -17,13 +17,18 @@ The divider component is used to visually separate content on a layout.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-divider/docs/README.md
+++ b/packages/terra-divider/docs/README.md
@@ -8,6 +8,18 @@ The divider component is used to visually separate content on a layout.
   - `npm install terra-divider`
   - `yarn add terra-divider`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-divider/docs/README.md
+++ b/packages/terra-divider/docs/README.md
@@ -11,13 +11,18 @@ The divider component is used to visually separate content on a layout.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-doc-template/CHANGELOG.md
+++ b/packages/terra-doc-template/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.12.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-doc-template/README.md
+++ b/packages/terra-doc-template/README.md
@@ -17,13 +17,18 @@ The terra-doc-template component provides an adjustable template for documentati
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-doc-template/README.md
+++ b/packages/terra-doc-template/README.md
@@ -14,6 +14,18 @@ The terra-doc-template component provides an adjustable template for documentati
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-doc-template`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2018 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-doc-template/docs/README.md
+++ b/packages/terra-doc-template/docs/README.md
@@ -6,3 +6,15 @@ The terra-doc-template component provides an adjustable template for documentati
 
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-doc-template`
+
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/packages/terra-doc-template/docs/README.md
+++ b/packages/terra-doc-template/docs/README.md
@@ -10,11 +10,16 @@ The terra-doc-template component provides an adjustable template for documentati
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/packages/terra-dynamic-grid/CHANGELOG.md
+++ b/packages/terra-dynamic-grid/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.10.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-dynamic-grid/README.md
+++ b/packages/terra-dynamic-grid/README.md
@@ -14,6 +14,18 @@ The terra-dynamic-grid component provides users a way to build dynamic layouts u
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-dynamic-grid`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-dynamic-grid/README.md
+++ b/packages/terra-dynamic-grid/README.md
@@ -17,13 +17,18 @@ The terra-dynamic-grid component provides users a way to build dynamic layouts u
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-dynamic-grid/docs/README.md
+++ b/packages/terra-dynamic-grid/docs/README.md
@@ -10,6 +10,18 @@ configuration. The component supports defining custom regions across multiple re
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-dynamic-grid`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-dynamic-grid/docs/README.md
+++ b/packages/terra-dynamic-grid/docs/README.md
@@ -13,13 +13,18 @@ configuration. The component supports defining custom regions across multiple re
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-form-checkbox/CHANGELOG.md
+++ b/packages/terra-form-checkbox/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.15.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-form-checkbox/README.md
+++ b/packages/terra-form-checkbox/README.md
@@ -14,6 +14,18 @@ The Terra Form Checkbox is a responsive input component rendered as a box. When 
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-form-checkbox`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-form-checkbox/README.md
+++ b/packages/terra-form-checkbox/README.md
@@ -17,13 +17,18 @@ The Terra Form Checkbox is a responsive input component rendered as a box. When 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-form-checkbox/docs/README.md
+++ b/packages/terra-form-checkbox/docs/README.md
@@ -7,6 +7,18 @@ The Terra Form Checkbox is a responsive input component rendered as a box next t
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-form-checkbox`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Implementation Notes:
 The Form-Checkbox component must be composed inside the [Base][1] component with a locale in order for it to load the correct translation strings.
 

--- a/packages/terra-form-checkbox/docs/README.md
+++ b/packages/terra-form-checkbox/docs/README.md
@@ -10,13 +10,18 @@ The Terra Form Checkbox is a responsive input component rendered as a box next t
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Implementation Notes:

--- a/packages/terra-form-field/CHANGELOG.md
+++ b/packages/terra-form-field/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.14.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-form-field/README.md
+++ b/packages/terra-form-field/README.md
@@ -14,6 +14,19 @@ The Form Field component handles the layout of the label, help text and error te
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-form-field`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-form-field/README.md
+++ b/packages/terra-form-field/README.md
@@ -17,7 +17,10 @@ The Form Field component handles the layout of the label, help text and error te
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -25,6 +28,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-form-field/docs/README.md
+++ b/packages/terra-form-field/docs/README.md
@@ -10,7 +10,10 @@ The Form Field component handles the layout of the label, help text and error te
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -18,6 +21,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Implementation Notes:

--- a/packages/terra-form-field/docs/README.md
+++ b/packages/terra-form-field/docs/README.md
@@ -7,6 +7,19 @@ The Form Field component handles the layout of the label, help text and error te
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-form-field`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Implementation Notes:
 The Form-Field component must be composed inside the [Base][1] component with a locale in order for it to load the correct translation strings.
 

--- a/packages/terra-form-fieldset/CHANGELOG.md
+++ b/packages/terra-form-fieldset/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.17.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-form-fieldset/README.md
+++ b/packages/terra-form-fieldset/README.md
@@ -17,7 +17,10 @@ Generic form fieldset component which handles the layout of a standard form fiel
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -25,6 +28,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-form-fieldset/README.md
+++ b/packages/terra-form-fieldset/README.md
@@ -14,6 +14,19 @@ Generic form fieldset component which handles the layout of a standard form fiel
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-form-fieldset`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2018 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-form-fieldset/docs/README.md
+++ b/packages/terra-form-fieldset/docs/README.md
@@ -10,7 +10,10 @@ Generic form fieldset component which handles the layout of a standard form fiel
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -18,6 +21,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-form-fieldset/docs/README.md
+++ b/packages/terra-form-fieldset/docs/README.md
@@ -7,6 +7,19 @@ Generic form fieldset component which handles the layout of a standard form fiel
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-form-fieldset`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-form-input/CHANGELOG.md
+++ b/packages/terra-form-input/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.16.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-form-input/README.md
+++ b/packages/terra-form-input/README.md
@@ -17,13 +17,18 @@ Generic input which represents an HTML input element directly.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-form-input/README.md
+++ b/packages/terra-form-input/README.md
@@ -14,6 +14,18 @@ Generic input which represents an HTML input element directly.
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-form-input`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-form-input/docs/README.md
+++ b/packages/terra-form-input/docs/README.md
@@ -7,6 +7,18 @@ Generic input which represents an HTML input element directly.
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-form-input`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-form-input/docs/README.md
+++ b/packages/terra-form-input/docs/README.md
@@ -10,13 +10,18 @@ Generic input which represents an HTML input element directly.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-form-radio/CHANGELOG.md
+++ b/packages/terra-form-radio/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.17.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-form-radio/README.md
+++ b/packages/terra-form-radio/README.md
@@ -14,6 +14,18 @@ The Terra Form Radio is a responsive input component rendered as a radio button 
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-form-radio`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-form-radio/README.md
+++ b/packages/terra-form-radio/README.md
@@ -17,13 +17,18 @@ The Terra Form Radio is a responsive input component rendered as a radio button 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-form-radio/docs/README.md
+++ b/packages/terra-form-radio/docs/README.md
@@ -10,13 +10,18 @@ The Terra Form Radio is a responsive input component rendered as a radio button 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Implementation Notes:

--- a/packages/terra-form-radio/docs/README.md
+++ b/packages/terra-form-radio/docs/README.md
@@ -7,6 +7,18 @@ The Terra Form Radio is a responsive input component rendered as a radio button 
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-form-radio`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Implementation Notes:
 
 The Form-Radio component must be composed inside the [Base][1] component with a locale in order for it to load the correct translation strings.

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 5.20.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-form-select/README.md
+++ b/packages/terra-form-select/README.md
@@ -17,7 +17,10 @@ The select component is a form input with a drop down list of options that allow
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -25,6 +28,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-form-select/README.md
+++ b/packages/terra-form-select/README.md
@@ -14,6 +14,19 @@ The select component is a form input with a drop down list of options that allow
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-form-select`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-form-select/docs/README.md
+++ b/packages/terra-form-select/docs/README.md
@@ -10,7 +10,10 @@ The Select component provides a dropdown of selectable options.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -18,6 +21,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Implementation Notes:

--- a/packages/terra-form-select/docs/README.md
+++ b/packages/terra-form-select/docs/README.md
@@ -7,6 +7,19 @@ The Select component provides a dropdown of selectable options.
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-form-select`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Implementation Notes:
 
 The Form-Select component must be composed inside the [Base][1] component with a locale in order for it to load the correct translation strings.

--- a/packages/terra-form-textarea/CHANGELOG.md
+++ b/packages/terra-form-textarea/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.16.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-form-textarea/README.md
+++ b/packages/terra-form-textarea/README.md
@@ -16,13 +16,18 @@ Element for building out textareas in a form.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-form-textarea/README.md
+++ b/packages/terra-form-textarea/README.md
@@ -13,6 +13,18 @@ Element for building out textareas in a form.
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-form-textarea`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-form-textarea/docs/README.md
+++ b/packages/terra-form-textarea/docs/README.md
@@ -7,6 +7,18 @@ Element for building out textareas in a form.
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-form-textarea`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Component Features
 * [Cross-Browser Support](https://github.com/cerner/terra-ui/blob/master/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md#cross-browser-support)
 * [Responsive Support](https://github.com/cerner/terra-ui/blob/master/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md#responsive-support)

--- a/packages/terra-form-textarea/docs/README.md
+++ b/packages/terra-form-textarea/docs/README.md
@@ -10,13 +10,18 @@ Element for building out textareas in a form.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Component Features

--- a/packages/terra-grid/CHANGELOG.md
+++ b/packages/terra-grid/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 6.3.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-grid/README.md
+++ b/packages/terra-grid/README.md
@@ -16,13 +16,18 @@ The terra-grid component provides a flexbox based grid system.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-grid/README.md
+++ b/packages/terra-grid/README.md
@@ -13,6 +13,18 @@ The terra-grid component provides a flexbox based grid system.
 
 - Install with [npm](https://www.npmjs.com): `npm install terra-grid`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-grid/docs/README.md
+++ b/packages/terra-grid/docs/README.md
@@ -11,13 +11,18 @@ The grid component provides a flexbox based grid system.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Component Features

--- a/packages/terra-grid/docs/README.md
+++ b/packages/terra-grid/docs/README.md
@@ -8,6 +8,18 @@ The grid component provides a flexbox based grid system.
   - `npm install terra-grid`
   - `yarn add terra-grid`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Component Features
 * [Cross-Browser Support](https://github.com/cerner/terra-ui/blob/master/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md#cross-browser-support)
 * [Responsive Support](https://github.com/cerner/terra-ui/blob/master/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md#responsive-support)

--- a/packages/terra-heading/CHANGELOG.md
+++ b/packages/terra-heading/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 4.10.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-heading/README.md
+++ b/packages/terra-heading/README.md
@@ -17,13 +17,18 @@ Terra includes styling for all standard headings `h1` through `h6`, as well as s
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-heading/README.md
+++ b/packages/terra-heading/README.md
@@ -14,6 +14,18 @@ Terra includes styling for all standard headings `h1` through `h6`, as well as s
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-heading`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-heading/docs/README.md
+++ b/packages/terra-heading/docs/README.md
@@ -10,13 +10,18 @@ Terra includes styling for all standard headings `h1` through `h6`, as well as s
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-heading/docs/README.md
+++ b/packages/terra-heading/docs/README.md
@@ -7,6 +7,18 @@ Terra includes styling for all standard headings `h1` through `h6`, as well as s
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-heading`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-hyperlink/CHANGELOG.md
+++ b/packages/terra-hyperlink/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.12.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-hyperlink/README.md
+++ b/packages/terra-hyperlink/README.md
@@ -14,6 +14,18 @@ The terra hyperlink component allows linking to other web pages, files, location
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-hyperlink`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2018 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-hyperlink/README.md
+++ b/packages/terra-hyperlink/README.md
@@ -17,13 +17,18 @@ The terra hyperlink component allows linking to other web pages, files, location
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-hyperlink/docs/README.md
+++ b/packages/terra-hyperlink/docs/README.md
@@ -10,13 +10,18 @@ The terra hyperlink component allows linking to other web pages, files, location
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Component Features

--- a/packages/terra-hyperlink/docs/README.md
+++ b/packages/terra-hyperlink/docs/README.md
@@ -7,6 +7,18 @@ The terra hyperlink component allows linking to other web pages, files, location
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-hyperlink`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Component Features
 
  * [Cross-Browser Support](https://github.com/cerner/terra-ui/blob/master/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md#cross-browser-support)

--- a/packages/terra-i18n/CHANGELOG.md
+++ b/packages/terra-i18n/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 4.8.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-i18n/README.md
+++ b/packages/terra-i18n/README.md
@@ -17,6 +17,19 @@ However, terra-i18n can be installed with [npmjs](https://www.npmjs.com):
   - `npm install terra-i18n`
   - `yarn add terra-i18n`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Documentation
 
 Documentation for this component is spilt into multiple files.

--- a/packages/terra-i18n/README.md
+++ b/packages/terra-i18n/README.md
@@ -20,7 +20,10 @@ However, terra-i18n can be installed with [npmjs](https://www.npmjs.com):
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -28,6 +31,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Documentation

--- a/packages/terra-i18n/docs/README.md
+++ b/packages/terra-i18n/docs/README.md
@@ -10,6 +10,19 @@ However, terra-i18n can be installed with [npmjs](https://www.npmjs.com):
 
 The terra-i18n package provides internationalization for React components by loading translations and locale data on demand and providing the translated messages to the component. It does this by utilizing the [`react-intl`](https://github.com/yahoo/react-intl) dependency to provide the formatted translation messages to the supplied React children. To enable this behavior, terra-i18n provides the `i18nLoader` and `I18nProvider` components.
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## i18nLoader
 
 The `i18nLoader` component guarantees that the Intl polyfill, locale data and translation messages are loaded before the translation-needing component is rendered. _This loader should be utilized only once within an application, because all internationalization information is loaded into memory to remove the need to dynamically load locale data on the server._

--- a/packages/terra-i18n/docs/README.md
+++ b/packages/terra-i18n/docs/README.md
@@ -13,7 +13,10 @@ The terra-i18n package provides internationalization for React components by loa
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -21,6 +24,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## i18nLoader

--- a/packages/terra-icon/CHANGELOG.md
+++ b/packages/terra-icon/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.13.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-icon/README.md
+++ b/packages/terra-icon/README.md
@@ -17,13 +17,18 @@ The terra-icon component is used to visually represent a literal or symbolic obj
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-icon/README.md
+++ b/packages/terra-icon/README.md
@@ -14,6 +14,18 @@ The terra-icon component is used to visually represent a literal or symbolic obj
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-icon`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-icon/docs/README.md
+++ b/packages/terra-icon/docs/README.md
@@ -11,13 +11,18 @@ The terra-icon component is used to visually represent a literal or symbolic obj
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-icon/docs/README.md
+++ b/packages/terra-icon/docs/README.md
@@ -8,6 +8,18 @@ The terra-icon component is used to visually represent a literal or symbolic obj
   - `npm install terra-icon`
   - `yarn add terra-icon`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 Each Icon can be imported individually.
 

--- a/packages/terra-image/CHANGELOG.md
+++ b/packages/terra-image/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.11.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-image/README.md
+++ b/packages/terra-image/README.md
@@ -17,13 +17,18 @@ The terra-image component provides styling for visual imagery.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-image/README.md
+++ b/packages/terra-image/README.md
@@ -14,6 +14,18 @@ The terra-image component provides styling for visual imagery.
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-image`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-image/docs/README.md
+++ b/packages/terra-image/docs/README.md
@@ -8,6 +8,18 @@ The terra-image component provides styling for visual imagery.
   - `npm install terra-image`
   - `yarn add terra-image`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-image/docs/README.md
+++ b/packages/terra-image/docs/README.md
@@ -11,13 +11,18 @@ The terra-image component provides styling for visual imagery.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-legacy-theme/CHANGELOG.md
+++ b/packages/terra-legacy-theme/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.39.0 - (June 28, 2019)
 ------------------

--- a/packages/terra-legacy-theme/README.md
+++ b/packages/terra-legacy-theme/README.md
@@ -16,6 +16,18 @@
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-legacy-theme`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 This project offers two formats of terra-legacy-theme based around [browsers support for native CSS custom properties](http://caniuse.com/#search=custom%20properties) .
 

--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 4.10.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-list/README.md
+++ b/packages/terra-list/README.md
@@ -14,6 +14,18 @@ The Terra List is a structural component to arrange content within list/listitem
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-list`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-list/README.md
+++ b/packages/terra-list/README.md
@@ -17,13 +17,18 @@ The Terra List is a structural component to arrange content within list/listitem
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-list/docs/README.md
+++ b/packages/terra-list/docs/README.md
@@ -2,7 +2,7 @@
 
 The Terra List is a structural component to vertically arrange content within list/list items.
 
-If a list implementation contains selectable list options the role prop should be set to "listbox" for accesibility. 
+If a list implementation contains selectable list options the role prop should be set to "listbox" for accesibility.
 
 Two padding variants are provide for list item content, standard and compact. If different padding is desired use the defaulted style of 'none' and set the padding on the list item's child content with your own css values, preferrably themeable variables.
 
@@ -11,6 +11,18 @@ Two padding variants are provide for list item content, standard and compact. If
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-list`
   - `yarn add terra-list`
+
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage
 

--- a/packages/terra-list/docs/README.md
+++ b/packages/terra-list/docs/README.md
@@ -15,13 +15,18 @@ Two padding variants are provide for list item content, standard and compact. If
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-list/src/terra-dev-site/doc/list/List.1.doc.jsx
+++ b/packages/terra-list/src/terra-dev-site/doc/list/List.1.doc.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import DocTemplate from 'terra-doc-template';
-import ReadMe from '../../../../docs/List.md';
+import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 
 /* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */

--- a/packages/terra-markdown/CHANGELOG.md
+++ b/packages/terra-markdown/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.28.0 - (June 28, 2019)
 ------------------

--- a/packages/terra-markdown/README.md
+++ b/packages/terra-markdown/README.md
@@ -17,13 +17,18 @@ React component to display the content of markdown files.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-markdown/README.md
+++ b/packages/terra-markdown/README.md
@@ -14,6 +14,18 @@ React component to display the content of markdown files.
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-markdown`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-markdown/docs/README.md
+++ b/packages/terra-markdown/docs/README.md
@@ -11,13 +11,18 @@ React component to display the content of markdown files.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-markdown/docs/README.md
+++ b/packages/terra-markdown/docs/README.md
@@ -8,6 +8,18 @@ React component to display the content of markdown files.
   - `npm install terra-markdown`
   - `yarn add terra-markdown`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-mixins/CHANGELOG.md
+++ b/packages/terra-mixins/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 1.31.0 - (June 28, 2019)
 ------------------

--- a/packages/terra-mixins/README.md
+++ b/packages/terra-mixins/README.md
@@ -14,6 +14,9 @@ The terra-mixins component supplies global mixins for use throughout the Terra e
 
 - Install with [npm](https://www.npmjs.com): `npm install terra-mixins`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-mixins/docs/README.md
+++ b/packages/terra-mixins/docs/README.md
@@ -8,6 +8,9 @@ The terra-mixins component supplies global mixins for use throughout the Terra e
   - `npm install terra-mixins`
   - `yarn add terra-mixins`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 SCSS

--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.19.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-overlay/README.md
+++ b/packages/terra-overlay/README.md
@@ -16,6 +16,19 @@ A Loading Overlay is a subcomponent that displays an overlay with a spinner icon
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-overlay`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-overlay/README.md
+++ b/packages/terra-overlay/README.md
@@ -19,7 +19,10 @@ A Loading Overlay is a subcomponent that displays an overlay with a spinner icon
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -27,6 +30,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-overlay/docs/README.md
+++ b/packages/terra-overlay/docs/README.md
@@ -10,6 +10,19 @@ A Loading Overlay is a specialized Overlay subcomponent that displays an overlay
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-overlay`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Implementation Notes:
 
 The Overlay component must be composed inside the [Base][1] component with a locale in order for it to load the correct translation strings.
@@ -82,7 +95,7 @@ class LoadingOverlayExample extends React.Component {
       this.setState({ show: false });
     }, 5000);
   }
- 
+
   addLoadingOverlay() {
     <LoadingOverlay isOpen={this.state.show} isAnimated />
   }

--- a/packages/terra-overlay/docs/README.md
+++ b/packages/terra-overlay/docs/README.md
@@ -13,7 +13,10 @@ A Loading Overlay is a specialized Overlay subcomponent that displays an overlay
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -21,6 +24,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Implementation Notes:

--- a/packages/terra-paginator/CHANGELOG.md
+++ b/packages/terra-paginator/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.17.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-paginator/README.md
+++ b/packages/terra-paginator/README.md
@@ -17,13 +17,18 @@ Paginator to be used for data sets of known and unknown size. Provides first, la
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-paginator/README.md
+++ b/packages/terra-paginator/README.md
@@ -14,6 +14,18 @@ Paginator to be used for data sets of known and unknown size. Provides first, la
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-paginator`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2018 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-paginator/docs/README.md
+++ b/packages/terra-paginator/docs/README.md
@@ -7,6 +7,18 @@ Standard paginator to be used for data sets of known and unknown size. Provides 
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-paginator`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-paginator/docs/README.md
+++ b/packages/terra-paginator/docs/README.md
@@ -10,13 +10,18 @@ Standard paginator to be used for data sets of known and unknown size. Provides 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-profile-image/CHANGELOG.md
+++ b/packages/terra-profile-image/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.12.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-profile-image/README.md
+++ b/packages/terra-profile-image/README.md
@@ -14,6 +14,18 @@ The terra-profile-image component displays an avatar image while the profile ima
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-profile-image`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-profile-image/README.md
+++ b/packages/terra-profile-image/README.md
@@ -17,13 +17,18 @@ The terra-profile-image component displays an avatar image while the profile ima
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-profile-image/docs/README.md
+++ b/packages/terra-profile-image/docs/README.md
@@ -11,13 +11,18 @@ The terra-profile-image component displays an avatar image while the profile ima
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-profile-image/docs/README.md
+++ b/packages/terra-profile-image/docs/README.md
@@ -8,13 +8,25 @@ The terra-profile-image component displays an avatar image while the profile ima
   - `npm install terra-profile-image`
   - `yarn add terra-profile-image`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx
 import React from 'react';
 import ProfileImage from 'terra-profile-image';
 
-<ProfileImage 
-  src='https://path/to/image.jpg' width="75" height="75" />} 
+<ProfileImage
+  src='https://path/to/image.jpg' width="75" height="75" />}
 />
 ```

--- a/packages/terra-progress-bar/CHANGELOG.md
+++ b/packages/terra-progress-bar/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 4.7.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-progress-bar/README.md
+++ b/packages/terra-progress-bar/README.md
@@ -15,6 +15,19 @@ Note: The progress bar displays fill with respect to percentage (value between 0
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-progress-bar`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| terra-markdown | ^2.20.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-progress-bar/README.md
+++ b/packages/terra-progress-bar/README.md
@@ -18,7 +18,10 @@ Note: The progress bar displays fill with respect to percentage (value between 0
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -26,6 +29,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | terra-markdown | ^2.20.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-progress-bar/docs/README.md
+++ b/packages/terra-progress-bar/docs/README.md
@@ -10,6 +10,19 @@ Note: The progress bar displays fill with respect to percentage (value between 0
   - `npm install terra-progress-bar`
   - `yarn add terra-progress-bar`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| terra-markdown | ^2.20.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-progress-bar/docs/README.md
+++ b/packages/terra-progress-bar/docs/README.md
@@ -13,7 +13,10 @@ Note: The progress bar displays fill with respect to percentage (value between 0
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -21,6 +24,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | terra-markdown | ^2.20.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-props-table/CHANGELOG.md
+++ b/packages/terra-props-table/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.32.0 - (June 28, 2019)
 ------------------

--- a/packages/terra-props-table/README.md
+++ b/packages/terra-props-table/README.md
@@ -17,13 +17,18 @@ React component to render a table view for the props metadata of another react c
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## CLI

--- a/packages/terra-props-table/README.md
+++ b/packages/terra-props-table/README.md
@@ -14,6 +14,18 @@ React component to render a table view for the props metadata of another react c
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-props-table`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## CLI
 Props table is also a command utility used to generate markdown tables. The CLI accepts multiple files as input and has a single output directory.
 

--- a/packages/terra-props-table/docs/README.md
+++ b/packages/terra-props-table/docs/README.md
@@ -8,6 +8,18 @@ React component to render a table view for the props metadata of another react c
   - `npm install terra-props-table`
   - `yarn add terra-props-table`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-props-table/docs/README.md
+++ b/packages/terra-props-table/docs/README.md
@@ -11,13 +11,18 @@ React component to render a table view for the props metadata of another react c
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-responsive-element/CHANGELOG.md
+++ b/packages/terra-responsive-element/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 5.2.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-responsive-element/README.md
+++ b/packages/terra-responsive-element/README.md
@@ -15,6 +15,18 @@ The viewport can be set to the immediate parent or window.
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-responsive-element`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-responsive-element/README.md
+++ b/packages/terra-responsive-element/README.md
@@ -18,13 +18,18 @@ The viewport can be set to the immediate parent or window.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-responsive-element/docs/README.md
+++ b/packages/terra-responsive-element/docs/README.md
@@ -21,13 +21,18 @@ For the uncontrolled version of this component it is not necessary to set each b
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Component Features

--- a/packages/terra-responsive-element/docs/README.md
+++ b/packages/terra-responsive-element/docs/README.md
@@ -18,6 +18,18 @@ For the uncontrolled version of this component it is not necessary to set each b
   * `npm install terra-responsive-element`
   * `yarn add terra-responsive-element`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Component Features
 
 * [Cross-Browser Support](https://github.com/cerner/terra-ui/blob/master/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md#cross-browser-support)

--- a/packages/terra-scroll/CHANGELOG.md
+++ b/packages/terra-scroll/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.11.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-scroll/README.md
+++ b/packages/terra-scroll/README.md
@@ -13,6 +13,18 @@ The terra-scroll is a content view that hides data accessible with scrolling and
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-scroll`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-scroll/README.md
+++ b/packages/terra-scroll/README.md
@@ -16,13 +16,18 @@ The terra-scroll is a content view that hides data accessible with scrolling and
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-scroll/docs/README.md
+++ b/packages/terra-scroll/docs/README.md
@@ -12,6 +12,18 @@ The terra-scroll expands to fill it's parent container, so parent nodes are expe
   - `npm install terra-scroll`
   - `yarn add terra-scroll`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Component Features
 * [Cross-Browser Support](https://github.com/cerner/terra-ui/blob/master/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md#cross-browser-support)
 * [Responsive Support](https://github.com/cerner/terra-ui/blob/master/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md#responsive-support)

--- a/packages/terra-scroll/docs/README.md
+++ b/packages/terra-scroll/docs/README.md
@@ -15,13 +15,18 @@ The terra-scroll expands to fill it's parent container, so parent nodes are expe
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Component Features

--- a/packages/terra-search-field/CHANGELOG.md
+++ b/packages/terra-search-field/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.18.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-search-field/README.md
+++ b/packages/terra-search-field/README.md
@@ -14,6 +14,19 @@ A search component with a field that automatically performs a search callback af
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-search-field`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-search-field/README.md
+++ b/packages/terra-search-field/README.md
@@ -17,7 +17,10 @@ A search component with a field that automatically performs a search callback af
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -25,6 +28,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-search-field/docs/README.md
+++ b/packages/terra-search-field/docs/README.md
@@ -7,6 +7,19 @@ A search component with a field that automatically performs a search callback af
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-search-field`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Implementation Notes:
 
 The Searach-Field component must be composed inside the [Base][1] component with a locale in order for it to load the correct translation strings.

--- a/packages/terra-search-field/docs/README.md
+++ b/packages/terra-search-field/docs/README.md
@@ -10,7 +10,10 @@ A search component with a field that automatically performs a search callback af
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -18,6 +21,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Implementation Notes:

--- a/packages/terra-section-header/CHANGELOG.md
+++ b/packages/terra-section-header/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.16.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-section-header/README.md
+++ b/packages/terra-section-header/README.md
@@ -14,6 +14,18 @@ Section Header presentational component that provides an onClick callback.
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-section-header`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2018 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-section-header/README.md
+++ b/packages/terra-section-header/README.md
@@ -17,13 +17,18 @@ Section Header presentational component that provides an onClick callback.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-section-header/docs/README.md
+++ b/packages/terra-section-header/docs/README.md
@@ -10,13 +10,18 @@ Section Header presentational component that provides an onClick callback.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-section-header/docs/README.md
+++ b/packages/terra-section-header/docs/README.md
@@ -7,6 +7,18 @@ Section Header presentational component that provides an onClick callback.
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-section-header`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-show-hide/CHANGELOG.md
+++ b/packages/terra-show-hide/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.15.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-show-hide/README.md
+++ b/packages/terra-show-hide/README.md
@@ -18,7 +18,10 @@ Show Hide Component that will show a preview of content and then expand it with 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -26,6 +29,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-show-hide/README.md
+++ b/packages/terra-show-hide/README.md
@@ -15,6 +15,19 @@ Show Hide Component that will show a preview of content and then expand it with 
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-show-hide`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2018 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-show-hide/docs/README.md
+++ b/packages/terra-show-hide/docs/README.md
@@ -10,7 +10,10 @@ Show Hide Component that will show a preview of content and then expand it with 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -18,6 +21,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Implementation Notes:

--- a/packages/terra-show-hide/docs/README.md
+++ b/packages/terra-show-hide/docs/README.md
@@ -7,6 +7,19 @@ Show Hide Component that will show a preview of content and then expand it with 
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-show-hide`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Implementation Notes:
 
 The Show-Hide component must be composed inside the [Base][1] component with a locale in order for it to load the correct translation strings.

--- a/packages/terra-signature/CHANGELOG.md
+++ b/packages/terra-signature/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.14.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-signature/README.md
+++ b/packages/terra-signature/README.md
@@ -19,13 +19,18 @@ already been recorded. Exiting the canvas then re-entering continues the drawing
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-signature/README.md
+++ b/packages/terra-signature/README.md
@@ -16,6 +16,18 @@ already been recorded. Exiting the canvas then re-entering continues the drawing
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-signature`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-signature/docs/README.md
+++ b/packages/terra-signature/docs/README.md
@@ -9,6 +9,18 @@ already been recorded. Exiting the canvas then re-entering continues the drawing
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-signature`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-signature/docs/README.md
+++ b/packages/terra-signature/docs/README.md
@@ -12,13 +12,18 @@ already been recorded. Exiting the canvas then re-entering continues the drawing
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-spacer/CHANGELOG.md
+++ b/packages/terra-spacer/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.14.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-spacer/README.md
+++ b/packages/terra-spacer/README.md
@@ -17,13 +17,18 @@ This component is used to provide margin and/or padding space between two compon
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-spacer/README.md
+++ b/packages/terra-spacer/README.md
@@ -14,6 +14,18 @@ This component is used to provide margin and/or padding space between two compon
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-spacer`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-spacer/docs/README.md
+++ b/packages/terra-spacer/docs/README.md
@@ -11,13 +11,18 @@ This component is used to provide margin and/or padding space between two compon
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Naming Convention

--- a/packages/terra-spacer/docs/README.md
+++ b/packages/terra-spacer/docs/README.md
@@ -8,6 +8,18 @@ This component is used to provide margin and/or padding space between two compon
   - `npm install terra-spacer`
   - `yarn add install terra-spacer`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Naming Convention
 
 | Spacing scale values   | Computed REM Value |

--- a/packages/terra-status-view/CHANGELOG.md
+++ b/packages/terra-status-view/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 4.1.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-status-view/README.md
+++ b/packages/terra-status-view/README.md
@@ -16,7 +16,10 @@ The status view component provides a customizable icon, message, and buttons in 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -24,6 +27,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-status-view/README.md
+++ b/packages/terra-status-view/README.md
@@ -13,6 +13,19 @@ The status view component provides a customizable icon, message, and buttons in 
 
 - Install with [npm](https://www.npmjs.com): `npm install terra-status-view`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-status-view/docs/README.md
+++ b/packages/terra-status-view/docs/README.md
@@ -11,7 +11,10 @@ Presents an icon, title, message, and/or buttons based on a status type scenario
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
@@ -19,6 +22,8 @@ This component requires the following peer dependencies be installed in your app
 | react-dom | ^16.8.5 |
 | react-intl | ^2.8.0 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Implementation Notes:

--- a/packages/terra-status-view/docs/README.md
+++ b/packages/terra-status-view/docs/README.md
@@ -8,6 +8,19 @@ Presents an icon, title, message, and/or buttons based on a status type scenario
   - `npm install terra-status-view`
   - `yarn add terra-status-view`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+| react-intl | ^2.8.0 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Implementation Notes:
 
 The Status-View component must be composed inside the [Base][1] component with a locale in order for it to load the correct translation strings.

--- a/packages/terra-status/CHANGELOG.md
+++ b/packages/terra-status/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 4.10.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-status/README.md
+++ b/packages/terra-status/README.md
@@ -13,6 +13,18 @@ The status component provides a customizable color indictor to signify a specifi
 
 - Install with [npm](https://www.npmjs.com): `npm install terra-status`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-status/README.md
+++ b/packages/terra-status/README.md
@@ -16,13 +16,18 @@ The status component provides a customizable color indictor to signify a specifi
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-status/docs/README.md
+++ b/packages/terra-status/docs/README.md
@@ -8,6 +8,18 @@ The status component provides a customizable color indictor to signify a specifi
   - `npm install terra-status`
   - `yarn add terra-status`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-status/docs/README.md
+++ b/packages/terra-status/docs/README.md
@@ -11,13 +11,18 @@ The status component provides a customizable color indictor to signify a specifi
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-table/CHANGELOG.md
+++ b/packages/terra-table/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.18.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-table/README.md
+++ b/packages/terra-table/README.md
@@ -17,13 +17,18 @@ The Terra Table is a structural component to arrange content within table.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-table/README.md
+++ b/packages/terra-table/README.md
@@ -14,6 +14,18 @@ The Terra Table is a structural component to arrange content within table.
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-table`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-table/docs/README.md
+++ b/packages/terra-table/docs/README.md
@@ -11,13 +11,18 @@ The Terra Table is a structural component to arrange content within a table.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-table/docs/README.md
+++ b/packages/terra-table/docs/README.md
@@ -8,6 +8,18 @@ The Terra Table is a structural component to arrange content within a table.
   - `npm install terra-table`
   - `yarn add terra-table`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 Terra-table provides several different components for building tables accessible through the Table component:

--- a/packages/terra-tag/CHANGELOG.md
+++ b/packages/terra-tag/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.15.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-tag/README.md
+++ b/packages/terra-tag/README.md
@@ -15,6 +15,18 @@ It can optionally display an icon along with the text.
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-tag`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2018 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-tag/README.md
+++ b/packages/terra-tag/README.md
@@ -18,13 +18,18 @@ It can optionally display an icon along with the text.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-tag/docs/README.md
+++ b/packages/terra-tag/docs/README.md
@@ -8,6 +8,18 @@ It can optionally display an icon along with the text.
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-tag`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Component Features
 
 * [Cross-Browser Support](https://github.com/cerner/terra-ui/blob/master/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md#cross-browser-support)

--- a/packages/terra-tag/docs/README.md
+++ b/packages/terra-tag/docs/README.md
@@ -11,13 +11,18 @@ It can optionally display an icon along with the text.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Component Features

--- a/packages/terra-text/CHANGELOG.md
+++ b/packages/terra-text/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 4.10.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-text/README.md
+++ b/packages/terra-text/README.md
@@ -21,13 +21,18 @@ However, there are drawbacks to be aware of with this component. The styles set 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-text/README.md
+++ b/packages/terra-text/README.md
@@ -18,6 +18,18 @@ However, there are drawbacks to be aware of with this component. The styles set 
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-text`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-text/docs/README.md
+++ b/packages/terra-text/docs/README.md
@@ -14,13 +14,18 @@ However, there are some drawbacks to be aware of with this component. The styles
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-text/docs/README.md
+++ b/packages/terra-text/docs/README.md
@@ -11,6 +11,18 @@ However, there are some drawbacks to be aware of with this component. The styles
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-text`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-toggle-button/CHANGELOG.md
+++ b/packages/terra-toggle-button/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.15.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-toggle-button/README.md
+++ b/packages/terra-toggle-button/README.md
@@ -14,6 +14,18 @@ ToggleButton component that transitions content in and out with the click on a b
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-toggle-button`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-toggle-button/README.md
+++ b/packages/terra-toggle-button/README.md
@@ -17,13 +17,18 @@ ToggleButton component that transitions content in and out with the click on a b
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-toggle-button/docs/README.md
+++ b/packages/terra-toggle-button/docs/README.md
@@ -7,6 +7,18 @@ Toggle Button component that transitions content in and out with the click on a 
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-toggle-button`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-toggle-button/docs/README.md
+++ b/packages/terra-toggle-button/docs/README.md
@@ -10,13 +10,18 @@ Toggle Button component that transitions content in and out with the click on a 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-toggle-section-header/CHANGELOG.md
+++ b/packages/terra-toggle-section-header/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.15.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-toggle-section-header/README.md
+++ b/packages/terra-toggle-section-header/README.md
@@ -14,6 +14,18 @@ Toggle section header component that transitions content in and out with a click
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-toggle-section-header`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2018 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-toggle-section-header/README.md
+++ b/packages/terra-toggle-section-header/README.md
@@ -17,13 +17,18 @@ Toggle section header component that transitions content in and out with a click
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-toggle-section-header/docs/README.md
+++ b/packages/terra-toggle-section-header/docs/README.md
@@ -7,6 +7,18 @@ Toggle section header component that transitions content in and out with a click
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-toggle-section-header`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-toggle-section-header/docs/README.md
+++ b/packages/terra-toggle-section-header/docs/README.md
@@ -10,13 +10,18 @@ Toggle section header component that transitions content in and out with a click
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-toggle/CHANGELOG.md
+++ b/packages/terra-toggle/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 3.14.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-toggle/README.md
+++ b/packages/terra-toggle/README.md
@@ -17,13 +17,18 @@ Toggle component that transitions content in and out.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-toggle/README.md
+++ b/packages/terra-toggle/README.md
@@ -14,6 +14,18 @@ Toggle component that transitions content in and out.
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-toggle`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2017 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-toggle/docs/README.md
+++ b/packages/terra-toggle/docs/README.md
@@ -7,6 +7,18 @@ Toggle component that transitions content in and out. For toggle button function
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-toggle`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Usage
 
 ```jsx

--- a/packages/terra-toggle/docs/README.md
+++ b/packages/terra-toggle/docs/README.md
@@ -10,13 +10,18 @@ Toggle component that transitions content in and out. For toggle button function
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Usage

--- a/packages/terra-visually-hidden-text/CHANGELOG.md
+++ b/packages/terra-visually-hidden-text/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added documentation on required peerDependencies
 
 2.11.0  - (July 11, 2019)
 ------------------

--- a/packages/terra-visually-hidden-text/README.md
+++ b/packages/terra-visually-hidden-text/README.md
@@ -13,6 +13,18 @@ Text that is designed to only be read by a screen reader.
 
 - Install from [npmjs](https://www.npmjs.com): `npm install terra-visually-hidden-text`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## LICENSE
 
 Copyright 2018 - 2019 Cerner Innovation, Inc.

--- a/packages/terra-visually-hidden-text/README.md
+++ b/packages/terra-visually-hidden-text/README.md
@@ -16,13 +16,18 @@ Text that is designed to only be read by a screen reader.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## LICENSE

--- a/packages/terra-visually-hidden-text/docs/README.md
+++ b/packages/terra-visually-hidden-text/docs/README.md
@@ -15,6 +15,18 @@ In these instances, it's recommended to use visually hidden text.
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-visually-hidden-text`
 
+<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+
+| Peer Dependency | Version |
+|-|-|
+| react | ^16.8.5 |
+| react-dom | ^16.8.5 |
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 ## Component Features
 
  * [Cross-Browser Support](https://engineering.cerner.com/terra-ui/#/getting-started/terra-ui/features)

--- a/packages/terra-visually-hidden-text/docs/README.md
+++ b/packages/terra-visually-hidden-text/docs/README.md
@@ -18,13 +18,18 @@ In these instances, it's recommended to use visually hidden text.
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 
 | Peer Dependency | Version |
 |-|-|
 | react | ^16.8.5 |
 | react-dom | ^16.8.5 |
 
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Component Features

--- a/scripts/peer-dependency-generator/findAndReplace.js
+++ b/scripts/peer-dependency-generator/findAndReplace.js
@@ -1,0 +1,24 @@
+/* eslint-disable no-console */
+/* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
+const fs = require('fs');
+
+const findAndReplace = (options) => {
+  /* eslint-disable-next-line consistent-return */
+  fs.readFile(options.file, 'utf8', (errMsg, data) => {
+    if (errMsg) {
+      return console.log(errMsg);
+    }
+
+    const result = data.replace(options.regex, options.content);
+
+    fs.writeFile(options.file, result, 'utf8', (error) => {
+      if (error) {
+        console.error(`Error writing content to ${options.file} ${error}\n`);
+      } else {
+        console.log(`Content written to ${options.file}`);
+      }
+    });
+  });
+};
+
+module.exports = findAndReplace;

--- a/scripts/peer-dependency-generator/generatePeerDependencyDoc.js
+++ b/scripts/peer-dependency-generator/generatePeerDependencyDoc.js
@@ -1,0 +1,24 @@
+const generatePeerDependencyDoc = (peerDependencies) => {
+  const tableHeader = '| Peer Dependency | Version |';
+  const tableHeaderBottom = '|-|-|';
+
+  const dependencyRows = Object.keys(peerDependencies).sort().map((dependency) => {
+    // Use the peer dependency version specified in the package.json
+    const specifiedVersion = peerDependencies[dependency];
+
+    return `| ${dependency} | ${specifiedVersion} |`;
+  });
+
+  const dependencyTableMarkdown = `\n${tableHeader}\n${tableHeaderBottom}\n${dependencyRows.join('\n')}\n`;
+
+  const peerDependenciesContent = `<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
+## Peer Dependencies
+
+This component requires the following peer dependencies be installed in your app to properly function as designed.
+${dependencyTableMarkdown}
+<!-- AUTO-GENERATED-CONTENT:END -->`;
+
+  return peerDependenciesContent;
+};
+
+module.exports = generatePeerDependencyDoc;

--- a/scripts/peer-dependency-generator/generatePeerDependencyDoc.js
+++ b/scripts/peer-dependency-generator/generatePeerDependencyDoc.js
@@ -14,8 +14,13 @@ const generatePeerDependencyDoc = (peerDependencies) => {
   const peerDependenciesContent = `<!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 
-This component requires the following peer dependencies be installed in your app to properly function as designed.
+<details>
+<summary>View information on this component's peer dependencies.</summary>
+
+This component requires the following peer dependencies be installed in your app for the component to properly function.
 ${dependencyTableMarkdown}
+
+</details>
 <!-- AUTO-GENERATED-CONTENT:END -->`;
 
   return peerDependenciesContent;

--- a/scripts/peer-dependency-generator/getPackagePaths.js
+++ b/scripts/peer-dependency-generator/getPackagePaths.js
@@ -1,0 +1,17 @@
+/* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
+const fs = require('fs');
+const glob = require('glob');
+const lernaJson = require('../../lerna.json');
+
+const packagePaths = ['./'];
+
+// Get the base directory paths for each package
+lernaJson.packages.forEach((globPath) => {
+  glob.sync(globPath).forEach((packagePath) => {
+    if (fs.existsSync(packagePath)) {
+      packagePaths.push(packagePath);
+    }
+  });
+});
+
+module.exports = packagePaths;

--- a/scripts/peer-dependency-generator/index.js
+++ b/scripts/peer-dependency-generator/index.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
+const fs = require('fs');
+const path = require('path');
+const packagePaths = require('./getPackagePaths');
+const generatePeerDependenciesDoc = require('./generatePeerDependencyDoc');
+const findAndReplace = require('./findAndReplace');
+
+// Generate the markdown to display peerDependencies information for each package
+packagePaths.forEach((packagePath) => {
+  const packageFile = path.resolve(packagePath, 'package.json');
+  const readmeFile = path.resolve(packagePath, 'README.md');
+  const docReadmeFile = path.resolve(packagePath, 'docs/README.md');
+
+  if (!fs.existsSync(packageFile) || !fs.existsSync(readmeFile) || !fs.existsSync(docReadmeFile)) {
+    return; /* eslint-disable-line no-useless-return */
+  }
+
+  // Read package.json and pull out peerDependencies
+  fs.readFile(packageFile, 'utf8', (err, packageJson) => {
+    if (err) {
+      console.error(`Error reading file ${packageFile} ${err}\n`);
+    } else {
+      const { peerDependencies } = JSON.parse(packageJson);
+
+      if (peerDependencies) {
+        const peerDependenciesDoc = generatePeerDependenciesDoc(peerDependencies);
+        const regex = /<!--.AUTO-GENERATED-CONTENT.START.Peer.Dependencies.-->(.|\n)*<!--.AUTO-GENERATED-CONTENT:END.-->/g;
+
+        // Update peerDependencies in ./README.md
+        findAndReplace({
+          file: readmeFile, regex, content: peerDependenciesDoc,
+        });
+
+        // Update peerDependencies in ./docs/README.md
+        findAndReplace({
+          file: docReadmeFile, regex, content: peerDependenciesDoc,
+        });
+      }
+    }
+  });
+});


### PR DESCRIPTION
### Summary
Adds npm script, `docs:peerDependencies`, that will find and replace file contents in our `README.md` files with peer dependency information for each package.''

Related to https://github.com/cerner/terra-framework/issues/778