### PR TITLE
Update overlay to use getAttribute

### DIFF
--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -1,10 +1,13 @@
 Changelog
 =========
-### Changed
-* Components updated to use `injectIntl` to interface with `react-intl's` `intl` context.
 
 Unreleased
 ----------
+### Fixed
+* Fixed issue in IE 10 when trying to pull value from data attribute
+
+### Changed
+* Components updated to use `injectIntl` to interface with `react-intl's` `intl` context.
 
 3.20.0 - (July 16, 2019)
 ------------------

--- a/packages/terra-overlay/src/Overlay.jsx
+++ b/packages/terra-overlay/src/Overlay.jsx
@@ -110,7 +110,7 @@ class Overlay extends React.Component {
         document.querySelector(selector).setAttribute('data-overlay-count', '1');
         document.querySelector(selector).setAttribute('inert', '');
       } else if (document.querySelector(selector) && document.querySelector(selector).hasAttribute('data-overlay-count')) {
-        const inert = +document.querySelector(selector).dataset.overlayCount;
+        const inert = +document.querySelector(selector).getAttribute('data-overlay-count');
 
         document.querySelector(selector).setAttribute('data-overlay-count', `${inert + 1}`);
         document.querySelector(selector).setAttribute('inert', '');
@@ -128,7 +128,7 @@ class Overlay extends React.Component {
       const selector = this.props.rootSelector;
 
       if (document.querySelector(selector)) { // Guard for Jest testing
-        const inert = +document.querySelector(selector).dataset.overlayCount;
+        const inert = +document.querySelector(selector).getAttribute('data-overlay-count');
 
         if (inert === 1) {
           document.querySelector(selector).removeAttribute('data-overlay-count');


### PR DESCRIPTION
### Summary
Updates code to use `.getAttribute` instead of `.dataset` to get data attribute value.

Resolves #2529 