### PR TITLE
Update markdown dependencies

### DIFF
--- a/packages/terra-markdown/CHANGELOG.md
+++ b/packages/terra-markdown/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated marked to 0.7.x
+* Updated primsjs to ~1.17.1
 
 2.30.0 - (July 24, 2019)
 ------------------

--- a/packages/terra-markdown/package.json
+++ b/packages/terra-markdown/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "marked": "0.6.2",
-    "prismjs": "~1.16.0",
+    "marked": "0.7.x",
+    "prismjs": "~1.17.1",
     "prop-types": "^15.5.8"
   },
   "scripts": {

--- a/packages/terra-markdown/src/Markdown.scss
+++ b/packages/terra-markdown/src/Markdown.scss
@@ -116,9 +116,11 @@
     color: #218336;
   }
 
-  .token.diff.important {
+  .token.diff.important,
+  .token.diff.bold {
     background: #ffebda;
     color: #b54d08;
+    font-weight: normal;
   }
 
   // All other markdown


### PR DESCRIPTION
### Summary
* Updated marked to `0.7.x`
* Updated primsjs to `~1.17.1`

[marked 0.7.0](https://github.com/markedjs/marked/releases/tag/v0.7.0) has breaking changes in it but I could not find anything in our use that would break with this update. Planning to consider this a minor update.

Updating primsjs to prevent duplicate package issue with dependency build in with [react-syntax-highlighter](https://github.com/conorhastings/react-syntax-highlighter/blob/master/package.json#L12)

<img width="342" alt="Screen Shot 2019-07-26 at 2 50 07 PM" src="https://user-images.githubusercontent.com/633148/61977683-b78dac00-afb4-11e9-843f-2206c07b6c85.png">
