### PR TITLE
Remove react and react-dom as dependencies from terra-section-header

### DIFF
--- a/packages/terra-section-header/CHANGELOG.md
+++ b/packages/terra-section-header/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * updated package.json test scripts
+* Remove react and react-dom as dependencies
 
 2.19.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-section-header/package.json
+++ b/packages/terra-section-header/package.json
@@ -28,8 +28,6 @@
     "classnames": "^2.2.5",
     "keycode-js": "^1.0.4",
     "prop-types": "^15.5.8",
-    "react": "^16.8.5",
-    "react-dom": "^16.8.5",
     "terra-arrange": "^3.17.0",
     "terra-doc-template": "^2.15.0",
     "terra-mixins": "^1.33.0"


### PR DESCRIPTION
### Summary
When consuming terra-section-header, a warning appears stating that "Multiple versions of react were found". I looked around and didn't see any other components declaring React as a dependency, only as a peer dependency, which makes sense. 

### Additional Details
Error
```
ERROR in react
  Multiple versions of react found:
    16.8.6 ./~/react
    16.9.0 ./~/terra-section-header/~/react
```