### PR TITLE
Test eslint-config major version bump changes

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -5,8 +5,8 @@ const CHANGELOG_PATTERN = /^packages\/terra-([a-z-0-9])*\/CHANGELOG\.md/i;
 
 const changedFiles = danger.git.created_files.concat(danger.git.modified_files);
 
-const changedChangelogs = new Set();
-const changedPackages = new Set();
+const changedChangelogs = new Set(); // eslint-disable-line compat/compat
+const changedPackages = new Set(); // eslint-disable-line compat/compat
 
 changedFiles.forEach((file) => {
   // file isn't in a package so it has no changelog, skip further processing
@@ -23,7 +23,7 @@ changedFiles.forEach((file) => {
   }
 });
 
-const missingChangelogs = [...changedPackages].filter(packageName => !changedChangelogs.has(packageName));
+const missingChangelogs = [...changedPackages].filter((packageName) => !changedChangelogs.has(packageName));
 
 // Fail if there are package changes without a CHANGELOG update
 if (missingChangelogs.length > 0) {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -5,8 +5,8 @@ const CHANGELOG_PATTERN = /^packages\/terra-([a-z-0-9])*\/CHANGELOG\.md/i;
 
 const changedFiles = danger.git.created_files.concat(danger.git.modified_files);
 
-const changedChangelogs = new Set(); // eslint-disable-line compat/compat
-const changedPackages = new Set(); // eslint-disable-line compat/compat
+const changedChangelogs = new Set();
+const changedPackages = new Set();
 
 changedFiles.forEach((file) => {
   // file isn't in a package so it has no changelog, skip further processing

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "jest:coverage": "jest --coverage --config jestconfig.js",
     "link-parent-bin": "link-parent-bin",
     "lint": "npm run lint:js && npm run lint:scss",
-    "lint:js": "eslint --ext .js,.jsx .",
+    "lint:js": "eslint --fix --ext .js,.jsx .",
     "lint:scss": "stylelint 'packages/**/src/**/*.scss' --syntax scss",
     "pretest": "npm run lint",
     "postinstall": "link-parent-bin && npm run compile && npm run bootstrap:hoist",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.2.2",
     "eslint": "^5.0.0",
-    "eslint-config-terra": "^2.0.0",
+    "eslint-config-terra": "cerner/eslint-config-terra#update-dependencies",
     "gh-pages": "^2.0.1",
     "glob": "^7.1.2",
     "identity-obj-proxy": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.2.2",
-    "eslint": "^5.0.0",
+    "eslint": "^6.1.0",
     "eslint-config-terra": "cerner/eslint-config-terra#update-dependencies",
     "gh-pages": "^2.0.1",
     "glob": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "jest:coverage": "jest --coverage --config jestconfig.js",
     "link-parent-bin": "link-parent-bin",
     "lint": "npm run lint:js && npm run lint:scss",
-    "lint:js": "eslint --fix --ext .js,.jsx .",
+    "lint:js": "eslint --ext .js,.jsx .",
     "lint:scss": "stylelint 'packages/**/src/**/*.scss' --syntax scss",
     "pretest": "npm run lint",
     "postinstall": "link-parent-bin && npm run compile && npm run bootstrap:hoist",

--- a/packages/terra-action-footer/CHANGELOG.md
+++ b/packages/terra-action-footer/CHANGELOG.md
@@ -4,7 +4,9 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
+* Updated code to match new eslint rules
 
 2.18.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-action-footer/src/terra-dev-site/doc/example/centered/MultipleActions.jsx
+++ b/packages/terra-action-footer/src/terra-dev-site/doc/example/centered/MultipleActions.jsx
@@ -9,12 +9,12 @@ export default () => (
   <ExampleTemplate>
     <CenteredActionFooter
       center={(
-        <React.Fragment>
+        <>
           <Spacer isInlineBlock marginRight="medium">
             <Button text="Action One" />
           </Spacer>
           <Button text="Action Two" />
-        </React.Fragment>
+        </>
       )}
     />
   </ExampleTemplate>

--- a/packages/terra-action-footer/src/terra-dev-site/doc/example/standard/MultipleStartEndActions.jsx
+++ b/packages/terra-action-footer/src/terra-dev-site/doc/example/standard/MultipleStartEndActions.jsx
@@ -11,12 +11,12 @@ export default () => (
     <ActionFooter
       start={<Hyperlink href="#">Start Action</Hyperlink>}
       end={(
-        <React.Fragment>
+        <>
           <Spacer isInlineBlock marginRight="medium">
             <Button text="Submit" variant={Button.Opts.Variants.EMPHASIS} />
           </Spacer>
           <Button text="Cancel" />
-        </React.Fragment>
+        </>
       )}
     />
   </ExampleTemplate>

--- a/packages/terra-action-header/CHANGELOG.md
+++ b/packages/terra-action-header/CHANGELOG.md
@@ -5,7 +5,8 @@ Unreleased
 ----------
 ### Changed
 * Components updated to use `FormattedMessage` to interface with `react-intl's` `intl` context.
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 2.24.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-action-header/src/ActionHeader.jsx
+++ b/packages/terra-action-header/src/ActionHeader.jsx
@@ -87,7 +87,7 @@ const ActionHeader = ({
   const closeButton = onClose
     ? (
       <FormattedMessage id="Terra.actionHeader.close">
-        {closeText => (
+        {(closeText) => (
           <Button className={cx('header-close-button')} isIconOnly icon={<span className={cx(['header-icon', 'close'])} />} text={closeText} onClick={onClose} />
         )}
       </FormattedMessage>
@@ -96,7 +96,7 @@ const ActionHeader = ({
   const backButton = onBack
     ? (
       <FormattedMessage id="Terra.actionHeader.back">
-        {backText => (
+        {(backText) => (
           <Button className={cx('header-back-button')} isIconOnly icon={<span className={cx(['header-icon', 'back'])} />} text={backText} onClick={onBack} />
         )}
       </FormattedMessage>
@@ -108,7 +108,7 @@ const ActionHeader = ({
     if (onMaximize) {
       expandButton = (
         <FormattedMessage id="Terra.actionHeader.maximize">
-          {maximizeText => (
+          {(maximizeText) => (
             <Button isIconOnly icon={<span className={cx(['header-icon', 'maximize'])} />} text={maximizeText} onClick={onMaximize} />
           )}
         </FormattedMessage>
@@ -116,7 +116,7 @@ const ActionHeader = ({
     } else if (onMinimize) {
       expandButton = (
         <FormattedMessage id="Terra.actionHeader.minimize">
-          {minimizeText => (
+          {(minimizeText) => (
             <Button isIconOnly icon={<span className={cx(['header-icon', 'minimize'])} />} text={minimizeText} onClick={onMinimize} />
           )}
         </FormattedMessage>
@@ -128,7 +128,7 @@ const ActionHeader = ({
     ? (
       <ButtonGroup>
         <FormattedMessage id="Terra.actionHeader.previous">
-          {previousText => (
+          {(previousText) => (
             <ButtonGroup.Button
               icon={<span className={cx(['header-icon', 'previous'])} />}
               text={previousText}
@@ -139,7 +139,7 @@ const ActionHeader = ({
           )}
         </FormattedMessage>
         <FormattedMessage id="Terra.actionHeader.next">
-          {nextText => (
+          {(nextText) => (
             <ButtonGroup.Button
               icon={<span className={cx(['header-icon', 'next'])} />}
               text={nextText}

--- a/packages/terra-action-header/src/_ActionHeaderContainer.jsx
+++ b/packages/terra-action-header/src/_ActionHeaderContainer.jsx
@@ -44,7 +44,7 @@ const ActionHeaderContainer = ({
 }) => {
   const HeaderElement = `h${level}`;
 
-  const content = React.Children.map(children, child => (
+  const content = React.Children.map(children, (child) => (
     React.cloneElement(child, { className: cx(['flex-collapse', children.props.className]) })
   ));
 

--- a/packages/terra-alert/CHANGELOG.md
+++ b/packages/terra-alert/CHANGELOG.md
@@ -5,7 +5,8 @@ Unreleased
 ----------
 ### Changed
 * Components updated to use `FormattedMessage` to interface with `react-intl's` `intl` context.
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 4.7.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-alert/src/Alert.jsx
+++ b/packages/terra-alert/src/Alert.jsx
@@ -108,7 +108,7 @@ const Alert = ({
   ...customProps
 }) => {
   const defaultTitle = type === AlertTypes.CUSTOM ? '' : <FormattedMessage id={`Terra.alert.${type}`} />;
-  const attributes = Object.assign({}, customProps);
+  const attributes = { ...customProps };
   const narrowAlertClassNames = cx([
     'alert-base',
     type,
@@ -138,7 +138,7 @@ const Alert = ({
   if (onDismiss) {
     dismissButton = (
       <FormattedMessage id="Terra.alert.dismiss">
-        {buttonText => (
+        {(buttonText) => (
           <Button text={buttonText} onClick={onDismiss} />
         )}
       </FormattedMessage>

--- a/packages/terra-alert/src/terra-dev-site/test/alert/AlertActionButton.test.jsx
+++ b/packages/terra-alert/src/terra-dev-site/test/alert/AlertActionButton.test.jsx
@@ -12,7 +12,7 @@ class AlertActionButton extends React.Component {
   }
 
   actionFunc() {
-    this.setState(prevState => ({ actionButtonClickCount: prevState.actionButtonClickCount + 1 }));
+    this.setState((prevState) => ({ actionButtonClickCount: prevState.actionButtonClickCount + 1 }));
   }
 
   render() {

--- a/packages/terra-arrange/CHANGELOG.md
+++ b/packages/terra-arrange/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 * Updated Props description for alignFitEnd and alignFill.
 
 3.17.0 - (July 30, 2019)

--- a/packages/terra-arrange/src/Arrange.jsx
+++ b/packages/terra-arrange/src/Arrange.jsx
@@ -70,9 +70,9 @@ const Arrange = ({
   fitEndAttributes,
   ...customProps
 }) => {
-  const fitStartProps = Object.assign({}, fitStartAttributes);
-  const fillProps = Object.assign({}, fillAttributes);
-  const fitEndProps = Object.assign({}, fitEndAttributes);
+  const fitStartProps = { ...fitStartAttributes };
+  const fillProps = { ...fillAttributes };
+  const fitEndProps = { ...fitEndAttributes };
 
   return (
     <div {...customProps} className={cx('arrange', customProps.className)}>

--- a/packages/terra-arrange/src/terra-dev-site/test/arrange/common/examplesetup.jsx
+++ b/packages/terra-arrange/src/terra-dev-site/test/arrange/common/examplesetup.jsx
@@ -25,7 +25,7 @@ const longText = (
 );
 const longWordText = <div>{longWord}</div>;
 
-const ArrangeWrapper = props => (
+const ArrangeWrapper = (props) => (
   <div className={cx('arrange-wrapper')}>
     {props.children}
   </div>

--- a/packages/terra-avatar/CHANGELOG.md
+++ b/packages/terra-avatar/CHANGELOG.md
@@ -7,7 +7,8 @@ Unreleased
 * Fixed issue for avatar to allow non-square images by sending `Fit` as `cover`.
 
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 2.23.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-avatar/src/variants/Avatar.jsx
+++ b/packages/terra-avatar/src/variants/Avatar.jsx
@@ -95,7 +95,7 @@ class Avatar extends React.Component {
     }
 
     const attributes = { ...customProps };
-    const customStyles = size ? Object.assign({ fontSize: size }, attributes.style) : attributes.style;
+    const customStyles = size ? ({ fontSize: size, ...attributes.style }) : attributes.style;
     const avatarClassNames = cx([
       'avatar',
       setColor(alt, color, hashValue),

--- a/packages/terra-avatar/src/variants/Facility.jsx
+++ b/packages/terra-avatar/src/variants/Facility.jsx
@@ -79,7 +79,7 @@ class Facility extends React.Component {
       facilityContent = generateImagePlaceholder(alt, isAriaHidden, AVATAR_VARIANTS.FACILITY);
     }
     const attributes = { ...customProps };
-    const customStyles = size ? Object.assign({ fontSize: size }, attributes.style) : attributes.style;
+    const customStyles = size ? ({ fontSize: size, ...attributes.style }) : attributes.style;
     const facilityClassNames = cx([
       'avatar',
       setColor(alt, color, hashValue),

--- a/packages/terra-avatar/src/variants/SharedUser.jsx
+++ b/packages/terra-avatar/src/variants/SharedUser.jsx
@@ -50,7 +50,7 @@ const SharedUser = ({
 }) => {
   const colorVariant = setColor(alt, color, hashValue);
   const attributes = { ...customProps };
-  const customStyles = size ? Object.assign({ fontSize: size }, attributes.style) : attributes.style;
+  const customStyles = size ? ({ fontSize: size, ...attributes.style }) : attributes.style;
   const multiUserClassNames = cx([
     'avatar',
     `${colorVariant}`,

--- a/packages/terra-badge/CHANGELOG.md
+++ b/packages/terra-badge/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
 
 3.19.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-base/CHANGELOG.md
+++ b/packages/terra-base/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 5.15.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-base/src/Base.jsx
+++ b/packages/terra-base/src/Base.jsx
@@ -79,7 +79,7 @@ class Base extends React.Component {
       translationsLoadingPlaceholder,
     } = this.props;
 
-    const messages = Object.assign({}, this.state.messages, customMessages);
+    const messages = { ...this.state.messages, ...customMessages };
     const renderChildren = strictMode ? (<React.StrictMode>{children}</React.StrictMode>) : children;
 
     if (!this.state.areTranslationsLoaded) return <div>{translationsLoadingPlaceholder}</div>;

--- a/packages/terra-breakpoints/CHANGELOG.md
+++ b/packages/terra-breakpoints/CHANGELOG.md
@@ -4,7 +4,8 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 2.14.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-breakpoints/src/terra-dev-site/doc/example/ActiveBreakpointProviderExample.jsx
+++ b/packages/terra-breakpoints/src/terra-dev-site/doc/example/ActiveBreakpointProviderExample.jsx
@@ -17,7 +17,7 @@ const ActiveBreakpointConsumer1 = withActiveBreakpoint(({ activeBreakpoint }) =>
 const ActiveBreakpointConsumer2 = () => (
   <ActiveBreakpointContext.Consumer>
     {
-      activeBreakpoint => (
+      (activeBreakpoint) => (
         <div>
           <p>This component interfaces with the ActiveBreakpointContext directly.</p>
           <p>

--- a/packages/terra-breakpoints/src/withActiveBreakpoint.jsx
+++ b/packages/terra-breakpoints/src/withActiveBreakpoint.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import ActiveBreakpointContext from './ActiveBreakpointContext';
 
 const withActiveBreakpoint = (WrappedComponent) => {
-  const WithActiveBreakpointComp = props => (
+  const WithActiveBreakpointComp = (props) => (
     <ActiveBreakpointContext.Consumer>
-      {activeBreakpoint => <WrappedComponent {...props} activeBreakpoint={activeBreakpoint} />}
+      {(activeBreakpoint) => <WrappedComponent {...props} activeBreakpoint={activeBreakpoint} />}
     </ActiveBreakpointContext.Consumer>
   );
 

--- a/packages/terra-button-group/CHANGELOG.md
+++ b/packages/terra-button-group/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 3.19.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-button-group/src/terra-dev-site/doc/example/ButtonGroupIsBlock.jsx
+++ b/packages/terra-button-group/src/terra-dev-site/doc/example/ButtonGroupIsBlock.jsx
@@ -11,7 +11,7 @@ class ButtonGroupIsBlock extends React.Component {
 
   handleSelection(event, key) {
     event.preventDefault();
-    this.setState(prevState => ({ selectedKeys: ButtonGroup.Utils.handleMultiSelectedKeys(prevState.selectedKeys, key) }));
+    this.setState((prevState) => ({ selectedKeys: ButtonGroup.Utils.handleMultiSelectedKeys(prevState.selectedKeys, key) }));
   }
 
   render() {

--- a/packages/terra-button-group/src/terra-dev-site/doc/example/ButtonGroupMultiSelect.jsx
+++ b/packages/terra-button-group/src/terra-dev-site/doc/example/ButtonGroupMultiSelect.jsx
@@ -11,7 +11,7 @@ class ButtonGroupMultiSelect extends React.Component {
 
   handleSelection(event, key) {
     event.preventDefault();
-    this.setState(prevState => ({ selectedKeys: ButtonGroup.Utils.handleMultiSelectedKeys(prevState.selectedKeys, key) }));
+    this.setState((prevState) => ({ selectedKeys: ButtonGroup.Utils.handleMultiSelectedKeys(prevState.selectedKeys, key) }));
   }
 
   render() {

--- a/packages/terra-button-group/src/terra-dev-site/test/button-group/ButtonGroupIsBlock.test.jsx
+++ b/packages/terra-button-group/src/terra-dev-site/test/button-group/ButtonGroupIsBlock.test.jsx
@@ -10,7 +10,7 @@ class ButtonGroupIsBlock extends React.Component {
 
   handleSelection(event, key) {
     event.preventDefault();
-    this.setState(prevState => ({ selectedKeys: ButtonGroup.Utils.handleMultiSelectedKeys(prevState.selectedKeys, key) }));
+    this.setState((prevState) => ({ selectedKeys: ButtonGroup.Utils.handleMultiSelectedKeys(prevState.selectedKeys, key) }));
   }
 
   render() {

--- a/packages/terra-button-group/src/terra-dev-site/test/button-group/ButtonGroupIsBlockLongText.test.jsx
+++ b/packages/terra-button-group/src/terra-dev-site/test/button-group/ButtonGroupIsBlockLongText.test.jsx
@@ -10,7 +10,7 @@ class ButtonGroupIsBlockLongText extends React.Component {
 
   handleSelection(event, key) {
     event.preventDefault();
-    this.setState(prevState => ({ selectedKeys: ButtonGroup.Utils.handleMultiSelectedKeys(prevState.selectedKeys, key) }));
+    this.setState((prevState) => ({ selectedKeys: ButtonGroup.Utils.handleMultiSelectedKeys(prevState.selectedKeys, key) }));
   }
 
   render() {

--- a/packages/terra-button-group/src/terra-dev-site/test/button-group/ButtonGroupMultiSelect.test.jsx
+++ b/packages/terra-button-group/src/terra-dev-site/test/button-group/ButtonGroupMultiSelect.test.jsx
@@ -10,7 +10,7 @@ class ButtonGroupMultiSelect extends React.Component {
 
   handleSelection(event, key) {
     event.preventDefault();
-    this.setState(prevState => ({ selectedKeys: ButtonGroup.Utils.handleMultiSelectedKeys(prevState.selectedKeys, key) }));
+    this.setState((prevState) => ({ selectedKeys: ButtonGroup.Utils.handleMultiSelectedKeys(prevState.selectedKeys, key) }));
   }
 
   render() {

--- a/packages/terra-button/CHANGELOG.md
+++ b/packages/terra-button/CHANGELOG.md
@@ -8,7 +8,7 @@ Unreleased
 
 ### Changed
 * Update tests for dev-site v6
-* updated package.json test scripts
+* Updated package.json test scripts
 
 3.18.0 - (July 24, 2019)
 ------------------

--- a/packages/terra-card/CHANGELOG.md
+++ b/packages/terra-card/CHANGELOG.md
@@ -4,7 +4,8 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 3.15.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-card/src/Card.jsx
+++ b/packages/terra-card/src/Card.jsx
@@ -21,7 +21,7 @@ const propTypes = {
   /**
    * Sets the card variant to change the style for different use cases. One of `default`,  `raised`.
    */
-  variant: PropTypes.oneOf([...Object.values(CardVariants)]), // eslint-disable-line compat/compat
+  variant: PropTypes.oneOf([...Object.values(CardVariants)]),
   /**
    * Text that describes the badge to a screen reader. Use this
    * if more information is needed to accurately describe

--- a/packages/terra-card/src/Card.jsx
+++ b/packages/terra-card/src/Card.jsx
@@ -21,7 +21,7 @@ const propTypes = {
   /**
    * Sets the card variant to change the style for different use cases. One of `default`,  `raised`.
    */
-  variant: PropTypes.oneOf([...Object.values(CardVariants)]),
+  variant: PropTypes.oneOf([...Object.values(CardVariants)]), // eslint-disable-line compat/compat
   /**
    * Text that describes the badge to a screen reader. Use this
    * if more information is needed to accurately describe

--- a/packages/terra-content-container/CHANGELOG.md
+++ b/packages/terra-content-container/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
 
 3.14.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-demographics-banner/CHANGELOG.md
+++ b/packages/terra-demographics-banner/CHANGELOG.md
@@ -5,7 +5,8 @@ Unreleased
 ----------
 ### Changed
 * Components updated to use `injectIntl` to interface with `react-intl's` `intl` context.
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 ### Updated
 * updated jest snapshots

--- a/packages/terra-demographics-banner/src/DemographicsBannerDisplay.jsx
+++ b/packages/terra-demographics-banner/src/DemographicsBannerDisplay.jsx
@@ -103,7 +103,7 @@ const defaultProps = {
   preferredFirstName: null,
 };
 
-const DemographicsBannerDisplay = props => (
+const DemographicsBannerDisplay = (props) => (
   <ResponsiveElement
     tiny={<SmallDemographicsBannerDisplay {...props} />}
     small={<LargeDemographicsBannerDisplay {...props} />}

--- a/packages/terra-demographics-banner/src/_sharedObjects.jsx
+++ b/packages/terra-demographics-banner/src/_sharedObjects.jsx
@@ -79,7 +79,7 @@ const applicationIdentifiers = (props) => {
   const { identifiers } = props;
 
   if (identifiers) {
-    return Object.keys(identifiers).map(key => (
+    return Object.keys(identifiers).map((key) => (
       <DemographicsBannerValue
         key={`identifier-${key}`}
         label={key}

--- a/packages/terra-dialog/CHANGELOG.md
+++ b/packages/terra-dialog/CHANGELOG.md
@@ -5,7 +5,8 @@ Unreleased
 ----------
 ### Changed
 * Components updated to use `FormattedMessage` to interface with `react-intl's` `intl` context.
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 2.21.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-dialog/src/Dialog.jsx
+++ b/packages/terra-dialog/src/Dialog.jsx
@@ -46,7 +46,7 @@ const Dialog = ({
     ? (
       <div className={cx('dialog-header-close')}>
         <FormattedMessage id="Terra.dialog.close">
-          {closeText => (
+          {(closeText) => (
             <Button variant="utility" text={closeText} onClick={onClose} isIconOnly icon={<span className={cx('close-icon')} />} />
           )}
         </FormattedMessage>

--- a/packages/terra-divider/CHANGELOG.md
+++ b/packages/terra-divider/CHANGELOG.md
@@ -4,7 +4,8 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 3.14.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-divider/src/terra-dev-site/doc/example/DividerExampleTemplate.jsx
+++ b/packages/terra-divider/src/terra-dev-site/doc/example/DividerExampleTemplate.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 /* eslint-disable react/prop-types */
-const DividerTemplate = props => (
+const DividerTemplate = (props) => (
   <div>
     <p>
       Lorem Ipsum is simply dummy text of the printing and typesetting industry.Lorem Ipsum has been the industrys standard

--- a/packages/terra-doc-template/CHANGELOG.md
+++ b/packages/terra-doc-template/CHANGELOG.md
@@ -4,7 +4,8 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 2.15.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-doc-template/src/DocTemplate.jsx
+++ b/packages/terra-doc-template/src/DocTemplate.jsx
@@ -107,7 +107,7 @@ const DocTemplate = ({
       </div>
 
       {exampleHeader}
-      {localExamples.map(example => (
+      {localExamples.map((example) => (
         <IndexExampleTemplate
           title={example.title}
           example={example.example}
@@ -118,7 +118,7 @@ const DocTemplate = ({
       ))}
 
       <div className={cx('doc-card')}>
-        {localPropsTables.map(propsTable => (
+        {localPropsTables.map((propsTable) => (
           <PropsTable
             src={propsTable.componentSrc}
             componentName={propsTable.componentName}

--- a/packages/terra-doc-template/src/ExampleTemplate.jsx
+++ b/packages/terra-doc-template/src/ExampleTemplate.jsx
@@ -55,11 +55,11 @@ class ExampleTemplate extends React.Component {
   }
 
   handleBgToggle() {
-    this.setState(prevState => ({ isBackgroundTransparent: !prevState.isBackgroundTransparent }));
+    this.setState((prevState) => ({ isBackgroundTransparent: !prevState.isBackgroundTransparent }));
   }
 
   handleCodeToggle() {
-    this.setState(prevState => ({ isExpanded: !prevState.isExpanded }));
+    this.setState((prevState) => ({ isExpanded: !prevState.isExpanded }));
   }
 
   render() {

--- a/packages/terra-doc-template/src/terra-dev-site/test/doc-template/common/TestComponent.jsx
+++ b/packages/terra-doc-template/src/terra-dev-site/test/doc-template/common/TestComponent.jsx
@@ -17,7 +17,7 @@ const defaultProps = {
   otherText: 'Bye.',
 };
 
-const TestComponent = props => (
+const TestComponent = (props) => (
   <p>
     {props.text}
 ,

--- a/packages/terra-dropdown-button/CHANGELOG.md
+++ b/packages/terra-dropdown-button/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 -----------------
+### Changed
+* Updated code to match new eslint rules
 
 1.0.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-dropdown-button/src/DropdownButton.jsx
+++ b/packages/terra-dropdown-button/src/DropdownButton.jsx
@@ -39,7 +39,7 @@ const propTypes = {
   /**
    * Sets the styles of the component, one of `neutral`, `emphasis`, or `ghost`.
    */
-  variant: PropTypes.oneOf(Object.values(Variants)), // eslint-disable-line compat/compat
+  variant: PropTypes.oneOf(Object.values(Variants)),
 };
 
 const defaultProps = {

--- a/packages/terra-dropdown-button/src/DropdownButton.jsx
+++ b/packages/terra-dropdown-button/src/DropdownButton.jsx
@@ -39,7 +39,7 @@ const propTypes = {
   /**
    * Sets the styles of the component, one of `neutral`, `emphasis`, or `ghost`.
    */
-  variant: PropTypes.oneOf(Object.values(Variants)),
+  variant: PropTypes.oneOf(Object.values(Variants)), // eslint-disable-line compat/compat
 };
 
 const defaultProps = {
@@ -62,7 +62,7 @@ class DropdownButton extends React.Component {
   }
 
   handleDropdownButtonClick() {
-    this.setState(prevState => ({ isOpen: !prevState.isOpen }));
+    this.setState((prevState) => ({ isOpen: !prevState.isOpen }));
   }
 
   handleDropdownRequestClose(callback) {

--- a/packages/terra-dropdown-button/src/SplitButton.jsx
+++ b/packages/terra-dropdown-button/src/SplitButton.jsx
@@ -43,7 +43,7 @@ const propTypes = {
   /**
    * Sets the styles of the component, one of `neutral`, or `ghost`.
    */
-  variant: PropTypes.oneOf(Object.values(Variants)),
+  variant: PropTypes.oneOf(Object.values(Variants)), // eslint-disable-line compat/compat
   /**
    * @private
    * The intl object to be injected for translations.
@@ -73,7 +73,7 @@ class SplitButton extends React.Component {
   }
 
   handleDropdownButtonClick() {
-    this.setState(prevState => ({ isOpen: !prevState.isOpen }));
+    this.setState((prevState) => ({ isOpen: !prevState.isOpen }));
   }
 
   handleDropdownRequestClose(callback) {

--- a/packages/terra-dropdown-button/src/SplitButton.jsx
+++ b/packages/terra-dropdown-button/src/SplitButton.jsx
@@ -43,7 +43,7 @@ const propTypes = {
   /**
    * Sets the styles of the component, one of `neutral`, or `ghost`.
    */
-  variant: PropTypes.oneOf(Object.values(Variants)), // eslint-disable-line compat/compat
+  variant: PropTypes.oneOf(Object.values(Variants)),
   /**
    * @private
    * The intl object to be injected for translations.

--- a/packages/terra-dropdown-button/src/_DropdownListUtil.js
+++ b/packages/terra-dropdown-button/src/_DropdownListUtil.js
@@ -54,7 +54,7 @@ class DropdownListUtil {
    * @return {number} - The index of the first option that starts with the provided string.
    */
   static findWithStartString(object, string) {
-    return DropdownListUtil.getChildArray(object).findIndex(opt => (
+    return DropdownListUtil.getChildArray(object).findIndex((opt) => (
       opt.props.label || '').toLowerCase().startsWith(string.toLowerCase()));
   }
 

--- a/packages/terra-dropdown-button/src/terra-dev-site/doc/example/BlockDropdownButton.jsx
+++ b/packages/terra-dropdown-button/src/terra-dev-site/doc/example/BlockDropdownButton.jsx
@@ -7,7 +7,7 @@ const Example = () => {
   const [message, setMessage] = useState('No option clicked');
 
   return (
-    <React.Fragment>
+    <>
       <DropdownButton
         label="Dropdown"
         isBlock
@@ -18,7 +18,7 @@ const Example = () => {
         <Item label="4th Option" onSelect={() => setMessage('4th option clicked')} />
       </DropdownButton>
       <p>{message}</p>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/terra-dropdown-button/src/terra-dev-site/doc/example/BlockSplitButton.jsx
+++ b/packages/terra-dropdown-button/src/terra-dev-site/doc/example/BlockSplitButton.jsx
@@ -7,7 +7,7 @@ const Example = () => {
   const [message, setMessage] = useState('No option clicked');
 
   return (
-    <React.Fragment>
+    <>
       <SplitButton
         primaryOptionLabel="Primary Option"
         onSelect={() => setMessage('Primary option clicked')}
@@ -19,7 +19,7 @@ const Example = () => {
         <Item label="4th Option" onSelect={() => setMessage('4th option clicked')} />
       </SplitButton>
       <p>{message}</p>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/terra-dropdown-button/src/terra-dev-site/doc/example/DefaultDropdownButton.jsx
+++ b/packages/terra-dropdown-button/src/terra-dev-site/doc/example/DefaultDropdownButton.jsx
@@ -7,7 +7,7 @@ const Example = () => {
   const [message, setMessage] = useState('No option clicked');
 
   return (
-    <React.Fragment>
+    <>
       <DropdownButton
         label="Export"
       >
@@ -17,7 +17,7 @@ const Example = () => {
         <Item label="Export as XML" onSelect={() => setMessage('Export as XML clicked')} />
       </DropdownButton>
       <p>{message}</p>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/terra-dropdown-button/src/terra-dev-site/doc/example/DefaultSplitButton.jsx
+++ b/packages/terra-dropdown-button/src/terra-dev-site/doc/example/DefaultSplitButton.jsx
@@ -7,7 +7,7 @@ const Example = () => {
   const [message, setMessage] = useState('No option clicked');
 
   return (
-    <React.Fragment>
+    <>
       <SplitButton
         primaryOptionLabel="Reply"
         onSelect={() => setMessage('Reply clicked')}
@@ -18,7 +18,7 @@ const Example = () => {
         <Item label="Selective Reply" onSelect={() => setMessage('Selective Reply clicked')} />
       </SplitButton>
       <p>{message}</p>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/terra-dropdown-button/src/terra-dev-site/doc/example/DisabledDropdownButton.jsx
+++ b/packages/terra-dropdown-button/src/terra-dev-site/doc/example/DisabledDropdownButton.jsx
@@ -7,7 +7,7 @@ const Example = () => {
   const [message, setMessage] = useState('No option clicked');
 
   return (
-    <React.Fragment>
+    <>
       <DropdownButton
         label="Dropdown"
         isDisabled
@@ -18,7 +18,7 @@ const Example = () => {
         <Item label="4th Option" onSelect={() => setMessage('4th option clicked')} />
       </DropdownButton>
       <p>{message}</p>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/terra-dropdown-button/src/terra-dev-site/doc/example/DisabledSplitButton.jsx
+++ b/packages/terra-dropdown-button/src/terra-dev-site/doc/example/DisabledSplitButton.jsx
@@ -7,7 +7,7 @@ const Example = () => {
   const [message, setMessage] = useState('No option clicked');
 
   return (
-    <React.Fragment>
+    <>
       <SplitButton
         primaryOptionLabel="Primary Option"
         onSelect={() => setMessage('Primary option clicked')}
@@ -19,7 +19,7 @@ const Example = () => {
         <Item label="4th Option" onSelect={() => setMessage('4th option clicked')} />
       </SplitButton>
       <p>{message}</p>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/terra-dropdown-button/src/terra-dev-site/doc/example/EmphasisDropdownButton.jsx
+++ b/packages/terra-dropdown-button/src/terra-dev-site/doc/example/EmphasisDropdownButton.jsx
@@ -7,7 +7,7 @@ const Example = () => {
   const [message, setMessage] = useState('No option clicked');
 
   return (
-    <React.Fragment>
+    <>
       <DropdownButton
         label="Dropdown"
         variant={Variants.EMPHASIS}
@@ -18,7 +18,7 @@ const Example = () => {
         <Item label="4th Option" onSelect={() => setMessage('4th option clicked')} />
       </DropdownButton>
       <p>{message}</p>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/terra-dropdown-button/src/terra-dev-site/doc/example/GhostDropdownButton.jsx
+++ b/packages/terra-dropdown-button/src/terra-dev-site/doc/example/GhostDropdownButton.jsx
@@ -7,7 +7,7 @@ const GhostDropdownButton = () => {
   const [message, setMessage] = useState('No option clicked');
 
   return (
-    <React.Fragment>
+    <>
       <DropdownButton
         label="Dropdown"
         variant="ghost"
@@ -18,7 +18,7 @@ const GhostDropdownButton = () => {
         <Item label="4th Option" onSelect={() => setMessage('4th option clicked')} />
       </DropdownButton>
       <p>{message}</p>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/terra-dropdown-button/src/terra-dev-site/doc/example/GhostSplitButton.jsx
+++ b/packages/terra-dropdown-button/src/terra-dev-site/doc/example/GhostSplitButton.jsx
@@ -7,7 +7,7 @@ const GhostSplitButton = () => {
   const [message, setMessage] = useState('No option clicked');
 
   return (
-    <React.Fragment>
+    <>
       <SplitButton
         primaryOptionLabel="Reply"
         onSelect={() => setMessage('Reply clicked')}
@@ -19,7 +19,7 @@ const GhostSplitButton = () => {
         <Item label="Selective Reply" onSelect={() => setMessage('Selective Reply clicked')} />
       </SplitButton>
       <p>{message}</p>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/terra-dynamic-grid/CHANGELOG.md
+++ b/packages/terra-dynamic-grid/CHANGELOG.md
@@ -4,7 +4,8 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 3.13.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-dynamic-grid/src/styles.js
+++ b/packages/terra-dynamic-grid/src/styles.js
@@ -50,7 +50,7 @@ const gridLineEnd = (prop, region) => {
 };
 
 
-const gridGap = layout => (
+const gridGap = (layout) => (
   layout['grid-gap']
     ? { 'grid-gap': layout['grid-gap'] }
     : {}
@@ -69,7 +69,7 @@ const gridDisplay = (layout) => {
   };
 };
 
-const grid = template => ({
+const grid = (template) => ({
   ...gridDisplay(template),
   ...gridGap(template),
   ...gridTemplate('columns', template),
@@ -77,7 +77,7 @@ const grid = template => ({
   ...(template.style || {}),
 });
 
-const region = position => ({
+const region = (position) => ({
   ...gridLineStart('column', position),
   ...gridLineEnd('column', position),
   ...gridLineStart('row', position),

--- a/packages/terra-dynamic-grid/src/terra-dev-site/doc/example/Card.jsx
+++ b/packages/terra-dynamic-grid/src/terra-dev-site/doc/example/Card.jsx
@@ -4,7 +4,7 @@ import styles from './Card.module.scss';
 
 const cx = classNames.bind(styles);
 
-export default props => (
+export default (props) => (
   <div
     className={cx('card')}
     {...props}

--- a/packages/terra-form-checkbox/CHANGELOG.md
+++ b/packages/terra-form-checkbox/CHANGELOG.md
@@ -5,7 +5,8 @@ Unreleased
 ----------
 ### Changed
 * Components updated to use `FormattedMessage` to interface with `react-intl's` `intl` context.
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 * Update tests for dev-site v6
 
 3.21.0 - (July 30, 2019)

--- a/packages/terra-form-checkbox/src/Checkbox.jsx
+++ b/packages/terra-form-checkbox/src/Checkbox.jsx
@@ -100,7 +100,7 @@ const Checkbox = ({
   value,
   ...customProps
 }) => {
-  const controlInputAttrs = Object.assign({}, inputAttrs);
+  const controlInputAttrs = { ...inputAttrs };
 
   if (checked !== undefined) {
     controlInputAttrs.checked = checked;

--- a/packages/terra-form-checkbox/src/CheckboxField.jsx
+++ b/packages/terra-form-checkbox/src/CheckboxField.jsx
@@ -106,21 +106,21 @@ const CheckboxField = (props) => {
       <div {...legendAttrs} className={legendClassNames}>
         {isInvalid && <span className={cx('error-icon')} />}
         {required && (isInvalid || !hideRequired) && (
-          <React.Fragment>
+          <>
             <div aria-hidden="true" className={cx('required')}>*</div>
             <FormattedMessage id="Terra.form.field.required">
-              {requiredText => (
+              {(requiredText) => (
                 <VisualyHiddenText text={requiredText} />
               )}
             </FormattedMessage>
-          </React.Fragment>
+          </>
         )}
         {legend}
         {required && !isInvalid && hideRequired && <span className={cx('required-hidden')}>*</span>}
         {showOptional && !required
           && (
             <FormattedMessage id="Terra.form.field.optional">
-              {optionalText => (
+              {(optionalText) => (
                 <span className={cx('optional')}>{optionalText}</span>
               )}
             </FormattedMessage>

--- a/packages/terra-form-checkbox/src/CheckboxUtil.js
+++ b/packages/terra-form-checkbox/src/CheckboxUtil.js
@@ -5,8 +5,8 @@ const CheckboxUtil = (() => {
       'ontouchstart' in window
       // eslint-disable-next-line no-undef
       || (window.DocumentTouch && document instanceof DocumentTouch)
-      || navigator.maxTouchPoints > 0
-      || navigator.msMaxTouchPoints > 0
+      || navigator.maxTouchPoints > 0 // eslint-disable-line compat/compat
+      || navigator.msMaxTouchPoints > 0 // eslint-disable-line compat/compat
     );
 
   return {

--- a/packages/terra-form-checkbox/src/terra-dev-site/doc/example/field/ControlledCheckboxField.jsx
+++ b/packages/terra-form-checkbox/src/terra-dev-site/doc/example/field/ControlledCheckboxField.jsx
@@ -31,7 +31,7 @@ export default class extends React.Component {
   }
 
   handleOnClick() {
-    this.setState(prevState => ({ isInvalid: !prevState.isInvalid }));
+    this.setState((prevState) => ({ isInvalid: !prevState.isInvalid }));
   }
 
   render() {

--- a/packages/terra-form-checkbox/src/terra-dev-site/doc/example/field/DefaultCheckboxField.jsx
+++ b/packages/terra-form-checkbox/src/terra-dev-site/doc/example/field/DefaultCheckboxField.jsx
@@ -17,7 +17,7 @@ class DefaultCheckboxField extends React.Component {
   }
 
   handleOnClick() {
-    this.setState(prevState => ({ isInvalid: !prevState.isInvalid }));
+    this.setState((prevState) => ({ isInvalid: !prevState.isInvalid }));
   }
 
   render() {

--- a/packages/terra-form-checkbox/src/terra-dev-site/doc/example/field/InlineCheckboxField.jsx
+++ b/packages/terra-form-checkbox/src/terra-dev-site/doc/example/field/InlineCheckboxField.jsx
@@ -36,11 +36,11 @@ export default class extends React.Component {
 
   handleOnClick(e) {
     if (e.currentTarget.id === 'inline') {
-      this.setState(prevState => ({
+      this.setState((prevState) => ({
         toggleInline: !prevState.toggleInline,
       }));
     } else {
-      this.setState(prevState => ({
+      this.setState((prevState) => ({
         isInvalid: !prevState.isInvalid,
       }));
     }

--- a/packages/terra-form-checkbox/src/terra-dev-site/doc/example/field/OptionalCheckboxField.jsx
+++ b/packages/terra-form-checkbox/src/terra-dev-site/doc/example/field/OptionalCheckboxField.jsx
@@ -31,7 +31,7 @@ export default class extends React.Component {
   }
 
   handleOnClick() {
-    this.setState(prevState => ({ isInvalid: !prevState.isInvalid }));
+    this.setState((prevState) => ({ isInvalid: !prevState.isInvalid }));
   }
 
   render() {

--- a/packages/terra-form-field/CHANGELOG.md
+++ b/packages/terra-form-field/CHANGELOG.md
@@ -5,7 +5,8 @@ Unreleased
 ----------
 ### Changed
 * Components updated to use `FormattedMessage` to interface with `react-intl's` `intl` context.
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 ### Fixed
 * Pass down `isInvalid` to children of Field

--- a/packages/terra-form-field/src/Field.jsx
+++ b/packages/terra-form-field/src/Field.jsx
@@ -89,7 +89,7 @@ const defaultProps = {
   showOptional: false,
 };
 
-const hasWhiteSpace = s => /\s/g.test(s);
+const hasWhiteSpace = (s) => /\s/g.test(s);
 // Detect IE 10 or IE 11
 // TODO - Delete detection logic when we drop support for IE
 const isIE = () => (window.navigator.userAgent.indexOf('Trident/6.0') > -1 || window.navigator.userAgent.indexOf('Trident/7.0') > -1);
@@ -114,7 +114,7 @@ const Field = (props) => {
     ...customProps
   } = props;
 
-  const customStyles = maxWidth ? Object.assign({ maxWidth }, style) : style;
+  const customStyles = maxWidth ? ({ maxWidth, ...style }) : style;
 
   const fieldClasses = cx([
     'field',
@@ -179,7 +179,7 @@ const Field = (props) => {
           {showOptional && !required
             && (
               <FormattedMessage id="Terra.form.field.optional">
-                {optionalText => (
+                {(optionalText) => (
                   <div className={cx('optional')}>{optionalText}</div>
                 )}
               </FormattedMessage>

--- a/packages/terra-form-field/src/terra-dev-site/doc/example/FieldExamples.jsx
+++ b/packages/terra-form-field/src/terra-dev-site/doc/example/FieldExamples.jsx
@@ -14,7 +14,7 @@ class FieldExamples extends React.Component {
   }
 
   toggleIsInvalid() {
-    this.setState(prevState => ({ isInvalid: !prevState.isInvalid }));
+    this.setState((prevState) => ({ isInvalid: !prevState.isInvalid }));
   }
 
   render() {

--- a/packages/terra-form-field/src/terra-dev-site/test/form-field/FieldInteractiveInvalid.test.jsx
+++ b/packages/terra-form-field/src/terra-dev-site/test/form-field/FieldInteractiveInvalid.test.jsx
@@ -13,7 +13,7 @@ class FieldExamples extends React.Component {
   }
 
   handleIsInvalidChange() {
-    this.setState(prevState => ({ isInvalid: !prevState.isInvalid }));
+    this.setState((prevState) => ({ isInvalid: !prevState.isInvalid }));
   }
 
   render() {

--- a/packages/terra-form-fieldset/CHANGELOG.md
+++ b/packages/terra-form-fieldset/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
 
 2.22.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-form-input/CHANGELOG.md
+++ b/packages/terra-form-input/CHANGELOG.md
@@ -9,7 +9,8 @@ Unreleased
 ### Changed
 * Minor dependency version bump
 * Updated errorIcon default prop from `Field.defaultProps.errorIcon` with `<IconError>` component.
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 2.20.0 - (July 24, 2019)
 ------------------

--- a/packages/terra-form-input/src/Input.jsx
+++ b/packages/terra-form-input/src/Input.jsx
@@ -98,7 +98,7 @@ class Input extends React.Component {
       ...customProps
     } = this.props;
 
-    const attributes = Object.assign({}, customProps);
+    const attributes = { ...customProps };
     const formInputClassNames = cx([
       'form-input',
       { 'form-error': isInvalid },

--- a/packages/terra-form-input/src/terra-dev-site/test/form-input/InputField.test.jsx
+++ b/packages/terra-form-input/src/terra-dev-site/test/form-input/InputField.test.jsx
@@ -14,7 +14,7 @@ class InputFieldExample extends React.Component {
   }
 
   toggleInvalid() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isInvalid: !prevState.isInvalid,
     }));
   }

--- a/packages/terra-form-radio/CHANGELOG.md
+++ b/packages/terra-form-radio/CHANGELOG.md
@@ -5,7 +5,8 @@ Unreleased
 ----------
 ### Changed
 * Components updated to use `FormattedMessage` to interface with `react-intl's` `intl` context.
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 3.23.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-form-radio/src/Radio.jsx
+++ b/packages/terra-form-radio/src/Radio.jsx
@@ -100,7 +100,7 @@ const Radio = ({
   value,
   ...customProps
 }) => {
-  const controlInputAttrs = Object.assign({}, inputAttrs);
+  const controlInputAttrs = { ...inputAttrs };
 
   if (checked !== undefined) {
     controlInputAttrs.checked = checked;

--- a/packages/terra-form-radio/src/RadioField.jsx
+++ b/packages/terra-form-radio/src/RadioField.jsx
@@ -107,26 +107,25 @@ const RadioField = (props) => {
       <div {...legendAttrs} className={legendClassNames}>
         {isInvalid && <span className={cx('error-icon')} />}
         {required && (isInvalid || !hideRequired) && (
-          <React.Fragment>
+          <>
             <div aria-hidden="true" className={cx('required')}>*</div>
             <FormattedMessage id="Terra.form.field.required">
-              {text => (
+              {(text) => (
                 <VisualyHiddenText text={text} />
               )}
             </FormattedMessage>
-          </React.Fragment>
+          </>
         )}
         {legend}
         {required && !isInvalid && hideRequired && <span className={cx('required-hidden')}>*</span>}
         {showOptional && !required
           && (
             <FormattedMessage id="Terra.form.field.optional">
-              {optionalText => (
+              {(optionalText) => (
                 <span className={cx('optional')}>{optionalText}</span>
               )}
             </FormattedMessage>
-          )
-        }
+          )}
         {!isInvalid && <span className={cx('error-icon-hidden')} />}
       </div>
     </legend>

--- a/packages/terra-form-radio/src/_RadioUtil.js
+++ b/packages/terra-form-radio/src/_RadioUtil.js
@@ -4,8 +4,8 @@ const isConsideredMobileDevice = () => window.matchMedia('(max-width: 1024px)').
       'ontouchstart' in window
       // eslint-disable-next-line no-undef
       || (window.DocumentTouch && document instanceof DocumentTouch)
-      || navigator.maxTouchPoints > 0
-      || navigator.msMaxTouchPoints > 0
+      || navigator.maxTouchPoints > 0 // eslint-disable-line compat/compat
+      || navigator.msMaxTouchPoints > 0 // eslint-disable-line compat/compat
     );
 
 export default {

--- a/packages/terra-form-radio/src/terra-dev-site/doc/example/field/ControlledRadioField.jsx
+++ b/packages/terra-form-radio/src/terra-dev-site/doc/example/field/ControlledRadioField.jsx
@@ -27,7 +27,7 @@ export default class extends React.Component {
   }
 
   handleOnClick() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       toggleInvalid: !prevState.toggleInvalid,
     }));
   }

--- a/packages/terra-form-radio/src/terra-dev-site/doc/example/field/DefaultRadioField.jsx
+++ b/packages/terra-form-radio/src/terra-dev-site/doc/example/field/DefaultRadioField.jsx
@@ -17,7 +17,7 @@ export default class extends React.Component {
   }
 
   handleOnClick() {
-    this.setState(prevState => ({ isInvalid: !prevState.isInvalid }));
+    this.setState((prevState) => ({ isInvalid: !prevState.isInvalid }));
   }
 
   render() {

--- a/packages/terra-form-radio/src/terra-dev-site/doc/example/field/InlineRadioField.jsx
+++ b/packages/terra-form-radio/src/terra-dev-site/doc/example/field/InlineRadioField.jsx
@@ -30,11 +30,11 @@ export default class extends React.Component {
 
   handleOnClick(e) {
     if (e.currentTarget.id === 'inline') {
-      this.setState(prevState => ({
+      this.setState((prevState) => ({
         toggleInline: !prevState.toggleInline,
       }));
     } else {
-      this.setState(prevState => ({
+      this.setState((prevState) => ({
         isInvalid: !prevState.isInvalid,
       }));
     }

--- a/packages/terra-form-radio/src/terra-dev-site/doc/example/field/OptionalRadioField.jsx
+++ b/packages/terra-form-radio/src/terra-dev-site/doc/example/field/OptionalRadioField.jsx
@@ -17,7 +17,7 @@ export default class extends React.Component {
   }
 
   handleOnClick() {
-    this.setState(prevState => ({ isInvalid: !prevState.isInvalid }));
+    this.setState((prevState) => ({ isInvalid: !prevState.isInvalid }));
   }
 
   render() {

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -9,7 +9,8 @@ Unreleased
 
 ### Changed
 * Components updated to use `injectIntl` to interface with `react-intl's` `intl` context.
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 * Update tests for dev-site v6
 
 5.25.0 - (July 30, 2019)

--- a/packages/terra-form-select/src/Select.jsx
+++ b/packages/terra-form-select/src/Select.jsx
@@ -154,7 +154,7 @@ class Select extends React.Component {
     switch (this.props.variant) {
       case Variants.TAG:
       case Variants.MULTIPLE:
-        return selectValue.map(tag => (
+        return selectValue.map((tag) => (
           <Tag value={tag} key={tag} onDeselect={this.handleDeselect}>
             {Util.valueDisplay(this.props, tag)}
           </Tag>
@@ -200,7 +200,7 @@ class Select extends React.Component {
 
     // Add new tags for uncontrolled components.
     if (this.props.value === undefined && !Util.findByValue(this.props, this.state, value)) {
-      this.setState(prevState => ({ tags: [...prevState.tags, <Option key={value} display={value} value={value} />] }));
+      this.setState((prevState) => ({ tags: [...prevState.tags, <Option key={value} display={value} value={value} />] }));
     }
 
     if (this.props.onSelect) {
@@ -237,7 +237,7 @@ class Select extends React.Component {
         required={required}
         totalOptions={Util.getTotalNumberOfOptions(children)}
         clearOptionDisplay={clearOptionDisplay}
-        dropdown={dropdownProps => (
+        dropdown={(dropdownProps) => (
           <DropdownMenu {...dropdownProps}>
             {this.state.tags}
             {children}

--- a/packages/terra-form-select/src/_Frame.jsx
+++ b/packages/terra-form-select/src/_Frame.jsx
@@ -231,8 +231,7 @@ class Frame extends React.Component {
                     </li>
                   </ul>
                 </li>
-              ) : null
-            }
+              ) : null}
             <li className={cx('search-wrapper')}>
               <input {...multipleInputAttrs} value={searchValue} />
             </li>
@@ -772,8 +771,7 @@ class Frame extends React.Component {
                  clearOptionDisplay,
                })}
           </Dropdown>
-          )
-        }
+          )}
       </div>
     );
   }

--- a/packages/terra-form-select/src/_FrameUtil.js
+++ b/packages/terra-form-select/src/_FrameUtil.js
@@ -9,7 +9,7 @@ class FrameUtil {
    */
   static dropdownStyle(props, state) {
     const { maxHeight, width } = state;
-    return Object.assign({}, Object.assign({}, props).style, { maxHeight, width });
+    return { ...({ ...props }).style, maxHeight, width };
   }
 
   /**
@@ -21,7 +21,7 @@ class FrameUtil {
    * @return {Object} - The calculated dropdown attributes.
    */
   static dropdownPosition(props, target, dropdown, maxHeight) {
-    const style = Object.assign({}, props).style || {};
+    const style = ({ ...props }).style || {};
     const { height } = dropdown.getBoundingClientRect();
     const { bottom, width, top } = target.getBoundingClientRect();
 

--- a/packages/terra-form-select/src/_Menu.jsx
+++ b/packages/terra-form-select/src/_Menu.jsx
@@ -325,8 +325,8 @@ class Menu extends React.Component {
           isSelected: Util.isSelected(this.props.value, option.props.value),
           variant: this.props.variant,
           onMouseDown: () => { this.downOption = option; },
-          onMouseUp: event => this.handleOptionClick(event, option),
-          onMouseEnter: event => this.handleMouseEnter(event, option),
+          onMouseUp: (event) => this.handleOptionClick(event, option),
+          onMouseEnter: (event) => this.handleMouseEnter(event, option),
           ...(option.props.value === this.state.active) && { 'data-select-active': true },
         });
       } if (option.type.isOptGroup) {
@@ -427,7 +427,7 @@ class Menu extends React.Component {
       this.searchString = this.searchString.concat(String.fromCharCode(keyCode));
       clearTimeout(this.searchTimeout);
       this.searchTimeout = setTimeout(this.clearSearch, 500);
-      this.setState(prevState => ({ active: Util.findWithStartString(prevState.children, this.searchString) || active }));
+      this.setState((prevState) => ({ active: Util.findWithStartString(prevState.children, this.searchString) || active }));
     }
   }
 

--- a/packages/terra-form-select/src/_MenuUtil.js
+++ b/packages/terra-form-select/src/_MenuUtil.js
@@ -61,7 +61,7 @@ class MenuUtil {
       return false;
     }
 
-    return array.find(option => MenuUtil.isEqual(option, query)) !== undefined;
+    return array.find((option) => MenuUtil.isEqual(option, query)) !== undefined;
   }
 
   /**
@@ -171,7 +171,7 @@ class MenuUtil {
    * @return {string|null} - The firt option that starts with the provided string.
    */
   static findWithStartString(object, string) {
-    const option = MenuUtil.flatten(object, true).find(opt => (
+    const option = MenuUtil.flatten(object, true).find((opt) => (
       opt.props.display || '').toLowerCase().startsWith(string.toLowerCase()));
     return option ? option.props.value : null;
   }
@@ -215,7 +215,7 @@ class MenuUtil {
     if (options.length === 0) {
       return null;
     } if (state.searchValue === undefined) {
-      const selected = options.find(option => (
+      const selected = options.find((option) => (
         Array.isArray(value) ? MenuUtil.includes(value, option.props.value) : MenuUtil.isEqual(value, option.props.value)
       ));
       return selected === undefined ? options[0].props.value : selected.props.value;

--- a/packages/terra-form-select/src/_OptGroup.jsx
+++ b/packages/terra-form-select/src/_OptGroup.jsx
@@ -33,9 +33,9 @@ const OptGroup = ({
       {label}
     </div>
     <FormattedMessage id="Terra.form.select.option">
-      {option => (
+      {(option) => (
         <ul className={cx('options')} role="listbox" aria-label={option}>
-          {React.Children.map(children, child => (
+          {React.Children.map(children, (child) => (
             React.cloneElement(child, { disabled: disabled || child.props.disabled })))}
         </ul>
       )}

--- a/packages/terra-form-select/src/_SelectUtil.js
+++ b/packages/terra-form-select/src/_SelectUtil.js
@@ -28,7 +28,7 @@ class SelectUtil {
    * @return {array} - The value resulting from the removal of an option.
    */
   static deselect(props, state, value) {
-    return SelectUtil.value(props, state).filter(option => option !== value);
+    return SelectUtil.value(props, state).filter((option) => option !== value);
   }
 
   /**

--- a/packages/terra-form-select/src/terra-dev-site/test/form-select/CustomAriaLabel.test.jsx
+++ b/packages/terra-form-select/src/terra-dev-site/test/form-select/CustomAriaLabel.test.jsx
@@ -3,7 +3,7 @@ import Select from '../../../Select';
 import SelectField from '../../../SelectField';
 
 const CustomAriaLabel = () => (
-  <React.Fragment>
+  <>
     <Select ariaLabel="Custom label 1" placeholder="Select a color" id="default" defaultValue="green">
       <Select.Option value="blue" display="Blue" />
       <Select.Option value="green" display="Green" />
@@ -19,7 +19,7 @@ const CustomAriaLabel = () => (
       <SelectField.Option value="large" display="Large" />
       <SelectField.Option value="xLarge" display="Extra Large" />
     </SelectField>
-  </React.Fragment>
+  </>
 );
 
 export default CustomAriaLabel;

--- a/packages/terra-form-select/src/terra-dev-site/test/form-select/SelectFieldMessages.test.jsx
+++ b/packages/terra-form-select/src/terra-dev-site/test/form-select/SelectFieldMessages.test.jsx
@@ -13,7 +13,7 @@ class SelectFieldMessagesExample extends React.Component {
   }
 
   toggleInvalid() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isInvalid: !prevState.isInvalid,
     }));
   }

--- a/packages/terra-form-select/tests/jest/Frame.test.jsx
+++ b/packages/terra-form-select/tests/jest/Frame.test.jsx
@@ -1,5 +1,3 @@
-/* global jest */
-
 import React from 'react';
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import { shallowWithIntl } from 'terra-enzyme-intl';

--- a/packages/terra-form-select/tests/jest/Menu.test.jsx
+++ b/packages/terra-form-select/tests/jest/Menu.test.jsx
@@ -15,7 +15,7 @@ describe('Menu', () => {
 
   it('should render a Menu with no results and update the live region appropriately', () => {
     const liveRegion = { current: document.createElement('div') };
-    const mockIntl = { formatMessage: id => (`No Results for ${id.id}`) };
+    const mockIntl = { formatMessage: (id) => (`No Results for ${id.id}`) };
 
     const menu = (
       <Menu onSelect={() => {}} visuallyHiddenComponent={liveRegion} intl={mockIntl} variant="default" value="value" searchValue="asdf">
@@ -35,7 +35,7 @@ describe('Menu', () => {
   });
 
   it('should not error when visuallyHiddenComponent is not provided', () => {
-    const mockIntl = { formatMessage: id => (`No Results for ${id.id}`) };
+    const mockIntl = { formatMessage: (id) => (`No Results for ${id.id}`) };
 
     const menu = (
       <Menu onSelect={() => {}} intl={mockIntl} variant="default" value="value" searchValue="asdf">
@@ -55,7 +55,7 @@ describe('Menu', () => {
 
   it('should not error when visuallyHiddenComponent has null for current', () => {
     const liveRegion = { current: null };
-    const mockIntl = { formatMessage: id => (`No Results for ${id.id}`) };
+    const mockIntl = { formatMessage: (id) => (`No Results for ${id.id}`) };
 
     const menu = (
       <Menu onSelect={() => {}} intl={mockIntl} visuallyHiddenComponent={liveRegion} variant="default" value="value" searchValue="asdf">

--- a/packages/terra-form-textarea/CHANGELOG.md
+++ b/packages/terra-form-textarea/CHANGELOG.md
@@ -9,7 +9,8 @@ Unreleased
 ### Changed
 * Minor dependency version bump
 * Updated errorIcon default prop from `Field.defaultProps.errorIcon` with `<IconError>` component.
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 3.20.0 - (July 24, 2019)
 ------------------

--- a/packages/terra-form-textarea/src/Textarea.jsx
+++ b/packages/terra-form-textarea/src/Textarea.jsx
@@ -11,8 +11,8 @@ const isMobileDevice = () => window.matchMedia('(max-width: 1024px)').matches
     'ontouchstart' in window
     // eslint-disable-next-line no-undef
     || (window.DocumentTouch && document instanceof DocumentTouch)
-    || navigator.maxTouchPoints > 0
-    || navigator.msMaxTouchPoints > 0
+    || navigator.maxTouchPoints > 0 // eslint-disable-line compat/compat
+    || navigator.msMaxTouchPoints > 0 // eslint-disable-line compat/compat
   );
 
 const TextareaSize = {
@@ -186,7 +186,7 @@ class Textarea extends React.Component {
       ...customProps
     } = this.props;
 
-    const additionalTextareaProps = Object.assign({}, customProps);
+    const additionalTextareaProps = { ...customProps };
 
     const textareaClasses = cx([
       'textarea',

--- a/packages/terra-form-textarea/src/terra-dev-site/test/form-textarea/AutoResizableTextareaMobileMaxTouchPoints.test.jsx
+++ b/packages/terra-form-textarea/src/terra-dev-site/test/form-textarea/AutoResizableTextareaMobileMaxTouchPoints.test.jsx
@@ -5,9 +5,9 @@ import Textarea from '../../../Textarea';
 export default class textarea extends React.Component {
   constructor() {
     super();
-    if (!navigator.maxTouchPoints || navigator.maxTouchPoints === 0) {
+    if (!navigator.maxTouchPoints || navigator.maxTouchPoints === 0) { // eslint-disable-line compat/compat
       this.resetMaxTouchPoints = true;
-      this.previousMaxTouchPoints = navigator.maxTouchPoints;
+      this.previousMaxTouchPoints = navigator.maxTouchPoints; // eslint-disable-line compat/compat
 
       Object.defineProperty(
         navigator, 'maxTouchPoints',
@@ -20,9 +20,9 @@ export default class textarea extends React.Component {
   }
 
   componentDidUpdate() {
-    if (!navigator.maxTouchPoints || navigator.maxTouchPoints === 0) {
+    if (!navigator.maxTouchPoints || navigator.maxTouchPoints === 0) { // eslint-disable-line compat/compat
       this.resetMaxTouchPoints = true;
-      this.previousMaxTouchPoints = navigator.maxTouchPoints;
+      this.previousMaxTouchPoints = navigator.maxTouchPoints; // eslint-disable-line compat/compat
 
       Object.defineProperty(
         navigator, 'maxTouchPoints',

--- a/packages/terra-form-textarea/src/terra-dev-site/test/form-textarea/SwapTextarea.test.jsx
+++ b/packages/terra-form-textarea/src/terra-dev-site/test/form-textarea/SwapTextarea.test.jsx
@@ -13,7 +13,7 @@ class textarea extends React.Component {
   }
 
   handleSwap() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       swap: !prevState.swap,
     }));
   }

--- a/packages/terra-form-textarea/src/terra-dev-site/test/form-textarea/TextareaField.test.jsx
+++ b/packages/terra-form-textarea/src/terra-dev-site/test/form-textarea/TextareaField.test.jsx
@@ -14,7 +14,7 @@ class TextareaFieldExample extends React.Component {
   }
 
   toggleInvalid() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isInvalid: !prevState.isInvalid,
     }));
   }

--- a/packages/terra-form-textarea/tests/jest/Textarea.test.jsx
+++ b/packages/terra-form-textarea/tests/jest/Textarea.test.jsx
@@ -109,13 +109,13 @@ it('should not set the textarea to resizable when viewed on browser with Documen
 
 it('should not set the textarea to resizable when viewed on browser with maxTouchPoints', () => {
   spyOn(window, 'matchMedia').and.returnValue({ matches: true });
-  navigator.maxTouchPoints = 1;
+  navigator.maxTouchPoints = 1; // eslint-disable-line compat/compat
 
   const textarea = <Textarea isAutoResizable />;
   const wrapper = render(textarea);
   expect(wrapper).toMatchSnapshot();
 
-  navigator.maxTouchPoints = 0;
+  navigator.maxTouchPoints = 0; // eslint-disable-line compat/compat
 });
 
 it('should not set the textarea to resizable when viewed on browser with msMaxTouchPoints', () => {

--- a/packages/terra-grid/CHANGELOG.md
+++ b/packages/terra-grid/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 6.6.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-grid/src/Grid.jsx
+++ b/packages/terra-grid/src/Grid.jsx
@@ -10,7 +10,7 @@ const propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const Grid = props => (<div {...props} />);
+const Grid = (props) => (<div {...props} />);
 
 Grid.propTypes = propTypes;
 Grid.Row = GridRow;

--- a/packages/terra-heading/CHANGELOG.md
+++ b/packages/terra-heading/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 4.13.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-heading/src/Heading.jsx
+++ b/packages/terra-heading/src/Heading.jsx
@@ -74,7 +74,7 @@ const defaultProps = {
 const Heading = ({
   level, children, isVisuallyHidden, isItalic, size, weight, colorClass, ...customProps
 }) => {
-  const attributes = Object.assign({}, customProps);
+  const attributes = { ...customProps };
   const TextClassNames = cx([
     'heading',
     { italic: isItalic },

--- a/packages/terra-hyperlink/CHANGELOG.md
+++ b/packages/terra-hyperlink/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
 
 2.15.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-i18n/CHANGELOG.md
+++ b/packages/terra-i18n/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 
 ### Changed

--- a/packages/terra-i18n/src/I18nProvider.jsx
+++ b/packages/terra-i18n/src/I18nProvider.jsx
@@ -21,9 +21,9 @@ const propTypes = {
 
 const I18nProvider = ({ children, locale, messages }) => (
   <IntlProvider locale={locale} key={locale} messages={messages}>
-    <React.Fragment>
+    <>
       {children}
-    </React.Fragment>
+    </>
   </IntlProvider>
 );
 

--- a/packages/terra-i18n/src/terra-dev-site/test/i18n/DefaultI18n.test.jsx
+++ b/packages/terra-i18n/src/terra-dev-site/test/i18n/DefaultI18n.test.jsx
@@ -45,7 +45,7 @@ class Base extends React.Component {
         >
           <label htmlFor="change-locale"> Current locale: </label>
           <select id="change-locale" onChange={this.handleLocaleChange} value={this.state.selectedLocale}>
-            {testLocales.map(locale => (<option key={locale} value={locale}>{locale}</option>))}
+            {testLocales.map((locale) => (<option key={locale} value={locale}>{locale}</option>))}
           </select>
           <p id="translated-message">
             <span className={cx('weighted-text')}> Loaded locale message: </span>

--- a/packages/terra-icon/CHANGELOG.md
+++ b/packages/terra-icon/CHANGELOG.md
@@ -17,7 +17,8 @@ Unreleased
 * Added new icon `IconXSymbolLight`
 
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 * Consume one-cerner-style-icons v1.27
 
 3.16.0 - (July 30, 2019)

--- a/packages/terra-icon/scripts/src/generate-icon/Icon.js
+++ b/packages/terra-icon/scripts/src/generate-icon/Icon.js
@@ -9,8 +9,8 @@ class Icon {
     this.name = `Icon${_.upperFirst(_.camelCase(name))}`;
     this.children = transformChildren(node);
     this.attributes = classNamesToAttributes(Array.prototype.slice.call(node.attributes)
-      .map(x => ({ name: htmlToReactAttributes(x.name), value: x.value }))
-      .reduce((attrs, x) => Object.assign({ [x.name]: x.value }, attrs), {}));
+      .map((x) => ({ name: htmlToReactAttributes(x.name), value: x.value }))
+      .reduce((attrs, x) => ({ [x.name]: x.value, ...attrs }), {}));
   }
 }
 

--- a/packages/terra-icon/scripts/src/generate-icon/classNamesToAttributes.js
+++ b/packages/terra-icon/scripts/src/generate-icon/classNamesToAttributes.js
@@ -1,5 +1,5 @@
 const classNamesToAttributes = (attributes) => {
-  const iconAttributes = Object.assign({}, attributes);
+  const iconAttributes = { ...attributes };
 
   if (iconAttributes.className) {
     // remove is-bidi css class and add isBidi as an attribute

--- a/packages/terra-icon/scripts/src/generate-icon/index.js
+++ b/packages/terra-icon/scripts/src/generate-icon/index.js
@@ -13,9 +13,9 @@ removeMakeDirectories();
 // get filepath for every svg
 const svgs = fs.readdirSync(TerraIcon.svgDir)
 // Only load svg files
-  .filter(f => path.extname(f) === '.svg')
+  .filter((f) => path.extname(f) === '.svg')
 // // Resolve to absolute path
-  .map(f => path.join(TerraIcon.svgDir, f));
+  .map((f) => path.join(TerraIcon.svgDir, f));
 
 /* eslint-disable no-console */
 svgs.forEach((svg) => {

--- a/packages/terra-icon/scripts/src/generate-icon/parseSvg.js
+++ b/packages/terra-icon/scripts/src/generate-icon/parseSvg.js
@@ -5,7 +5,7 @@ import path from 'path';
 import Icon from './Icon';
 /* eslint-enable import/no-extraneous-dependencies */
 
-const parseSvg = filepath => new Promise((resolve) => {
+const parseSvg = (filepath) => new Promise((resolve) => {
   const source = fs.readFileSync(filepath, 'utf-8');
   const { name } = path.parse(filepath);
 

--- a/packages/terra-icon/scripts/src/generate-icon/renderJsx.js
+++ b/packages/terra-icon/scripts/src/generate-icon/renderJsx.js
@@ -11,14 +11,14 @@ const themeIconTemplatePath = path.join(__dirname, './template.txt');
 
 // Generate list of static color icon names
 const staticIcons = iconData
-  .filter(icon => !icon.themeable && !icon.deprecated)
-  .map(icon => icon.componentName);
+  .filter((icon) => !icon.themeable && !icon.deprecated)
+  .map((icon) => icon.componentName);
 
 /**
  * generateJsx - Takes an Icon object as input and returns a React component
  * @param {object} icon Icon object that stores svg attributes, children, and name
  */
-const renderJsx = icon => new Promise((resolve, reject) => {
+const renderJsx = (icon) => new Promise((resolve, reject) => {
   if (staticIcons.includes(icon.name)) {
     fs.readFile(staticIconTemplatePath, 'utf-8', (error, text) => {
       if (error) {

--- a/packages/terra-icon/scripts/src/generate-icon/writeIcon.js
+++ b/packages/terra-icon/scripts/src/generate-icon/writeIcon.js
@@ -5,7 +5,7 @@ import fs from 'fs';
  * generateJsx - Takes an Icon object as input and returns a React component
  * @param {object} icon Icon object that stores svg attributes, children, and name
  */
-const writeIcon = reactIcon => new Promise((resolve, reject) => {
+const writeIcon = (reactIcon) => new Promise((resolve, reject) => {
   fs.writeFile(reactIcon.file, reactIcon.component, (error) => {
     if (error) {
       reject(error);

--- a/packages/terra-icon/scripts/src/icon-utils/parseCsv.js
+++ b/packages/terra-icon/scripts/src/icon-utils/parseCsv.js
@@ -21,7 +21,7 @@ const parseCsv = () => new Promise((resolve) => {
       jsonObj.syntaxComponent = `<${jsonObj.componentName} height='2em' width='2em' />`;
       jsonObj.syntaxImport = `import ${jsonObj.componentName} from 'terra-icon/lib/icon/${jsonObj.componentName}';\n`;
       /* eslint-enable  no-param-reassign */
-    }).then(jsonObj => resolve(jsonObj));
+    }).then((jsonObj) => resolve(jsonObj));
 });
 
 export default parseCsv;

--- a/packages/terra-icon/scripts/src/migrate-svg/optimizeSvg.js
+++ b/packages/terra-icon/scripts/src/migrate-svg/optimizeSvg.js
@@ -3,8 +3,8 @@ import SVGO from 'svgo';
 import optimizeConfig from './optimizeConfig';
 /* eslint-enable import/no-extraneous-dependencies */
 
-const optimizeSvg = csvObject => new Promise((resolve, reject) => {
-  const objectCsv = Object.assign({}, csvObject);
+const optimizeSvg = (csvObject) => new Promise((resolve, reject) => {
+  const objectCsv = { ...csvObject };
   const config = optimizeConfig(objectCsv);
   const svgo = new SVGO(config);
 

--- a/packages/terra-icon/scripts/src/migrate-svg/readSvg.js
+++ b/packages/terra-icon/scripts/src/migrate-svg/readSvg.js
@@ -1,8 +1,8 @@
 /* eslint-disable compat/compat */
 const fs = require('fs');
 
-const readSvg = csvObject => new Promise((resolve, reject) => {
-  const objectCsv = Object.assign({}, csvObject);
+const readSvg = (csvObject) => new Promise((resolve, reject) => {
+  const objectCsv = { ...csvObject };
   fs.readFile(objectCsv.svgSrc, 'utf-8', (error, svg) => {
     if (error) {
       reject(error);

--- a/packages/terra-icon/scripts/src/migrate-svg/writeSvg.js
+++ b/packages/terra-icon/scripts/src/migrate-svg/writeSvg.js
@@ -1,7 +1,7 @@
 /* eslint-disable compat/compat */
 const fs = require('fs');
 
-const writeSvg = csvObject => new Promise((resolve, reject) => {
+const writeSvg = (csvObject) => new Promise((resolve, reject) => {
   fs.writeFile(csvObject.svgDest, csvObject.svg, 'utf-8', (error) => {
     if (error) {
       reject(error);

--- a/packages/terra-icon/src/IconBase.jsx
+++ b/packages/terra-icon/src/IconBase.jsx
@@ -59,7 +59,7 @@ const IconBase = ({
   focusable,
   ...customProps
 }) => {
-  const attributes = Object.assign({}, customProps);
+  const attributes = { ...customProps };
 
   const addAnimationStyles = () => {
     if (isSpin) {

--- a/packages/terra-image/CHANGELOG.md
+++ b/packages/terra-image/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 3.14.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-image/src/Image.jsx
+++ b/packages/terra-image/src/Image.jsx
@@ -61,7 +61,7 @@ const propTypes = {
   /**
   * Sets the `object-fit` style of the image from the following values; `cover`, `contain`, `fill`, `scale-down`, `none`.
   */
-  fit: PropTypes.oneOf(Object.values(FitTypes)),
+  fit: PropTypes.oneOf(Object.values(FitTypes)), // eslint-disable-line compat/compat
 };
 
 /* eslint-disable react/default-props-match-prop-types */

--- a/packages/terra-image/src/Image.jsx
+++ b/packages/terra-image/src/Image.jsx
@@ -61,7 +61,7 @@ const propTypes = {
   /**
   * Sets the `object-fit` style of the image from the following values; `cover`, `contain`, `fill`, `scale-down`, `none`.
   */
-  fit: PropTypes.oneOf(Object.values(FitTypes)), // eslint-disable-line compat/compat
+  fit: PropTypes.oneOf(Object.values(FitTypes)),
 };
 
 /* eslint-disable react/default-props-match-prop-types */

--- a/packages/terra-legacy-theme/CHANGELOG.md
+++ b/packages/terra-legacy-theme/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
 
 2.27.0 - (July 24, 2019)
 ------------------

--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 4.14.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-list/src/ListItem.jsx
+++ b/packages/terra-list/src/ListItem.jsx
@@ -92,8 +92,8 @@ const ListItem = ({
     attrSpread.role = 'option';
     attrSpread['aria-selected'] = isSelected;
     attrSpread['data-item-show-focus'] = 'true';
-    attrSpread.onBlur = ListUtils.wrappedEventCallback(onBlur, event => event.currentTarget.setAttribute('data-item-show-focus', 'true'));
-    attrSpread.onMouseDown = ListUtils.wrappedEventCallback(onMouseDown, event => event.currentTarget.setAttribute('data-item-show-focus', 'false'));
+    attrSpread.onBlur = ListUtils.wrappedEventCallback(onBlur, (event) => event.currentTarget.setAttribute('data-item-show-focus', 'true'));
+    attrSpread.onMouseDown = ListUtils.wrappedEventCallback(onMouseDown, (event) => event.currentTarget.setAttribute('data-item-show-focus', 'false'));
   }
 
   return (

--- a/packages/terra-list/src/ListSection.jsx
+++ b/packages/terra-list/src/ListSection.jsx
@@ -58,10 +58,10 @@ const ListSection = ({
   }
 
   return (
-    <React.Fragment>
+    <>
       <SectionHeader {...customProps} isCollapsible={isCollapsible} isCollapsed={isCollapsed} />
       {sectionItems}
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/terra-list/src/ListSectionHeader.jsx
+++ b/packages/terra-list/src/ListSectionHeader.jsx
@@ -104,8 +104,8 @@ const ListSectionHeader = ({
     attrSpread['aria-expanded'] = !isCollapsed;
     attrSpread['aria-level'] = 1;
     attrSpread['data-item-show-focus'] = 'true';
-    attrSpread.onBlur = ListUtils.wrappedEventCallback(onBlur, event => event.currentTarget.setAttribute('data-item-show-focus', 'true'));
-    attrSpread.onMouseDown = ListUtils.wrappedEventCallback(onMouseDown, event => event.currentTarget.setAttribute('data-item-show-focus', 'false'));
+    attrSpread.onBlur = ListUtils.wrappedEventCallback(onBlur, (event) => event.currentTarget.setAttribute('data-item-show-focus', 'true'));
+    attrSpread.onMouseDown = ListUtils.wrappedEventCallback(onMouseDown, (event) => event.currentTarget.setAttribute('data-item-show-focus', 'false'));
   }
 
   return (

--- a/packages/terra-list/src/ListSubsection.jsx
+++ b/packages/terra-list/src/ListSubsection.jsx
@@ -58,10 +58,10 @@ const ListSubsection = ({
   }
 
   return (
-    <React.Fragment>
+    <>
       <SubsectionHeader {...customProps} isCollapsible={isCollapsible} isCollapsed={isCollapsed} />
       {sectionItems}
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/terra-list/src/ListSubsectionHeader.jsx
+++ b/packages/terra-list/src/ListSubsectionHeader.jsx
@@ -104,8 +104,8 @@ const ListSubsectionHeader = ({
     attrSpread['aria-expanded'] = !isCollapsed;
     attrSpread['aria-level'] = 2;
     attrSpread['data-item-show-focus'] = 'true';
-    attrSpread.onBlur = ListUtils.wrappedEventCallback(onBlur, event => event.currentTarget.setAttribute('data-item-show-focus', 'true'));
-    attrSpread.onMouseDown = ListUtils.wrappedEventCallback(onMouseDown, event => event.currentTarget.setAttribute('data-item-show-focus', 'false'));
+    attrSpread.onBlur = ListUtils.wrappedEventCallback(onBlur, (event) => event.currentTarget.setAttribute('data-item-show-focus', 'true'));
+    attrSpread.onMouseDown = ListUtils.wrappedEventCallback(onMouseDown, (event) => event.currentTarget.setAttribute('data-item-show-focus', 'false'));
   }
 
   return (

--- a/packages/terra-list/src/terra-dev-site/doc/example/ListDivided.jsx
+++ b/packages/terra-list/src/terra-dev-site/doc/example/ListDivided.jsx
@@ -8,7 +8,7 @@ import styles from './ListDocCommon.module.scss';
 const cx = classNames.bind(styles);
 
 const ListDividedExample = () => (
-  <React.Fragment>
+  <>
     <List dividerStyle="standard">
       <Item key="123">
         <Placeholder title="Standard Divider Item 0" className={cx('placeholder')} />
@@ -32,7 +32,7 @@ const ListDividedExample = () => (
         <Placeholder title="Bottom Divider Item 2" className={cx('placeholder')} />
       </Item>
     </List>
-  </React.Fragment>
+  </>
 );
 
 export default ListDividedExample;

--- a/packages/terra-list/src/terra-dev-site/doc/example/ListPadded.jsx
+++ b/packages/terra-list/src/terra-dev-site/doc/example/ListPadded.jsx
@@ -8,7 +8,7 @@ import styles from './ListDocCommon.module.scss';
 const cx = classNames.bind(styles);
 
 const ListPaddedExample = () => (
-  <React.Fragment>
+  <>
     <List paddingStyle="standard">
       <Item key="123">
         <Placeholder title="Standard Padding Item 0" className={cx('placeholder')} />
@@ -32,7 +32,7 @@ const ListPaddedExample = () => (
         <Placeholder title="Compact Padding Item 2" className={cx('placeholder')} />
       </Item>
     </List>
-  </React.Fragment>
+  </>
 );
 
 export default ListPaddedExample;

--- a/packages/terra-list/src/terra-dev-site/doc/guides/MultiSelectList.jsx
+++ b/packages/terra-list/src/terra-dev-site/doc/guides/MultiSelectList.jsx
@@ -20,7 +20,7 @@ class MutliSelectList extends React.Component {
 
   handleItemSelection(event, metaData) {
     event.preventDefault();
-    this.setState(state => ({ selectedKeys: Utils.updatedMultiSelectedKeys(state.selectedKeys, metaData.key) }));
+    this.setState((state) => ({ selectedKeys: Utils.updatedMultiSelectedKeys(state.selectedKeys, metaData.key) }));
   }
 
   createListItem(itemData) {
@@ -38,7 +38,7 @@ class MutliSelectList extends React.Component {
   }
 
   createListItems(data) {
-    return data.map(childItem => this.createListItem(childItem));
+    return data.map((childItem) => this.createListItem(childItem));
   }
 
   render() {

--- a/packages/terra-list/src/terra-dev-site/doc/guides/SectionList.jsx
+++ b/packages/terra-list/src/terra-dev-site/doc/guides/SectionList.jsx
@@ -14,7 +14,7 @@ import styles from '../example/ListDocCommon.module.scss';
 
 const cx = classNames.bind(styles);
 
-const createListItem = itemData => (
+const createListItem = (itemData) => (
   <Item key={itemData.key}>
     <Placeholder title={itemData.title} className={cx('placeholder')} />
   </Item>
@@ -31,7 +31,7 @@ class SectionList extends React.Component {
 
   handleSectionSelection(event, metaData) {
     event.preventDefault();
-    this.setState(state => ({ collapsedKeys: Utils.updatedMultiSelectedKeys(state.collapsedKeys, metaData.key) }));
+    this.setState((state) => ({ collapsedKeys: Utils.updatedMultiSelectedKeys(state.collapsedKeys, metaData.key) }));
   }
 
   createSection(sectionData) {
@@ -44,13 +44,13 @@ class SectionList extends React.Component {
         metaData={{ key: sectionData.key }}
         onSelect={this.handleSectionSelection}
       >
-        {sectionData.childItems.map(childItem => createListItem(childItem))}
+        {sectionData.childItems.map((childItem) => createListItem(childItem))}
       </Section>
     );
   }
 
   createSections(data) {
-    return data.map(section => this.createSection(section));
+    return data.map((section) => this.createSection(section));
   }
 
   render() {

--- a/packages/terra-list/src/terra-dev-site/doc/guides/SectionWithSubsection1.jsx
+++ b/packages/terra-list/src/terra-dev-site/doc/guides/SectionWithSubsection1.jsx
@@ -15,18 +15,18 @@ import styles from '../example/ListDocCommon.module.scss';
 
 const cx = classNames.bind(styles);
 
-const createListItem = itemData => (
+const createListItem = (itemData) => (
   <Item key={itemData.key}>
     <Placeholder title={itemData.title} className={cx('placeholder')} />
   </Item>
 );
 
-const createSubsection = subsectionData => (
+const createSubsection = (subsectionData) => (
   <Subsection
     key={subsectionData.key}
     title={subsectionData.title}
   >
-    {subsectionData.childItems.map(childItem => createListItem(childItem))}
+    {subsectionData.childItems.map((childItem) => createListItem(childItem))}
   </Subsection>
 );
 
@@ -42,7 +42,7 @@ class SectionWithSubsection1 extends React.Component {
   handleSectionSelection(event, metaData) {
     event.preventDefault();
 
-    this.setState(state => ({ collapsedKeys: Utils.updatedMultiSelectedKeys(state.collapsedKeys, metaData.key) }));
+    this.setState((state) => ({ collapsedKeys: Utils.updatedMultiSelectedKeys(state.collapsedKeys, metaData.key) }));
   }
 
   createSection(sectionData) {
@@ -56,13 +56,13 @@ class SectionWithSubsection1 extends React.Component {
         metaData={{ key: sectionData.key }}
         onSelect={this.handleSectionSelection}
       >
-        {!isCollapsed && sectionData.childItems.map(childItem => createSubsection(childItem))}
+        {!isCollapsed && sectionData.childItems.map((childItem) => createSubsection(childItem))}
       </Section>
     );
   }
 
   createSections(data) {
-    return data.map(section => this.createSection(section));
+    return data.map((section) => this.createSection(section));
   }
 
   render() {

--- a/packages/terra-list/src/terra-dev-site/doc/guides/SectionWithSubsection2.jsx
+++ b/packages/terra-list/src/terra-dev-site/doc/guides/SectionWithSubsection2.jsx
@@ -14,7 +14,7 @@ import styles from '../example/ListDocCommon.module.scss';
 
 const cx = classNames.bind(styles);
 
-const createListItem = itemData => (
+const createListItem = (itemData) => (
   <Item key={itemData.key}>
     <Placeholder title={itemData.title} className={cx('placeholder')} />
   </Item>
@@ -33,7 +33,7 @@ class SectionWithSubsection2 extends React.Component {
   handleSectionSelection(event, metaData) {
     event.preventDefault();
 
-    this.setState(state => ({ collapsedKeys: Utils.updatedMultiSelectedKeys(state.collapsedKeys, metaData.key) }));
+    this.setState((state) => ({ collapsedKeys: Utils.updatedMultiSelectedKeys(state.collapsedKeys, metaData.key) }));
   }
 
   createSubsection(subsectionData) {
@@ -47,7 +47,7 @@ class SectionWithSubsection2 extends React.Component {
         metaData={{ key: subsectionData.key }}
         onSelect={this.handleSectionSelection}
       >
-        {!isCollapsed && subsectionData.childItems.map(childItem => createListItem(childItem))}
+        {!isCollapsed && subsectionData.childItems.map((childItem) => createListItem(childItem))}
       </Subsection>
     );
   }
@@ -58,13 +58,13 @@ class SectionWithSubsection2 extends React.Component {
         key={sectionData.key}
         title={sectionData.title}
       >
-        {sectionData.childItems.map(childItem => this.createSubsection(childItem))}
+        {sectionData.childItems.map((childItem) => this.createSubsection(childItem))}
       </Section>
     );
   }
 
   createSections(data) {
-    return data.map(section => this.createSection(section));
+    return data.map((section) => this.createSection(section));
   }
 
   render() {

--- a/packages/terra-list/src/terra-dev-site/doc/guides/SingleSelectList.jsx
+++ b/packages/terra-list/src/terra-dev-site/doc/guides/SingleSelectList.jsx
@@ -38,7 +38,7 @@ class SingleSelectList extends React.Component {
   }
 
   createListItems(data) {
-    return data.map(childItem => this.createListItem(childItem));
+    return data.map((childItem) => this.createListItem(childItem));
   }
 
   render() {

--- a/packages/terra-list/src/terra-dev-site/test/list/List.test.jsx
+++ b/packages/terra-list/src/terra-dev-site/test/list/List.test.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import List, { Item } from 'terra-list/lib/index';
 
 const ListTest = () => (
-  <React.Fragment>
+  <>
     <List>
       <Item key="0">
         <p>test 0</p>
@@ -37,7 +37,7 @@ const ListTest = () => (
         <p>divided test 2</p>
       </Item>
     </List>
-  </React.Fragment>
+  </>
 );
 
 export default ListTest;

--- a/packages/terra-list/src/terra-dev-site/test/list/ListItem.test.jsx
+++ b/packages/terra-list/src/terra-dev-site/test/list/ListItem.test.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import List, { Item } from 'terra-list/lib/index';
 
 const ListItemTest = () => (
-  <React.Fragment>
+  <>
     <List>
       <Item
         key="default"
@@ -33,7 +33,7 @@ const ListItemTest = () => (
         <p>test selected</p>
       </Item>
     </List>
-  </React.Fragment>
+  </>
 );
 
 export default ListItemTest;

--- a/packages/terra-markdown/CHANGELOG.md
+++ b/packages/terra-markdown/CHANGELOG.md
@@ -9,7 +9,8 @@ Unreleased
 ### Changed
 * Updated marked to 0.7.x
 * Updated primsjs to ~1.17.1
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 2.30.0 - (July 24, 2019)
 ------------------

--- a/packages/terra-markdown/src/Markdown.jsx
+++ b/packages/terra-markdown/src/Markdown.jsx
@@ -11,7 +11,7 @@ import styles from './Markdown.scss';
 const cx = classNames.bind(styles);
 
 // Create a list of loaded languages, remove functions that aren't actaully languages.
-const supportedLanguages = Object.keys(Prism.languages).filter(lang => !['extend', 'insertBefore', 'DFS'].includes(lang));
+const supportedLanguages = Object.keys(Prism.languages).filter((lang) => !['extend', 'insertBefore', 'DFS'].includes(lang));
 
 // If the supported language is requested, highlight it.
 const highlight = (code, lang) => {
@@ -61,7 +61,7 @@ const defaultProps = {
 };
 
 /* eslint react/no-danger:0 */
-const Markdown = props => (
+const Markdown = (props) => (
   <div
     dir="ltr"
     className={cx(['markdown'])}

--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -6,7 +6,8 @@ Unreleased
 ### Changed
 * Components updated to use `FormattedMessage` to interface with `react-intl's` `intl` context.
 * Update tests for dev-site v6
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 3.23.0 - (July 24, 2019)
 ------------------

--- a/packages/terra-overlay/src/LoadingOverlay.jsx
+++ b/packages/terra-overlay/src/LoadingOverlay.jsx
@@ -65,12 +65,11 @@ const LoadingOverlay = ({
         ? <div className={cx('message')}>{message}</div>
         : (
           <FormattedMessage id="Terra.Overlay.loading">
-            {loadingMessage => (
+            {(loadingMessage) => (
               <div className={cx('message')}>{loadingMessage}</div>
             )}
           </FormattedMessage>
-        )
-      }
+        )}
     </Overlay>
   );
 };

--- a/packages/terra-paginator/CHANGELOG.md
+++ b/packages/terra-paginator/CHANGELOG.md
@@ -4,7 +4,8 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 2.22.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-paginator/src/ControlledPaginator.jsx
+++ b/packages/terra-paginator/src/ControlledPaginator.jsx
@@ -52,6 +52,7 @@ class Paginator extends React.Component {
     return (event) => {
       event.preventDefault();
 
+      // eslint-disable-next-line compat/compat
       if (Number.isNaN(Number(index))) {
         this.props.onPageChange(event.currentTarget.attributes['aria-label'].value);
 
@@ -69,6 +70,7 @@ class Paginator extends React.Component {
       if (event.nativeEvent.keyCode === KeyCode.KEY_RETURN || event.nativeEvent.keyCode === KeyCode.KEY_SPACE) {
         event.preventDefault();
 
+        // eslint-disable-next-line compat/compat
         if (Number.isNaN(Number(index))) {
           this.props.onPageChange(event.currentTarget.attributes['aria-label'].value);
 

--- a/packages/terra-paginator/src/ControlledPaginator.jsx
+++ b/packages/terra-paginator/src/ControlledPaginator.jsx
@@ -52,7 +52,6 @@ class Paginator extends React.Component {
     return (event) => {
       event.preventDefault();
 
-      // eslint-disable-next-line compat/compat
       if (Number.isNaN(Number(index))) {
         this.props.onPageChange(event.currentTarget.attributes['aria-label'].value);
 
@@ -70,7 +69,6 @@ class Paginator extends React.Component {
       if (event.nativeEvent.keyCode === KeyCode.KEY_RETURN || event.nativeEvent.keyCode === KeyCode.KEY_SPACE) {
         event.preventDefault();
 
-        // eslint-disable-next-line compat/compat
         if (Number.isNaN(Number(index))) {
           this.props.onPageChange(event.currentTarget.attributes['aria-label'].value);
 

--- a/packages/terra-paginator/src/ControlledProgressivePaginator.jsx
+++ b/packages/terra-paginator/src/ControlledProgressivePaginator.jsx
@@ -57,7 +57,6 @@ class ProgressivePaginator extends React.Component {
       if (event.nativeEvent.keyCode === KeyCode.KEY_RETURN || event.nativeEvent.keyCode === KeyCode.KEY_SPACE) {
         event.preventDefault();
 
-        // eslint-disable-next-line compat/compat
         if (Number.isNaN(Number(index))) {
           this.props.onPageChange(event.target.text.trim().toLowerCase());
 

--- a/packages/terra-paginator/src/ControlledProgressivePaginator.jsx
+++ b/packages/terra-paginator/src/ControlledProgressivePaginator.jsx
@@ -57,6 +57,7 @@ class ProgressivePaginator extends React.Component {
       if (event.nativeEvent.keyCode === KeyCode.KEY_RETURN || event.nativeEvent.keyCode === KeyCode.KEY_SPACE) {
         event.preventDefault();
 
+        // eslint-disable-next-line compat/compat
         if (Number.isNaN(Number(index))) {
           this.props.onPageChange(event.target.text.trim().toLowerCase());
 

--- a/packages/terra-paginator/src/Paginator.jsx
+++ b/packages/terra-paginator/src/Paginator.jsx
@@ -59,7 +59,6 @@ class Paginator extends React.Component {
     return (event) => {
       event.preventDefault();
 
-      // eslint-disable-next-line compat/compat
       if (Number.isNaN(Number(index))) {
         this.props.onPageChange(event.currentTarget.attributes['aria-label'].value);
 
@@ -81,7 +80,6 @@ class Paginator extends React.Component {
       if (event.nativeEvent.keyCode === KeyCode.KEY_RETURN || event.nativeEvent.keyCode === KeyCode.KEY_SPACE) {
         event.preventDefault();
 
-        // eslint-disable-next-line compat/compat
         if (Number.isNaN(Number(index))) {
           this.props.onPageChange(event.currentTarget.attributes['aria-label'].value);
 

--- a/packages/terra-paginator/src/Paginator.jsx
+++ b/packages/terra-paginator/src/Paginator.jsx
@@ -59,6 +59,7 @@ class Paginator extends React.Component {
     return (event) => {
       event.preventDefault();
 
+      // eslint-disable-next-line compat/compat
       if (Number.isNaN(Number(index))) {
         this.props.onPageChange(event.currentTarget.attributes['aria-label'].value);
 
@@ -80,6 +81,7 @@ class Paginator extends React.Component {
       if (event.nativeEvent.keyCode === KeyCode.KEY_RETURN || event.nativeEvent.keyCode === KeyCode.KEY_SPACE) {
         event.preventDefault();
 
+        // eslint-disable-next-line compat/compat
         if (Number.isNaN(Number(index))) {
           this.props.onPageChange(event.currentTarget.attributes['aria-label'].value);
 

--- a/packages/terra-paginator/src/ProgressivePaginator.jsx
+++ b/packages/terra-paginator/src/ProgressivePaginator.jsx
@@ -65,6 +65,7 @@ class ProgressivePaginator extends React.Component {
       if (event.nativeEvent.keyCode === KeyCode.KEY_RETURN || event.nativeEvent.keyCode === KeyCode.KEY_SPACE) {
         event.preventDefault();
 
+        // eslint-disable-next-line compat/compat
         if (Number.isNaN(Number(index))) {
           this.props.onPageChange(event.target.text.trim().toLowerCase());
 

--- a/packages/terra-paginator/src/ProgressivePaginator.jsx
+++ b/packages/terra-paginator/src/ProgressivePaginator.jsx
@@ -65,7 +65,6 @@ class ProgressivePaginator extends React.Component {
       if (event.nativeEvent.keyCode === KeyCode.KEY_RETURN || event.nativeEvent.keyCode === KeyCode.KEY_SPACE) {
         event.preventDefault();
 
-        // eslint-disable-next-line compat/compat
         if (Number.isNaN(Number(index))) {
           this.props.onPageChange(event.target.text.trim().toLowerCase());
 

--- a/packages/terra-paginator/src/terra-dev-site/test/paginator/Paginator.test.jsx
+++ b/packages/terra-paginator/src/terra-dev-site/test/paginator/Paginator.test.jsx
@@ -3,7 +3,7 @@ import Paginator from '../../../Paginator';
 
 const PaginatorExample = () => (
   // eslint-disable-next-line no-console
-  <Paginator onPageChange={i => console.log(i)} selectedPage={1} totalCount={2234} itemCountPerPage={20} />
+  <Paginator onPageChange={(i) => console.log(i)} selectedPage={1} totalCount={2234} itemCountPerPage={20} />
 );
 
 export default PaginatorExample;

--- a/packages/terra-paginator/src/terra-dev-site/test/paginator/PaginatorNoPages.test.jsx
+++ b/packages/terra-paginator/src/terra-dev-site/test/paginator/PaginatorNoPages.test.jsx
@@ -3,7 +3,7 @@ import Paginator from '../../../Paginator';
 
 const PaginatorNoPagesExample = () => (
   // eslint-disable-next-line no-console
-  <Paginator onPageChange={i => console.log(i)} />
+  <Paginator onPageChange={(i) => console.log(i)} />
 );
 
 export default PaginatorNoPagesExample;

--- a/packages/terra-paginator/src/terra-dev-site/test/paginator/ProgressivePaginator.test.jsx
+++ b/packages/terra-paginator/src/terra-dev-site/test/paginator/ProgressivePaginator.test.jsx
@@ -3,7 +3,7 @@ import ProgressivePaginator from '../../../ProgressivePaginator';
 
 const ProgressivePaginatorExample = () => (
   // eslint-disable-next-line no-console
-  <ProgressivePaginator onPageChange={i => console.log(i)} selectedPage={1} totalCount={2234} itemCountPerPage={20} />
+  <ProgressivePaginator onPageChange={(i) => console.log(i)} selectedPage={1} totalCount={2234} itemCountPerPage={20} />
 );
 
 export default ProgressivePaginatorExample;

--- a/packages/terra-paginator/tests/jest/ControlledPaginator.test.jsx
+++ b/packages/terra-paginator/tests/jest/ControlledPaginator.test.jsx
@@ -4,7 +4,7 @@ import { shallowWithIntl } from 'terra-enzyme-intl';
 import ControlledPaginator from '../../src/ControlledPaginator';
 
 describe('Paginator', () => {
-  const defaultRender = <ControlledPaginator onPageChange={e => typeof e} selectedPage={1} totalCount={2234} itemCountPerPage={20} />;
+  const defaultRender = <ControlledPaginator onPageChange={(e) => typeof e} selectedPage={1} totalCount={2234} itemCountPerPage={20} />;
 
   // Snapshot Tests
   it('should render a Controlled Paginator', () => {

--- a/packages/terra-paginator/tests/jest/ControlledProgressivePaginator.test.jsx
+++ b/packages/terra-paginator/tests/jest/ControlledProgressivePaginator.test.jsx
@@ -4,7 +4,7 @@ import { shallowWithIntl } from 'terra-enzyme-intl';
 import ControlledProgressivePaginator from '../../src/ControlledProgressivePaginator';
 
 describe('Paginator', () => {
-  const defaultRender = <ControlledProgressivePaginator onPageChange={e => typeof e} selectedPage={1} totalCount={2234} itemCountPerPage={20} />;
+  const defaultRender = <ControlledProgressivePaginator onPageChange={(e) => typeof e} selectedPage={1} totalCount={2234} itemCountPerPage={20} />;
 
   // Snapshot Tests
   it('should render a Controlled ProgressivePaginator', () => {

--- a/packages/terra-paginator/tests/jest/Paginator.test.jsx
+++ b/packages/terra-paginator/tests/jest/Paginator.test.jsx
@@ -4,8 +4,8 @@ import { shallowWithIntl } from 'terra-enzyme-intl';
 import Paginator from '../../src/Paginator';
 
 describe('Paginator', () => {
-  const defaultRender = <Paginator onPageChange={e => typeof e} selectedPage={1} totalCount={2234} itemCountPerPage={20} />;
-  const noPagesRender = <Paginator onPageChange={e => typeof e} />;
+  const defaultRender = <Paginator onPageChange={(e) => typeof e} selectedPage={1} totalCount={2234} itemCountPerPage={20} />;
+  const noPagesRender = <Paginator onPageChange={(e) => typeof e} />;
 
   // Snapshot Tests
   it('should render a default paginator', () => {

--- a/packages/terra-paginator/tests/jest/ProgressivePaginator.test.jsx
+++ b/packages/terra-paginator/tests/jest/ProgressivePaginator.test.jsx
@@ -4,7 +4,7 @@ import { shallowWithIntl } from 'terra-enzyme-intl';
 import ProgressivePaginator from '../../src/ProgressivePaginator';
 
 describe('ProgressivePaginator', () => {
-  const defaultRender = <ProgressivePaginator onPageChange={e => typeof e} selectedPage={1} totalCount={2234} itemCountPerPage={20} />;
+  const defaultRender = <ProgressivePaginator onPageChange={(e) => typeof e} selectedPage={1} totalCount={2234} itemCountPerPage={20} />;
 
   // Snapshot Tests
   it('should render a default ProgressivePaginator', () => {

--- a/packages/terra-profile-image/CHANGELOG.md
+++ b/packages/terra-profile-image/CHANGELOG.md
@@ -8,7 +8,8 @@ Unreleased
 * updated to set `fit` to always be `cover` to handle non-square images.
 
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 3.15.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-profile-image/src/ProfileImage.jsx
+++ b/packages/terra-profile-image/src/ProfileImage.jsx
@@ -34,7 +34,7 @@ const propTypes = {
   onError: PropTypes.func,
 };
 
-const isOnlyNumbers = toTest => !(/\D/).test(toTest);
+const isOnlyNumbers = (toTest) => !(/\D/).test(toTest);
 
 const ProfileImage = (props) => {
   // img tags assume a height attribute of only numbers is in px but CSS does not

--- a/packages/terra-progress-bar/CHANGELOG.md
+++ b/packages/terra-progress-bar/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
 
 4.10.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-props-table/CHANGELOG.md
+++ b/packages/terra-props-table/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 2.37.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-props-table/bin/generateMarkdown/generatePropType.js
+++ b/packages/terra-props-table/bin/generateMarkdown/generatePropType.js
@@ -6,7 +6,6 @@ const generatePropType = (type) => {
   let typeName = type.name;
 
   if (type.name === 'enum') {
-    // eslint-disable-next-line compat/compat
     if (Number.isNaN(Number(type.value[0].value))) {
       typeName = typeof type.value[0].value;
     } else {

--- a/packages/terra-props-table/bin/generateMarkdown/generatePropType.js
+++ b/packages/terra-props-table/bin/generateMarkdown/generatePropType.js
@@ -6,6 +6,7 @@ const generatePropType = (type) => {
   let typeName = type.name;
 
   if (type.name === 'enum') {
+    // eslint-disable-next-line compat/compat
     if (Number.isNaN(Number(type.value[0].value))) {
       typeName = typeof type.value[0].value;
     } else {

--- a/packages/terra-props-table/bin/generateMarkdown/generateProps.js
+++ b/packages/terra-props-table/bin/generateMarkdown/generateProps.js
@@ -6,7 +6,7 @@ const generateProps = (props) => {
 
   return (
     `${tableHeader}${tableHeaderBottom}${
-      Object.keys(props).sort().map(propName => generatePropRow(propName, props[propName])).join('\n')}`
+      Object.keys(props).sort().map((propName) => generatePropRow(propName, props[propName])).join('\n')}`
   );
 };
 

--- a/packages/terra-props-table/bin/props-table.js
+++ b/packages/terra-props-table/bin/props-table.js
@@ -26,7 +26,7 @@ let filenames = commander.args.reduce((globbed, input) => {
 }, []);
 
 // verify filenames are unique
-filenames = [...new Set(filenames)]; // eslint-disable-line compat/compat
+filenames = [...new Set(filenames)];
 
 // check if filenames exist
 filenames.forEach((filename) => {

--- a/packages/terra-props-table/bin/props-table.js
+++ b/packages/terra-props-table/bin/props-table.js
@@ -26,7 +26,7 @@ let filenames = commander.args.reduce((globbed, input) => {
 }, []);
 
 // verify filenames are unique
-filenames = [...new Set(filenames)];
+filenames = [...new Set(filenames)]; // eslint-disable-line compat/compat
 
 // check if filenames exist
 filenames.forEach((filename) => {

--- a/packages/terra-props-table/src/terra-dev-site/test/props-table-test/MockComponent.jsx
+++ b/packages/terra-props-table/src/terra-dev-site/test/props-table-test/MockComponent.jsx
@@ -60,7 +60,7 @@ const propTypes = {
 };
 /* eslint-enable react/no-unused-prop-types */
 
-const MockComponent = props => (
+const MockComponent = (props) => (
   React.createElement('span', JSON.stringify({ props }))
 );
 

--- a/packages/terra-props-table/src/terra-dev-site/test/props-table-test/MockPrivatePropsComponent.jsx
+++ b/packages/terra-props-table/src/terra-dev-site/test/props-table-test/MockPrivatePropsComponent.jsx
@@ -20,7 +20,7 @@ const propTypes = {
 };
 /* eslint-enable react/no-unused-prop-types */
 
-const MockComponent = props => (
+const MockComponent = (props) => (
   React.createElement('span', JSON.stringify({ props }))
 );
 

--- a/packages/terra-responsive-element/CHANGELOG.md
+++ b/packages/terra-responsive-element/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 5.5.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-responsive-element/src/ResponsiveElement.jsx
+++ b/packages/terra-responsive-element/src/ResponsiveElement.jsx
@@ -153,10 +153,10 @@ class ResponsiveElement extends React.Component {
     }
 
     return (
-      <React.Fragment>
+      <>
         {responsiveTo === 'parent' && !this.container && <div ref={this.setContainer} />}
         {children}
-      </React.Fragment>
+      </>
     );
   }
 }

--- a/packages/terra-responsive-element/src/terra-dev-site/doc/example/BreakpointExample.jsx
+++ b/packages/terra-responsive-element/src/terra-dev-site/doc/example/BreakpointExample.jsx
@@ -7,7 +7,7 @@ const BreakpointExample = () => {
   const [breakpoint, setBreakpoint] = useState('');
 
   return (
-    <ResponsiveElement onChange={value => setBreakpoint(value)}>
+    <ResponsiveElement onChange={(value) => setBreakpoint(value)}>
       <Placeholder title={breakpoint} />
     </ResponsiveElement>
   );

--- a/packages/terra-responsive-element/src/terra-dev-site/doc/example/ResizeExample.jsx
+++ b/packages/terra-responsive-element/src/terra-dev-site/doc/example/ResizeExample.jsx
@@ -7,7 +7,7 @@ const ResizeExample = () => {
   const [width, setWidth] = useState('');
 
   return (
-    <ResponsiveElement onResize={value => setWidth(value)}>
+    <ResponsiveElement onResize={(value) => setWidth(value)}>
       <Placeholder title={width} />
     </ResponsiveElement>
   );

--- a/packages/terra-scroll/CHANGELOG.md
+++ b/packages/terra-scroll/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
 
 2.13.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-search-field/CHANGELOG.md
+++ b/packages/terra-search-field/CHANGELOG.md
@@ -7,7 +7,8 @@ Unreleased
 * Updated search-field example code to show more usage.
 * Components updated to use `injectIntl` to interface with `react-intl's` `intl` context.
 * Update jest test snanpshot
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 3.23.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-search-field/src/SearchField.jsx
+++ b/packages/terra-search-field/src/SearchField.jsx
@@ -223,7 +223,7 @@ class SearchField extends React.Component {
     const inputText = intl.formatMessage({ id: 'Terra.searchField.search' });
     const buttonText = intl.formatMessage({ id: 'Terra.searchField.submit-search' });
     const clearText = intl.formatMessage({ id: 'Terra.searchField.clear' });
-    const additionalInputAttributes = Object.assign({ 'aria-label': inputText }, inputAttributes);
+    const additionalInputAttributes = { 'aria-label': inputText, ...inputAttributes };
     const clearIcon = <span className={cx('clear-icon')} />;
 
     if (value !== undefined) {

--- a/packages/terra-search-field/src/terra-dev-site/test/search-field/SearchFieldEnter.test.jsx
+++ b/packages/terra-search-field/src/terra-dev-site/test/search-field/SearchFieldEnter.test.jsx
@@ -16,11 +16,11 @@ class AutoSearchDisabledSearchField extends React.Component {
   }
 
   handleSearch(searchText) {
-    this.setState(prevState => ({ searchCount: prevState.searchCount + 1, searchText, message: 'Search Text: ' }));
+    this.setState((prevState) => ({ searchCount: prevState.searchCount + 1, searchText, message: 'Search Text: ' }));
   }
 
   handleInvalidSearch(searchText) {
-    this.setState(prevState => ({ searchCount: prevState.searchCount + 1, searchText, message: 'INVALID Search Text: ' }));
+    this.setState((prevState) => ({ searchCount: prevState.searchCount + 1, searchText, message: 'INVALID Search Text: ' }));
   }
 
   render() {

--- a/packages/terra-search-field/src/terra-dev-site/test/search-field/SearchFieldFocus.test.jsx
+++ b/packages/terra-search-field/src/terra-dev-site/test/search-field/SearchFieldFocus.test.jsx
@@ -23,14 +23,14 @@ class SearchFieldFocus extends React.Component {
 
   render() {
     return (
-      <React.Fragment>
+      <>
         <Button text="Focus Me" onClick={this.handleButtonClick} id="search-field-focus-button" />
         <SearchField
           onChange={this.onChange}
           value={this.state.searchText}
           inputRefCallback={(inputRef) => { this.searchInput = inputRef; }}
         />
-      </React.Fragment>
+      </>
     );
   }
 }

--- a/packages/terra-search-field/src/terra-dev-site/test/search-field/SearchFieldOnChange.test.jsx
+++ b/packages/terra-search-field/src/terra-dev-site/test/search-field/SearchFieldOnChange.test.jsx
@@ -13,7 +13,7 @@ class SearchFieldOnChange extends React.Component {
     if (text && text.length > 0 && /\d/.test(text)) {
       searchText = text.substring(0, text.length - 1);
     }
-    this.setState(prevState => ({ searchText, callCount: prevState.callCount + 1 }));
+    this.setState((prevState) => ({ searchText, callCount: prevState.callCount + 1 }));
   }
 
   render() {

--- a/packages/terra-section-header/CHANGELOG.md
+++ b/packages/terra-section-header/CHANGELOG.md
@@ -4,7 +4,8 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 * Remove react and react-dom as dependencies
 
 2.19.0 - (July 30, 2019)

--- a/packages/terra-section-header/src/SectionHeader.jsx
+++ b/packages/terra-section-header/src/SectionHeader.jsx
@@ -37,7 +37,7 @@ const defaultProps = {
   level: 2,
 };
 
-const isRecognizedKeyPress = event => ((event.nativeEvent.keyCode === KeyCode.KEY_RETURN) || (event.nativeEvent.keyCode === KeyCode.KEY_SPACE));
+const isRecognizedKeyPress = (event) => ((event.nativeEvent.keyCode === KeyCode.KEY_RETURN) || (event.nativeEvent.keyCode === KeyCode.KEY_SPACE));
 
 class SectionHeader extends React.Component {
   constructor(props) {
@@ -92,7 +92,7 @@ class SectionHeader extends React.Component {
       console.warn('\'isOpen\' are intended to be used only when \'onClick\' is provided.');
     }
 
-    const attributes = Object.assign({}, customProps);
+    const attributes = { ...customProps };
 
     if (onClick) {
       attributes.tabIndex = '0';

--- a/packages/terra-section-header/src/terra-dev-site/doc/example/AccordionSectionHeader.jsx
+++ b/packages/terra-section-header/src/terra-dev-site/doc/example/AccordionSectionHeader.jsx
@@ -11,7 +11,7 @@ class AccordionSectionHeader extends React.Component {
   }
 
   handleClick() {
-    this.setState(prevState => ({ isOpen: !prevState.isOpen }));
+    this.setState((prevState) => ({ isOpen: !prevState.isOpen }));
   }
 
   render() {

--- a/packages/terra-section-header/src/terra-dev-site/doc/example/LongTitleAccordionSectionHeader.jsx
+++ b/packages/terra-section-header/src/terra-dev-site/doc/example/LongTitleAccordionSectionHeader.jsx
@@ -11,7 +11,7 @@ class LongTitleAccordionSectionHeader extends React.Component {
   }
 
   handleClick() {
-    this.setState(prevState => ({ isOpen: !prevState.isOpen }));
+    this.setState((prevState) => ({ isOpen: !prevState.isOpen }));
   }
 
   render() {

--- a/packages/terra-show-hide/CHANGELOG.md
+++ b/packages/terra-show-hide/CHANGELOG.md
@@ -4,7 +4,8 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 2.18.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-show-hide/src/terra-dev-site/doc/example/ButtonAlignCenterShowHide.jsx
+++ b/packages/terra-show-hide/src/terra-dev-site/doc/example/ButtonAlignCenterShowHide.jsx
@@ -14,7 +14,7 @@ class ButtonAlignCenterShowHide extends React.Component {
   }
 
   toggleShowHide() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-show-hide/src/terra-dev-site/doc/example/ButtonAlignRightShowHide.jsx
+++ b/packages/terra-show-hide/src/terra-dev-site/doc/example/ButtonAlignRightShowHide.jsx
@@ -14,7 +14,7 @@ class ButtonAlignRightShowHideTest extends React.Component {
   }
 
   toggleShowHide() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-show-hide/src/terra-dev-site/doc/example/CustomButtonTextShowHide.jsx
+++ b/packages/terra-show-hide/src/terra-dev-site/doc/example/CustomButtonTextShowHide.jsx
@@ -24,7 +24,7 @@ class CustomButtonTextShowHide extends React.Component {
   }
 
   toggleShowHide() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-show-hide/src/terra-dev-site/doc/example/DefaultShowHide.jsx
+++ b/packages/terra-show-hide/src/terra-dev-site/doc/example/DefaultShowHide.jsx
@@ -14,7 +14,7 @@ class DefaultShowHide extends React.Component {
   }
 
   toggleShowHide() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-show-hide/src/terra-dev-site/doc/example/InitiallyOpenShowHide.jsx
+++ b/packages/terra-show-hide/src/terra-dev-site/doc/example/InitiallyOpenShowHide.jsx
@@ -14,7 +14,7 @@ class InitiallyOpenShowHide extends React.Component {
   }
 
   toggleShowHide() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-show-hide/src/terra-dev-site/doc/example/NoPreviewShowHide.jsx
+++ b/packages/terra-show-hide/src/terra-dev-site/doc/example/NoPreviewShowHide.jsx
@@ -13,7 +13,7 @@ class NoPreviewShowHide extends React.Component {
   }
 
   toggleShowHide() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-show-hide/src/terra-dev-site/test/show-hide/ButtonAlignCenterShowHide.test.jsx
+++ b/packages/terra-show-hide/src/terra-dev-site/test/show-hide/ButtonAlignCenterShowHide.test.jsx
@@ -14,7 +14,7 @@ class ButtonAlignCenterShowHide extends React.Component {
   }
 
   toggleShowHide() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-show-hide/src/terra-dev-site/test/show-hide/ButtonAlignEndShowHide.test.jsx
+++ b/packages/terra-show-hide/src/terra-dev-site/test/show-hide/ButtonAlignEndShowHide.test.jsx
@@ -14,7 +14,7 @@ class ButtonAlignRightShowHideTest extends React.Component {
   }
 
   toggleShowHide() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-show-hide/src/terra-dev-site/test/show-hide/ButtonAlignStartShowHide.test.jsx
+++ b/packages/terra-show-hide/src/terra-dev-site/test/show-hide/ButtonAlignStartShowHide.test.jsx
@@ -14,7 +14,7 @@ class ButtonAlignLeftShowHideTest extends React.Component {
   }
 
   toggleShowHide() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-show-hide/src/terra-dev-site/test/show-hide/CustomButtonTextShowHide.test.jsx
+++ b/packages/terra-show-hide/src/terra-dev-site/test/show-hide/CustomButtonTextShowHide.test.jsx
@@ -24,7 +24,7 @@ class CustomButtonTextShowHideTest extends React.Component {
   }
 
   toggleShowHide() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-show-hide/src/terra-dev-site/test/show-hide/DefaultShowHide.test.jsx
+++ b/packages/terra-show-hide/src/terra-dev-site/test/show-hide/DefaultShowHide.test.jsx
@@ -14,7 +14,7 @@ class DefaultShowHide extends React.Component {
   }
 
   toggleShowHide() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-show-hide/src/terra-dev-site/test/show-hide/InitiallyOpenShowHide.test.jsx
+++ b/packages/terra-show-hide/src/terra-dev-site/test/show-hide/InitiallyOpenShowHide.test.jsx
@@ -14,7 +14,7 @@ class InitiallyOpenShowHide extends React.Component {
   }
 
   toggleShowHide() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-show-hide/src/terra-dev-site/test/show-hide/LongButtonTextShowHide.test.jsx
+++ b/packages/terra-show-hide/src/terra-dev-site/test/show-hide/LongButtonTextShowHide.test.jsx
@@ -14,7 +14,7 @@ class DefaultShowHide extends React.Component {
   }
 
   toggleShowHide() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-show-hide/src/terra-dev-site/test/show-hide/NoPreviewShowHide.test.jsx
+++ b/packages/terra-show-hide/src/terra-dev-site/test/show-hide/NoPreviewShowHide.test.jsx
@@ -13,7 +13,7 @@ class NoPreviewShowHide extends React.Component {
   }
 
   toggleShowHide() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-show-hide/tests/jest/ShowHide.test.jsx
+++ b/packages/terra-show-hide/tests/jest/ShowHide.test.jsx
@@ -7,81 +7,81 @@ import ShowHide from '../../src/ShowHide';
 describe('ShowHide', () => {
   // Snapshot Tests
   it('should render a default show-hide component', () => {
-    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={e => typeof e}>Full Text</ShowHide>);
+    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={(e) => typeof e}>Full Text</ShowHide>);
     expect(showHide).toMatchSnapshot();
   });
 
   it('should render a no preview show-hide component', () => {
-    const showHide = mountWithIntl(<ShowHide onChange={e => typeof e}>Full Text</ShowHide>);
+    const showHide = mountWithIntl(<ShowHide onChange={(e) => typeof e}>Full Text</ShowHide>);
     expect(showHide).toMatchSnapshot();
   });
 
   it('should render an initially open show-hide component', () => {
-    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={e => typeof e} isOpen>Full Text</ShowHide>);
+    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={(e) => typeof e} isOpen>Full Text</ShowHide>);
     expect(showHide).toMatchSnapshot();
   });
 
   it('should render a center-aligned button show-hide component', () => {
-    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={e => typeof e} buttonAlign="center">Full Text</ShowHide>);
+    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={(e) => typeof e} buttonAlign="center">Full Text</ShowHide>);
     expect(showHide).toMatchSnapshot();
   });
 
   // Prop Tests
   it('should set children prop correctly', () => {
-    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={e => typeof e}>Full Text</ShowHide>);
+    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={(e) => typeof e}>Full Text</ShowHide>);
     expect(showHide).toMatchSnapshot();
   });
 
   it('should set buttonText prop correctly when it is collapsed', () => {
-    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={e => typeof e} buttonText="Collapsed Text" isOpen={false}>Full Text</ShowHide>);
+    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={(e) => typeof e} buttonText="Collapsed Text" isOpen={false}>Full Text</ShowHide>);
     expect(showHide).toMatchSnapshot();
   });
 
   it('should set buttonText prop correctly when it is expanded', () => {
-    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={e => typeof e} buttonText="Expanded Text" isOpen>Full Text</ShowHide>);
+    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={(e) => typeof e} buttonText="Expanded Text" isOpen>Full Text</ShowHide>);
     expect(showHide).toMatchSnapshot();
   });
 
   it('should set isOpen prop correctly', () => {
-    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={e => typeof e} isOpen>Full Text</ShowHide>);
+    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={(e) => typeof e} isOpen>Full Text</ShowHide>);
     expect(showHide).toMatchSnapshot();
   });
 
   it('should set the button to align right', () => {
-    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={e => typeof e} buttonAlign="end">Full Text</ShowHide>);
+    const showHide = mountWithIntl(<ShowHide preview={<p>Test</p>} onChange={(e) => typeof e} buttonAlign="end">Full Text</ShowHide>);
     expect(showHide).toMatchSnapshot();
   });
 
   it('should set preview prop correctly', () => {
-    const showHide = mountWithIntl(<ShowHide preview={<p>Preview Text</p>} onChange={e => typeof e}>Full Text</ShowHide>);
+    const showHide = mountWithIntl(<ShowHide preview={<p>Preview Text</p>} onChange={(e) => typeof e}>Full Text</ShowHide>);
     expect(showHide).toMatchSnapshot();
   });
 
   // Attributes
   it('should merge classes passed in with attributes', () => {
-    const showHide = mountWithIntl(<ShowHide className="TestClass" preview={<p>Test</p>} onChange={e => typeof e}>Full Text</ShowHide>);
+    const showHide = mountWithIntl(<ShowHide className="TestClass" preview={<p>Test</p>} onChange={(e) => typeof e}>Full Text</ShowHide>);
     expect(showHide).toMatchSnapshot();
   });
 
   it('should merge ids passed in with attributes', () => {
-    const showHide = mountWithIntl(<ShowHide id="TestId" preview={<p>Test</p>} onChange={e => typeof e}>Full Text</ShowHide>);
+    const showHide = mountWithIntl(<ShowHide id="TestId" preview={<p>Test</p>} onChange={(e) => typeof e}>Full Text</ShowHide>);
     expect(showHide).toMatchSnapshot();
   });
 
   it('should append data passed in with attributes', () => {
-    const showHide = mountWithIntl(<ShowHide data-terra-text-mock="MockData" preview={<p>Test</p>} onChange={e => typeof e}>Full Text</ShowHide>);
+    const showHide = mountWithIntl(<ShowHide data-terra-text-mock="MockData" preview={<p>Test</p>} onChange={(e) => typeof e}>Full Text</ShowHide>);
     expect(showHide).toMatchSnapshot();
   });
 
   it('should append styles passed in with attributes', () => {
-    const showHide = mountWithIntl(<ShowHide style={{ height: '100px' }} preview={<p>Test</p>} onChange={e => typeof e}>Full Text</ShowHide>);
+    const showHide = mountWithIntl(<ShowHide style={{ height: '100px' }} preview={<p>Test</p>} onChange={(e) => typeof e}>Full Text</ShowHide>);
     expect(showHide).toMatchSnapshot();
   });
 
   // Error Handling Test
   it('should throw error for required children', () => {
     try {
-      mountWithIntl(<ShowHide onChange={e => typeof e} />);
+      mountWithIntl(<ShowHide onChange={(e) => typeof e} />);
     } catch (e) {
       expect(e.message).toContain('The prop `children` is marked as required');
     }
@@ -97,7 +97,7 @@ describe('ShowHide', () => {
 
   it('should throw error for required intl prop', () => {
     try {
-      render(<ShowHide onChange={e => typeof e}>Full Text</ShowHide>);
+      render(<ShowHide onChange={(e) => typeof e}>Full Text</ShowHide>);
     } catch (e) {
       expect(e.message).toContain('[React Intl] Could not find required `intl` object. <IntlProvider> needs to exist in the component ancestry.');
     }

--- a/packages/terra-signature/CHANGELOG.md
+++ b/packages/terra-signature/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 2.17.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-signature/src/Signature.jsx
+++ b/packages/terra-signature/src/Signature.jsx
@@ -161,7 +161,7 @@ class Signature extends React.Component {
     }
 
     // Record new line segment
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       lineSegments: [...prevState.lineSegments, newSegment],
       lastLineSegments: [...prevState.lastLineSegments, newSegment],
     }));

--- a/packages/terra-signature/src/terra-dev-site/doc/example/SignatureExample.jsx
+++ b/packages/terra-signature/src/terra-dev-site/doc/example/SignatureExample.jsx
@@ -45,12 +45,12 @@ class SignatureExample extends React.Component {
     }, {
       x1: 71, y1: 87, x2: 71, y2: 87,
     }];
-    const newState = Object.assign({}, this.state, { lineSegments: singleLine });
+    const newState = { ...this.state, lineSegments: singleLine };
     this.setState(newState);
   }
 
   handleClear() {
-    const newState = Object.assign({}, this.state, { lineSegments: [] });
+    const newState = { ...this.state, lineSegments: [] };
     this.setState(newState);
   }
 

--- a/packages/terra-spacer/CHANGELOG.md
+++ b/packages/terra-spacer/CHANGELOG.md
@@ -4,7 +4,8 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 3.17.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-spacer/src/Spacer.jsx
+++ b/packages/terra-spacer/src/Spacer.jsx
@@ -13,7 +13,7 @@ const cx = classNames.bind(styles);
   as defined. Currently, simply putting `Object.values(SpacerSizes)` causes all other `marginX` and `paddingX` props to be recognized as `undefined`
   in the PropsTable.
 */
-const arrayOfSpacerSizes = [...Object.values(SpacerSizes)]; // eslint-disable-line compat/compat
+const arrayOfSpacerSizes = [...Object.values(SpacerSizes)];
 
 const propTypes = {
   /**

--- a/packages/terra-spacer/src/Spacer.jsx
+++ b/packages/terra-spacer/src/Spacer.jsx
@@ -13,7 +13,7 @@ const cx = classNames.bind(styles);
   as defined. Currently, simply putting `Object.values(SpacerSizes)` causes all other `marginX` and `paddingX` props to be recognized as `undefined`
   in the PropsTable.
 */
-const arrayOfSpacerSizes = [...Object.values(SpacerSizes)];
+const arrayOfSpacerSizes = [...Object.values(SpacerSizes)]; // eslint-disable-line compat/compat
 
 const propTypes = {
   /**

--- a/packages/terra-spacer/src/_spacerShorthandUtils.js
+++ b/packages/terra-spacer/src/_spacerShorthandUtils.js
@@ -20,7 +20,7 @@ const invalidShArgsLengthError = (
 const invalidShArgValuesError = (
   propName = '<SUPPLY SHORTHAND PROP NAME>',
   invalidShValues = [],
-  expectedValues = Object.values(SpacerSizes), // eslint-disable-line compat/compat
+  expectedValues = Object.values(SpacerSizes),
   componentName = 'Spacer',
 ) => new Error(`Expected ${propName} shorthand values to be one of ${expectedValues} but "${invalidShValues}" supplied to ${componentName}. Validation Failed.`);
 
@@ -86,7 +86,7 @@ export const shorthandValidator = (props = {}, propName = '') => {
   }
 
   const invalidShValues = (() => {
-    const sizes = Object.values(SpacerSizes); // eslint-disable-line compat/compat
+    const sizes = Object.values(SpacerSizes);
     const invalidValues = shValues.filter((val) => sizes.indexOf(val) === -1);
     return invalidValues.length > 0 ? invalidValues : null;
   })();

--- a/packages/terra-spacer/src/_spacerShorthandUtils.js
+++ b/packages/terra-spacer/src/_spacerShorthandUtils.js
@@ -20,7 +20,7 @@ const invalidShArgsLengthError = (
 const invalidShArgValuesError = (
   propName = '<SUPPLY SHORTHAND PROP NAME>',
   invalidShValues = [],
-  expectedValues = Object.values(SpacerSizes),
+  expectedValues = Object.values(SpacerSizes), // eslint-disable-line compat/compat
   componentName = 'Spacer',
 ) => new Error(`Expected ${propName} shorthand values to be one of ${expectedValues} but "${invalidShValues}" supplied to ${componentName}. Validation Failed.`);
 
@@ -61,7 +61,7 @@ export const shorthandValidator = (props = {}, propName = '') => {
   }
 
   const conflictingPropName = (() => {
-    const propertyConflicts = dir => (props[`${propName}${dir}`] && (props[`${propName}${dir}`] !== SpacerSizes.NONE));
+    const propertyConflicts = (dir) => (props[`${propName}${dir}`] && (props[`${propName}${dir}`] !== SpacerSizes.NONE));
 
     const conflictProp = (
       (propertyConflicts('Top') ? `${propName}Top` : undefined)
@@ -78,7 +78,7 @@ export const shorthandValidator = (props = {}, propName = '') => {
   }
 
   const shValuesUnfiltered = propVal.split(SHORTHAND_DELIMITER);
-  const shValues = shValuesUnfiltered.filter(val => val); // Remove any falsey values (including empty strings)
+  const shValues = shValuesUnfiltered.filter((val) => val); // Remove any falsey values (including empty strings)
   const shValueCountValid = shValues.length >= shLengthBoundaries.min && shValues.length <= shLengthBoundaries.max;
 
   if (!shValueCountValid) {
@@ -86,8 +86,8 @@ export const shorthandValidator = (props = {}, propName = '') => {
   }
 
   const invalidShValues = (() => {
-    const sizes = Object.values(SpacerSizes);
-    const invalidValues = shValues.filter(val => sizes.indexOf(val) === -1);
+    const sizes = Object.values(SpacerSizes); // eslint-disable-line compat/compat
+    const invalidValues = shValues.filter((val) => sizes.indexOf(val) === -1);
     return invalidValues.length > 0 ? invalidValues : null;
   })();
 

--- a/packages/terra-status-view/CHANGELOG.md
+++ b/packages/terra-status-view/CHANGELOG.md
@@ -5,7 +5,8 @@ Unreleased
 ----------
 ### Changed
 * Update jest test snanpshot
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 4.4.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-status-view/src/StatusView.jsx
+++ b/packages/terra-status-view/src/StatusView.jsx
@@ -53,7 +53,7 @@ const propTypes = {
    * Sets the glyph and title using a pre-baked variant. One of the following: `no-data`,
    * `no-matching-results`, `not-authorized`, or `error`
    */
-  variant: PropTypes.oneOf(Object.values(StatusViewVariants)),
+  variant: PropTypes.oneOf(Object.values(StatusViewVariants)), // eslint-disable-line compat/compat
 };
 /* eslint-enable react/forbid-foreign-prop-types */
 
@@ -72,7 +72,7 @@ const generateButtons = (buttonAttrsArray) => {
     return undefined;
   }
 
-  return buttonAttrsArray.map(button => <Button {...button} className={cx(['button', button.className])} />);
+  return buttonAttrsArray.map((button) => <Button {...button} className={cx(['button', button.className])} />);
 };
 
 const StatusView = ({

--- a/packages/terra-status-view/src/StatusView.jsx
+++ b/packages/terra-status-view/src/StatusView.jsx
@@ -53,7 +53,7 @@ const propTypes = {
    * Sets the glyph and title using a pre-baked variant. One of the following: `no-data`,
    * `no-matching-results`, `not-authorized`, or `error`
    */
-  variant: PropTypes.oneOf(Object.values(StatusViewVariants)), // eslint-disable-line compat/compat
+  variant: PropTypes.oneOf(Object.values(StatusViewVariants)),
 };
 /* eslint-enable react/forbid-foreign-prop-types */
 

--- a/packages/terra-status/CHANGELOG.md
+++ b/packages/terra-status/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
 
 4.13.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-table/CHANGELOG.md
+++ b/packages/terra-table/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 3.21.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-table/src/terra-dev-site/doc/example/SingleSelectableRowsOnChangeAdditionalDetails.jsx
+++ b/packages/terra-table/src/terra-dev-site/doc/example/SingleSelectableRowsOnChangeAdditionalDetails.jsx
@@ -37,7 +37,7 @@ const SingleSelectableRowsOnChangeAdditionalDetails = () => (
     </Table.Header>
     <Table.SingleSelectableRows onChange={onChange}>
       {
-        people.map(person => (
+        people.map((person) => (
           <Table.Row key={person.key}>
             <Table.Cell content={person.name} key="NAME" />
             <Table.Cell content={person.address} key="ADDRESS" />

--- a/packages/terra-table/src/terra-dev-site/doc/example/TableWithCustomCells.jsx
+++ b/packages/terra-table/src/terra-dev-site/doc/example/TableWithCustomCells.jsx
@@ -7,7 +7,7 @@ import styles from './TableWithCustomCells.module.scss';
 
 const cx = classNames.bind(styles);
 
-const CustomCell = props => (
+const CustomCell = (props) => (
   <div>
     <h3>{props.text}</h3>
     {props.subtext ? <h4 className={cx('custom-cell-header-wrapper')}>{props.subtext}</h4> : null}

--- a/packages/terra-table/tests/jest/TableHeader.test.jsx
+++ b/packages/terra-table/tests/jest/TableHeader.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Table from '../../src/Table';
 
 // Constants
-const clickHandler = e => e;
+const clickHandler = (e) => e;
 const headerData1 = <Table.HeaderCell content="Name" key="NAME" onClick={clickHandler} />;
 const headerData2 = <Table.HeaderCell content="Address" key="ADDRESS" />;
 const headerData3 = <Table.HeaderCell content="Phone Number" key="PHONE_NUMBER" />;

--- a/packages/terra-tag/CHANGELOG.md
+++ b/packages/terra-tag/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
 
 2.18.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-text/CHANGELOG.md
+++ b/packages/terra-text/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 4.13.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-text/src/Text.jsx
+++ b/packages/terra-text/src/Text.jsx
@@ -76,7 +76,7 @@ const defaultProps = {
 const Text = ({
   children, isVisuallyHidden, isItalic, fontSize, weight, isWordWrapped, colorClass, ...customProps
 }) => {
-  const attributes = Object.assign({}, customProps);
+  const attributes = { ...customProps };
   const TextClassNames = cx([
     'text',
     { italic: isItalic },

--- a/packages/terra-toggle-button/CHANGELOG.md
+++ b/packages/terra-toggle-button/CHANGELOG.md
@@ -5,7 +5,8 @@ Unreleased
 ----------
 ### Changed
 * Update jest test snanpshot
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 3.18.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-toggle-button/src/ToggleButton.jsx
+++ b/packages/terra-toggle-button/src/ToggleButton.jsx
@@ -84,7 +84,7 @@ class ToggleButton extends React.Component {
       this.props.onClose();
     }
 
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }

--- a/packages/terra-toggle-button/src/terra-dev-site/doc/example/OpenCloseEventToggleButton.jsx
+++ b/packages/terra-toggle-button/src/terra-dev-site/doc/example/OpenCloseEventToggleButton.jsx
@@ -19,11 +19,11 @@ class OpenCloseEventToggleButton extends React.Component {
   }
 
   handleOnOpen() {
-    this.setState(prevState => ({ timesOpened: prevState.timesOpened + 1 }));
+    this.setState((prevState) => ({ timesOpened: prevState.timesOpened + 1 }));
   }
 
   handleOnClose() {
-    this.setState(prevState => ({ timesClosed: prevState.timesClosed + 1 }));
+    this.setState((prevState) => ({ timesClosed: prevState.timesClosed + 1 }));
   }
 
   render() {

--- a/packages/terra-toggle-button/src/terra-dev-site/test/toggle-button/OnCloseToggleButton.test.jsx
+++ b/packages/terra-toggle-button/src/terra-dev-site/test/toggle-button/OnCloseToggleButton.test.jsx
@@ -9,7 +9,7 @@ class OnCloseToggleButton extends React.Component {
   }
 
   handleOnClose() {
-    this.setState(prevState => ({ timesClosed: prevState.timesClosed + 1 }));
+    this.setState((prevState) => ({ timesClosed: prevState.timesClosed + 1 }));
   }
 
   render() {

--- a/packages/terra-toggle-button/src/terra-dev-site/test/toggle-button/OnOpenToggleButton.test.jsx
+++ b/packages/terra-toggle-button/src/terra-dev-site/test/toggle-button/OnOpenToggleButton.test.jsx
@@ -9,7 +9,7 @@ class OnOpenToggleButton extends React.Component {
   }
 
   handleOnOpen() {
-    this.setState(prevState => ({ timesOpened: prevState.timesOpened + 1 }));
+    this.setState((prevState) => ({ timesOpened: prevState.timesOpened + 1 }));
   }
 
   render() {

--- a/packages/terra-toggle-section-header/CHANGELOG.md
+++ b/packages/terra-toggle-section-header/CHANGELOG.md
@@ -4,7 +4,8 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 2.18.0 - (July 30, 2019)
 ------------------

--- a/packages/terra-toggle-section-header/src/ToggleSectionHeader.jsx
+++ b/packages/terra-toggle-section-header/src/ToggleSectionHeader.jsx
@@ -75,7 +75,7 @@ class ToggleSectionHeader extends React.Component {
       onClose();
     }
 
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }
@@ -104,7 +104,7 @@ class ToggleSectionHeader extends React.Component {
       ...customProps
     } = this.props;
 
-    const sectionHeaderProps = Object.assign({}, sectionHeaderAttrs);
+    const sectionHeaderProps = { ...sectionHeaderAttrs };
     sectionHeaderProps.onClick = this.wrapOnClick(sectionHeaderAttrs.onClick);
 
     return (

--- a/packages/terra-toggle/CHANGELOG.md
+++ b/packages/terra-toggle/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
+* Updated code to match new eslint rules
 
 
 ### Changed

--- a/packages/terra-toggle/src/terra-dev-site/doc/example/AnimatedToggle.jsx
+++ b/packages/terra-toggle/src/terra-dev-site/doc/example/AnimatedToggle.jsx
@@ -12,7 +12,7 @@ class ToggleDefault extends React.Component {
   }
 
   handleOnClick() {
-    this.setState(prevState => ({ isOpen: !prevState.isOpen }));
+    this.setState((prevState) => ({ isOpen: !prevState.isOpen }));
   }
 
   render() {

--- a/packages/terra-toggle/src/terra-dev-site/doc/example/DefaultToggle.jsx
+++ b/packages/terra-toggle/src/terra-dev-site/doc/example/DefaultToggle.jsx
@@ -12,7 +12,7 @@ class ToggleDefault extends React.Component {
   }
 
   handleOnClick() {
-    this.setState(prevState => ({ isOpen: !prevState.isOpen }));
+    this.setState((prevState) => ({ isOpen: !prevState.isOpen }));
   }
 
   render() {

--- a/packages/terra-toggle/src/terra-dev-site/test/toggle/AnimatedToggle.test.jsx
+++ b/packages/terra-toggle/src/terra-dev-site/test/toggle/AnimatedToggle.test.jsx
@@ -10,7 +10,7 @@ class AnimatedToggle extends React.Component {
   }
 
   handleOnClick() {
-    this.setState(prevState => ({ isOpen: !prevState.isOpen }));
+    this.setState((prevState) => ({ isOpen: !prevState.isOpen }));
   }
 
   render() {

--- a/packages/terra-toggle/src/terra-dev-site/test/toggle/DefaultToggle.test.jsx
+++ b/packages/terra-toggle/src/terra-dev-site/test/toggle/DefaultToggle.test.jsx
@@ -10,7 +10,7 @@ class ToggleDefault extends React.Component {
   }
 
   handleOnClick() {
-    this.setState(prevState => ({ isOpen: !prevState.isOpen }));
+    this.setState((prevState) => ({ isOpen: !prevState.isOpen }));
   }
 
   render() {

--- a/packages/terra-toggle/src/terra-dev-site/test/toggle/OpenToggle.test.jsx
+++ b/packages/terra-toggle/src/terra-dev-site/test/toggle/OpenToggle.test.jsx
@@ -10,7 +10,7 @@ class OpenToggle extends React.Component {
   }
 
   handleOnClick() {
-    this.setState(prevState => ({ isOpen: !prevState.isOpen }));
+    this.setState((prevState) => ({ isOpen: !prevState.isOpen }));
   }
 
   render() {

--- a/packages/terra-visually-hidden-text/CHANGELOG.md
+++ b/packages/terra-visually-hidden-text/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* updated package.json test scripts
+* Updated package.json test scripts
 
 2.14.0 - (July 30, 2019)
 ------------------

--- a/scripts/changelog-updater/index.js
+++ b/scripts/changelog-updater/index.js
@@ -13,7 +13,7 @@ exec('npx lerna updated', (error, stdout) => {
   }
 
   // Clean up lerna updated output and convert to an array
-  const updatedPackages = stdout.split('\n').map(x => `packages/${x}`);
+  const updatedPackages = stdout.split('\n').map((x) => `packages/${x}`);
   updatedPackages.pop(); // Remove last item as it is an empty string
 
   // Update release version in changelog files

--- a/scripts/root-readme-updater/index.js
+++ b/scripts/root-readme-updater/index.js
@@ -9,11 +9,11 @@ const rootReadMe = path.join(__dirname, '../../README.md');
 
 // Clean up package entries array
 const packages = packagePaths
-  .map(component => component.replace('packages/', ''))
-  .filter(component => component.startsWith('terra-'));
+  .map((component) => component.replace('packages/', ''))
+  .filter((component) => component.startsWith('terra-'));
 
 // Generate package listing template
-const packageListing = packages.map(component => `| [${component}](https://github.com/cerner/terra-core/tree/master/packages/${component}) | [![NPM version](https://badgen.net/npm/v/${component})](https://www.npmjs.org/package/${component}) | ![Stable](https://badgen.net/badge/status/Stable/green) | [![${component}](https://badgen.net/david/dep/cerner/terra-core/packages/${component})](https://david-dm.org/cerner/terra-core?path=packages/${component}) |`);
+const packageListing = packages.map((component) => `| [${component}](https://github.com/cerner/terra-core/tree/master/packages/${component}) | [![NPM version](https://badgen.net/npm/v/${component})](https://www.npmjs.org/package/${component}) | ![Stable](https://badgen.net/badge/status/Stable/green) | [![${component}](https://badgen.net/david/dep/cerner/terra-core/packages/${component})](https://david-dm.org/cerner/terra-core?path=packages/${component}) |`);
 
 const content = [
   '<!-- AUTO-GENERATED-CONTENT:START (SUBPACKAGELIST) -->',


### PR DESCRIPTION
### Summary
Testing out [`eslint-config-terra` update](https://github.com/cerner/eslint-config-terra/pull/34)

Changes include:
* Update `<React.Fragment>` syntax to `<>`: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md
* Arguments in arrow functions are now wrapped in parens, even if there is only 1 arg: https://eslint.org/docs/rules/arrow-parens
* Object.assign usage switched to Object spread syntax: https://eslint.org/docs/rules/prefer-object-spread#prefer-use-of-an-object-spread-over-objectassign-prefer-object-spread