### PR TITLE
[terra-form-field] Issue 2609 label hidden axe error

### DIFF
--- a/packages/terra-form-field/CHANGELOG.md
+++ b/packages/terra-form-field/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed 'label hidden' accessibility error by using 'visually-hidden text styles' instead of 'display:none'.
 
 3.21.0 - (August 21, 2019)
 ------------------

--- a/packages/terra-form-field/src/Field.module.scss
+++ b/packages/terra-form-field/src/Field.module.scss
@@ -20,7 +20,15 @@
   }
 
   .label-group-hidden {
-    display: none;
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap; /* Ensures words  are not read one at a time on screen readers*/
+    width: 1px;
   }
 
   .label {


### PR DESCRIPTION
### Summary
Fixed 'label hidden' accessibility error by using 'visually-hidden text styles' instead of 'display:none'.

Fixes #2609 