### PR TITLE
Update wcig-inert path to import directly the ES5 version of the package

### DIFF
--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -6,6 +6,8 @@ Unreleased
 ### Added
 * Props table markdown file import added to doc site page
 
+### Changed
+* Update wcig-inert path to import directly the ES5 version of the package
 
 3.27.0 - (September 3, 2019)
 ------------------

--- a/packages/terra-overlay/src/Overlay.jsx
+++ b/packages/terra-overlay/src/Overlay.jsx
@@ -7,7 +7,7 @@ import * as KeyCode from 'keycode-js';
 import 'mutationobserver-shim';
 import './_contains-polyfill';
 import './_matches-polyfill';
-import 'wicg-inert';
+import 'wicg-inert/dist/inert';
 import styles from './Overlay.module.scss';
 import Container from './OverlayContainer';
 

--- a/packages/terra-overlay/src/Overlay.jsx
+++ b/packages/terra-overlay/src/Overlay.jsx
@@ -123,6 +123,8 @@ class Overlay extends React.Component {
     if (this.props.isRelativeToContainer) {
       if (this.container && this.container.querySelector('[data-terra-overlay-container-content]')) {
         this.container.querySelector('[data-terra-overlay-container-content]').removeAttribute('inert');
+        // Ensures aria-hidden is properly cleaned up
+        setTimeout(() => this.container.querySelector('[data-terra-overlay-container-content]').removeAttribute('aria-hidden'), 0);
       }
     } else {
       const selector = this.props.rootSelector;
@@ -133,6 +135,8 @@ class Overlay extends React.Component {
         if (inert === 1) {
           document.querySelector(selector).removeAttribute('data-overlay-count');
           document.querySelector(selector).removeAttribute('inert');
+          // Ensures aria-hidden is properly cleaned up
+          setTimeout(() => document.querySelector(selector).removeAttribute('aria-hidden'), 0);
         } else if (inert && inert > 1) {
           document.querySelector(selector).setAttribute('data-overlay-count', `${inert - 1}`);
         }

--- a/packages/terra-overlay/tests/wdio/overlay-spec.js
+++ b/packages/terra-overlay/tests/wdio/overlay-spec.js
@@ -37,6 +37,8 @@ Terra.describeViewports('Overlay', ['huge'], () => {
 
       it('Clicks on the Full screen overlay button', () => {
         browser.click('#trigger_fullscreen');
+        expect(browser.getAttribute('#root', 'inert')).to.equal('true');
+        expect(browser.getAttribute('#root', 'aria-hidden')).to.equal('true');
       });
 
       it('Background does not scroll when a fullscreen Overlay is open', () => {
@@ -48,16 +50,22 @@ Terra.describeViewports('Overlay', ['huge'], () => {
       it('closes overlay on escape keydown', () => {
         browser.keys('Escape');
         browser.waitForExist('#terra-Overlay--fullscreen', DEFAULT_TIMEOUT, SHOULD_NOT_EXIST);
+        expect(browser.getAttribute('#root', 'inert')).to.equal('false');
+        expect(browser.getAttribute('#root', 'aria-hidden')).to.equal(null);
       });
 
       it('reopens the overlay', () => {
         browser.click('#trigger_fullscreen');
         browser.waitForExist('#terra-Overlay--fullscreen');
+        expect(browser.getAttribute('#root', 'inert')).to.equal('true');
+        expect(browser.getAttribute('#root', 'aria-hidden')).to.equal('true');
       });
 
       it('closes the overlay when clicking inside of the Overlay', () => {
         browser.click('#terra-Overlay--fullscreen');
         browser.waitForExist('#terra-Overlay--fullscreen', DEFAULT_TIMEOUT, SHOULD_NOT_EXIST);
+        expect(browser.getAttribute('#root', 'inert')).to.equal('false');
+        expect(browser.getAttribute('#root', 'aria-hidden')).to.equal(null);
       });
     });
 
@@ -66,6 +74,8 @@ Terra.describeViewports('Overlay', ['huge'], () => {
 
       it('Clicks on Container Overlay', () => {
         browser.click('#trigger_container');
+        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'inert')).to.equal('true');
+        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'aria-hidden')).to.equal('true');
       });
 
       it('Container Overlay- Background can scroll when Overlay relative to container is open', () => {
@@ -77,16 +87,22 @@ Terra.describeViewports('Overlay', ['huge'], () => {
       it('closes overlay on escape keydown', () => {
         browser.keys('Escape');
         browser.waitForExist('#terra-Overlay--container', DEFAULT_TIMEOUT, SHOULD_NOT_EXIST);
+        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'inert')).to.equal('false');
+        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'aria-hidden')).to.equal(null);
       });
 
       it('reopens the overlay', () => {
         browser.click('#trigger_container');
         browser.waitForExist('#terra-Overlay--container');
+        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'inert')).to.equal('true');
+        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'aria-hidden')).to.equal('true');
       });
 
       it('closes the overlay when clicking inside of the Overlay', () => {
         browser.click('#terra-Overlay--container');
         browser.waitForExist('#terra-Overlay--container', DEFAULT_TIMEOUT, SHOULD_NOT_EXIST);
+        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'inert')).to.equal('false');
+        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'aria-hidden')).to.equal(null);
       });
     });
   });


### PR DESCRIPTION
### Summary
[wcig-inert recently added a `module` key to their package.json](https://github.com/WICG/inert/commit/c27413c1a06f61a5d798522588238ca02d9f639a).
With our webpack setup, webpack will prefer resolving `module` over `main` keys defined in the package.json. This change makes the wcig-inert import explicitly import the ES5 version of wcig-inert.