### PR TITLE
[terra-dropdown-button] Remove the default margin in Safari.

### DIFF
--- a/packages/terra-dropdown-button/CHANGELOG.md
+++ b/packages/terra-dropdown-button/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Reset default margin in Safari.
 
 1.4.0 - (September 6, 2019)
 ------------------

--- a/packages/terra-dropdown-button/src/DropdownButton.module.scss
+++ b/packages/terra-dropdown-button/src/DropdownButton.module.scss
@@ -14,6 +14,7 @@
     font-family: inherit;
     font-size: inherit;
     line-height: inherit;
+    margin: 0;/* Reset margin for Safari. Safari defaults to 2px. */
     outline: 0;
     padding-bottom: var(--terra-dropdown-button-dropdown-type-padding-bottom, 0.28571rem);
     padding-left: var(--terra-dropdown-button-dropdown-type-padding-left, 0.71428rem);


### PR DESCRIPTION
### Summary
Resolves #2633 