### PR TITLE
[terra-form-input] - Add placeholder as a property

### DIFF
--- a/packages/terra-form-input/CHANGELOG.md
+++ b/packages/terra-form-input/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added `placeholder` as a first class property to `<Input />` and `<InputField />`
 
 2.27.0 - (September 26, 2019)
 ------------------

--- a/packages/terra-form-input/src/Input.jsx
+++ b/packages/terra-form-input/src/Input.jsx
@@ -45,6 +45,10 @@ const propTypes = {
    */
   pattern: PropTypes.string,
   /**
+   * Placeholder text.
+   */
+  placeholder: PropTypes.string,
+  /**
    * Callback ref to pass into the input dom element.
    */
   refCallback: PropTypes.func,
@@ -79,6 +83,7 @@ const defaultProps = {
   onFocus: undefined,
   name: null,
   pattern: undefined,
+  placeholder: undefined,
   required: false,
   refCallback: undefined,
   type: undefined,
@@ -96,6 +101,7 @@ class Input extends React.Component {
       onFocus,
       name,
       pattern,
+      placeholder,
       refCallback,
       required,
       type,
@@ -144,6 +150,7 @@ class Input extends React.Component {
         name={name}
         type={type}
         pattern={pattern}
+        placeholder={placeholder}
         onBlur={onBlur}
         onChange={onChange}
         onFocus={onFocus}

--- a/packages/terra-form-input/src/InputField.jsx
+++ b/packages/terra-form-input/src/InputField.jsx
@@ -72,6 +72,10 @@ const propTypes = {
    */
   onChange: PropTypes.func,
   /**
+   * Placeholder text.
+   */
+  placeholder: PropTypes.string,
+  /**
    * Ref callback to pass into the ref attribute of the html input element.
    */
   refCallback: PropTypes.func,
@@ -109,6 +113,7 @@ const defaultProps = {
   isLabelHidden: false,
   labelAttrs: {},
   onChange: undefined,
+  placeholder: undefined,
   maxWidth: undefined,
   refCallback: undefined,
   required: false,
@@ -134,6 +139,7 @@ const InputField = (props) => {
     labelAttrs,
     maxWidth,
     onChange,
+    placeholder,
     refCallback,
     required,
     showOptional,
@@ -157,6 +163,7 @@ const InputField = (props) => {
   }
 
   const inputType = type || inputAttrs.type;
+
   return (
     <Field
       label={label}
@@ -180,6 +187,7 @@ const InputField = (props) => {
         id={inputId}
         type={inputType}
         onChange={onChange}
+        placeholder={inputAttrs.placeholder || placeholder}
         value={value}
         defaultValue={defaultValue}
         refCallback={refCallback}

--- a/packages/terra-form-input/src/InputField.jsx
+++ b/packages/terra-form-input/src/InputField.jsx
@@ -187,7 +187,7 @@ const InputField = (props) => {
         id={inputId}
         type={inputType}
         onChange={onChange}
-        placeholder={inputAttrs.placeholder || placeholder}
+        placeholder={placeholder || inputAttrs.placeholder}
         value={value}
         defaultValue={defaultValue}
         refCallback={refCallback}

--- a/packages/terra-form-input/src/terra-dev-site/doc/common/NumberInputExample.jsx
+++ b/packages/terra-form-input/src/terra-dev-site/doc/common/NumberInputExample.jsx
@@ -5,7 +5,7 @@ import Input from 'terra-form-input';
 const NumberInputExample = () => (
   <div>
     <Field label="Numeric Input" htmlFor="numeric">
-      <Input name="number input" placeholder="enter digits" id="numeric" type="number" ariaLabel="Numeric Input" />
+      <Input name="number input" placeholder="Enter Digits" id="numeric" type="number" ariaLabel="Numeric Input" />
     </Field>
   </div>
 );

--- a/packages/terra-form-input/src/terra-dev-site/doc/example/InputField.jsx
+++ b/packages/terra-form-input/src/terra-dev-site/doc/example/InputField.jsx
@@ -7,8 +7,8 @@ const DefaultInputField = () => (
     label="Profile Name"
     help="Note: This can not be changed in the future"
     type="text"
+    placeholder="Profile Name"
     inputAttrs={{
-      placeholder: 'Profile Name',
       name: 'profile',
     }}
   />

--- a/packages/terra-form-input/src/terra-dev-site/doc/example/NumberInputField.jsx
+++ b/packages/terra-form-input/src/terra-dev-site/doc/example/NumberInputField.jsx
@@ -6,8 +6,8 @@ const NumberInputField = () => (
     inputId="numeric-input"
     label="Numeric Value"
     type="number"
+    placeholder="Enter Digits"
     inputAttrs={{
-      placeholder: 'Enter Digits',
       name: 'numeric',
     }}
   />

--- a/packages/terra-form-input/tests/jest/InputField.test.jsx
+++ b/packages/terra-form-input/tests/jest/InputField.test.jsx
@@ -2,145 +2,159 @@ import React from 'react';
 import IconHelp from 'terra-icon/lib/icon/IconHelp';
 import InputField from '../../src/InputField';
 
-it('should render a default InputField component', () => {
-  const textarea = <InputField inputId="test-input" label="Label" />;
-  const wrapper = shallow(textarea);
-  expect(wrapper).toMatchSnapshot();
-});
+describe('InputField', () => {
+  it('should render a default InputField component', () => {
+    const textarea = <InputField inputId="test-input" label="Label" />;
+    const wrapper = shallow(textarea);
+    expect(wrapper).toMatchSnapshot();
+  });
 
-it('should render a disabled InputField component', () => {
-  const textarea = <InputField disabled inputId="test-input" label="Label" />;
-  const wrapper = shallow(textarea);
-  expect(wrapper).toMatchSnapshot();
-});
+  it('should render a disabled InputField component', () => {
+    const textarea = <InputField disabled inputId="test-input" label="Label" />;
+    const wrapper = shallow(textarea);
+    expect(wrapper).toMatchSnapshot();
+  });
 
-it('should render a disabled InputField component via inputAttrs', () => {
-  const textarea = <InputField inputId="test-input" inputAttrs={{ disabled: true }} label="Label" />;
-  const wrapper = shallow(textarea);
-  expect(wrapper).toMatchSnapshot();
-});
+  it('should render a disabled InputField component via inputAttrs', () => {
+    const textarea = <InputField inputId="test-input" inputAttrs={{ disabled: true }} label="Label" />;
+    const wrapper = shallow(textarea);
+    expect(wrapper).toMatchSnapshot();
+  });
 
-it('should render a InputField with props', () => {
-  const textarea = (
-    <InputField
-      inputId="test-input"
-      defaultValue="Value"
-      error="Text"
-      errorIcon={<IconHelp />}
-      help="Help"
-      hideRequired
-      inputAttrs={{
-        name: 'test',
-      }}
-      type="number"
-      isInline
-      isInvalid
-      isLabelHidden
-      label="Label Test"
-      labelAttrs={{
-        className: 'label',
-      }}
-      onChange={() => {}}
-      refCallback={() => {}}
-      showOptional
-      value="Value"
-    />
-  );
+  it('should render a InputField with props', () => {
+    const textarea = (
+      <InputField
+        inputId="test-input"
+        defaultValue="Value"
+        error="Text"
+        errorIcon={<IconHelp />}
+        help="Help"
+        hideRequired
+        inputAttrs={{
+          name: 'test',
+        }}
+        type="number"
+        isInline
+        isInvalid
+        isLabelHidden
+        label="Label Test"
+        labelAttrs={{
+          className: 'label',
+        }}
+        onChange={() => { }}
+        refCallback={() => { }}
+        showOptional
+        value="Value"
+      />
+    );
 
-  const wrapper = shallow(textarea);
-  expect(wrapper).toMatchSnapshot();
-});
+    const wrapper = shallow(textarea);
+    expect(wrapper).toMatchSnapshot();
+  });
 
-it('should render a valid InputField with props', () => {
-  const textarea = (
-    <InputField
-      inputId="test-input"
-      defaultValue="Value"
-      error="Text"
-      errorIcon={<IconHelp />}
-      help="Help"
-      hideRequired
-      inputAttrs={{
-        name: 'test',
-      }}
-      type="number"
-      isInline
-      isLabelHidden
-      label="Label Test"
-      labelAttrs={{
-        className: 'label',
-      }}
-      onChange={() => {}}
-      refCallback={() => {}}
-      showOptional
-      value="Value"
-    />
-  );
+  it('should render a valid InputField with props', () => {
+    const textarea = (
+      <InputField
+        inputId="test-input"
+        defaultValue="Value"
+        error="Text"
+        errorIcon={<IconHelp />}
+        help="Help"
+        hideRequired
+        inputAttrs={{
+          name: 'test',
+        }}
+        type="number"
+        isInline
+        isLabelHidden
+        label="Label Test"
+        labelAttrs={{
+          className: 'label',
+        }}
+        onChange={() => { }}
+        refCallback={() => { }}
+        showOptional
+        value="Value"
+      />
+    );
 
-  const wrapper = shallow(textarea);
-  expect(wrapper).toMatchSnapshot();
-});
+    const wrapper = shallow(textarea);
+    expect(wrapper).toMatchSnapshot();
+  });
 
-it('should render a InputField with type specified through InputAttributes', () => {
-  const textarea = (
-    <InputField
-      inputId="test-input"
-      defaultValue="Value"
-      error="Text"
-      errorIcon={<IconHelp />}
-      help="Help"
-      hideRequired
-      inputAttrs={{
-        name: 'test',
-        type: 'number',
-      }}
-      isInline
-      isInvalid
-      isLabelHidden
-      label="Label Test"
-      labelAttrs={{
-        className: 'label',
-      }}
-      onChange={() => {}}
-      refCallback={() => {}}
-      showOptional
-      value="Value"
-    />
-  );
+  it('should render a InputField with type specified through InputAttributes', () => {
+    const textarea = (
+      <InputField
+        inputId="test-input"
+        defaultValue="Value"
+        error="Text"
+        errorIcon={<IconHelp />}
+        help="Help"
+        hideRequired
+        inputAttrs={{
+          name: 'test',
+          type: 'number',
+        }}
+        isInline
+        isInvalid
+        isLabelHidden
+        label="Label Test"
+        labelAttrs={{
+          className: 'label',
+        }}
+        onChange={() => { }}
+        refCallback={() => { }}
+        showOptional
+        value="Value"
+      />
+    );
 
-  const wrapper = shallow(textarea);
-  expect(wrapper).toMatchSnapshot();
-});
+    const wrapper = shallow(textarea);
+    expect(wrapper).toMatchSnapshot();
+  });
 
-it('should render a InputField with type specified by type attribute when both type attribute and InputAttributes are given', () => {
-  const type = 'Text';
-  const textarea = (
-    <InputField
-      inputId="test-input"
-      defaultValue="Value"
-      error="Text"
-      errorIcon={<IconHelp />}
-      help="Help"
-      hideRequired
-      inputAttrs={{
-        name: 'test',
-        type: 'number',
-      }}
-      type={type}
-      isInline
-      isInvalid
-      isLabelHidden
-      label="Label Test"
-      labelAttrs={{
-        className: 'label',
-      }}
-      onChange={() => {}}
-      refCallback={() => {}}
-      showOptional
-      value="Value"
-    />
-  );
+  it('should render a InputField with type specified by type attribute when both type attribute and InputAttributes are given', () => {
+    const type = 'Text';
+    const textarea = (
+      <InputField
+        inputId="test-input"
+        defaultValue="Value"
+        error="Text"
+        errorIcon={<IconHelp />}
+        help="Help"
+        hideRequired
+        inputAttrs={{
+          name: 'test',
+          type: 'number',
+        }}
+        type={type}
+        isInline
+        isInvalid
+        isLabelHidden
+        label="Label Test"
+        labelAttrs={{
+          className: 'label',
+        }}
+        onChange={() => { }}
+        refCallback={() => { }}
+        showOptional
+        value="Value"
+      />
+    );
 
-  const wrapper = shallow(textarea);
-  expect(wrapper).toMatchSnapshot();
+    const wrapper = shallow(textarea);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render a placeholder within the InputField component', () => {
+    const textarea = <InputField inputId="test-input" label="Label" placeholder="Placeholder" />;
+    const wrapper = shallow(textarea);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render a placeholder within the InputField component when passed as an input attribute', () => {
+    const textarea = <InputField inputId="test-input" label="Label" inputAttrs={{ placeholder: 'Placeholder' }} />;
+    const wrapper = shallow(textarea);
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/packages/terra-form-input/tests/jest/__snapshots__/InputField.test.jsx.snap
+++ b/packages/terra-form-input/tests/jest/__snapshots__/InputField.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render a InputField with props 1`] = `
+exports[`InputField should render a InputField with props 1`] = `
 <Field
   error="Text"
   errorIcon={
@@ -40,7 +40,7 @@ exports[`should render a InputField with props 1`] = `
 </Field>
 `;
 
-exports[`should render a InputField with type specified by type attribute when both type attribute and InputAttributes are given 1`] = `
+exports[`InputField should render a InputField with type specified by type attribute when both type attribute and InputAttributes are given 1`] = `
 <Field
   error="Text"
   errorIcon={
@@ -80,7 +80,7 @@ exports[`should render a InputField with type specified by type attribute when b
 </Field>
 `;
 
-exports[`should render a InputField with type specified through InputAttributes 1`] = `
+exports[`InputField should render a InputField with type specified through InputAttributes 1`] = `
 <Field
   error="Text"
   errorIcon={
@@ -120,7 +120,7 @@ exports[`should render a InputField with type specified through InputAttributes 
 </Field>
 `;
 
-exports[`should render a default InputField component 1`] = `
+exports[`InputField should render a default InputField component 1`] = `
 <Field
   error={null}
   errorIcon={
@@ -150,7 +150,7 @@ exports[`should render a default InputField component 1`] = `
 </Field>
 `;
 
-exports[`should render a disabled InputField component 1`] = `
+exports[`InputField should render a disabled InputField component 1`] = `
 <Field
   error={null}
   errorIcon={
@@ -180,7 +180,7 @@ exports[`should render a disabled InputField component 1`] = `
 </Field>
 `;
 
-exports[`should render a disabled InputField component via inputAttrs 1`] = `
+exports[`InputField should render a disabled InputField component via inputAttrs 1`] = `
 <Field
   error={null}
   errorIcon={
@@ -210,7 +210,69 @@ exports[`should render a disabled InputField component via inputAttrs 1`] = `
 </Field>
 `;
 
-exports[`should render a valid InputField with props 1`] = `
+exports[`InputField should render a placeholder within the InputField component 1`] = `
+<Field
+  error={null}
+  errorIcon={
+    <IconError
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  }
+  help={null}
+  hideRequired={false}
+  htmlFor="test-input"
+  isInline={false}
+  isInvalid={false}
+  isLabelHidden={false}
+  label="Label"
+  labelAttrs={Object {}}
+  required={false}
+  showOptional={false}
+>
+  <Input
+    disabled={false}
+    id="test-input"
+    isInvalid={false}
+    name={null}
+    placeholder="Placeholder"
+    required={false}
+  />
+</Field>
+`;
+
+exports[`InputField should render a placeholder within the InputField component when passed as an input attribute 1`] = `
+<Field
+  error={null}
+  errorIcon={
+    <IconError
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  }
+  help={null}
+  hideRequired={false}
+  htmlFor="test-input"
+  isInline={false}
+  isInvalid={false}
+  isLabelHidden={false}
+  label="Label"
+  labelAttrs={Object {}}
+  required={false}
+  showOptional={false}
+>
+  <Input
+    disabled={false}
+    id="test-input"
+    isInvalid={false}
+    name={null}
+    placeholder="Placeholder"
+    required={false}
+  />
+</Field>
+`;
+
+exports[`InputField should render a valid InputField with props 1`] = `
 <Field
   error="Text"
   errorIcon={


### PR DESCRIPTION
### Summary

This PR adds the `placeholder` attribute as a declared propType within the `<Input />` and `<InputField />` components. 

### Additional Details

Several [site examples](https://engineering.cerner.com/terra-ui/components/terra-form-input/form-input/input) are displaying placeholder text. The property should be shown within generated props table.

Resolves #2675

### Testing

Coincidentally there were already several tests for the placeholder attribute even though it was not a declared propType.

- [Test 1](https://github.com/cerner/terra-core/blob/master/packages/terra-form-input/tests/wdio/form-input-spec.js#L36)
- [Test 2](https://github.com/cerner/terra-core/blob/master/packages/terra-form-input/tests/wdio/form-input-spec.js#L71)
- [Test 3](https://github.com/cerner/terra-core/blob/master/packages/terra-form-input/tests/jest/Input.test.jsx#L25)

I added a couple additional placeholder tests for the InputField.

Thanks for contributing to Terra.
@cerner/terra

[CONTRIBUTORS.md]: ../CONTRIBUTORS.md
[License]: ../LICENSE
