### PR TITLE
[terra-form-textarea] - Add placeholder as a property

### DIFF
--- a/packages/terra-form-textarea/CHANGELOG.md
+++ b/packages/terra-form-textarea/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added `placeholder` as a property to `<Textarea />` and `<TextareaField />`
 
 3.28.0 - (October 3, 2019)
 ------------------

--- a/packages/terra-form-textarea/src/Textarea.jsx
+++ b/packages/terra-form-textarea/src/Textarea.jsx
@@ -62,6 +62,10 @@ const propTypes = {
    */
   onFocus: PropTypes.func,
   /**
+   * Placeholder text.
+   */
+  placeholder: PropTypes.string,
+  /**
    * Whether the input is required or not.
    */
   required: PropTypes.bool,
@@ -92,6 +96,7 @@ const defaultProps = {
   isAutoResizable: false,
   isInvalid: false,
   onChange: undefined,
+  placeholder: undefined,
   required: false,
   rows: null,
   size: 'small',
@@ -180,6 +185,7 @@ class Textarea extends React.Component {
       required,
       onChange,
       onFocus,
+      placeholder,
       isAutoResizable,
       isInvalid,
       value,
@@ -237,6 +243,7 @@ class Textarea extends React.Component {
         name={name}
         onFocus={this.onFocus}
         onChange={this.onChange}
+        placeholder={placeholder}
         required={required}
         rows={textareaRows}
         className={textareaClasses}

--- a/packages/terra-form-textarea/src/TextareaField.jsx
+++ b/packages/terra-form-textarea/src/TextareaField.jsx
@@ -72,6 +72,10 @@ const propTypes = {
    */
   onChange: PropTypes.func,
   /**
+   * Placeholder text.
+   */
+  placeholder: PropTypes.string,
+  /**
    * Whether or not the field is required.
    */
   required: PropTypes.bool,
@@ -102,6 +106,7 @@ const defaultProps = {
   labelAttrs: {},
   maxWidth: undefined,
   onChange: undefined,
+  placeholder: undefined,
   required: false,
   showOptional: false,
   value: undefined,
@@ -126,6 +131,7 @@ const TextareaField = (props) => {
     required,
     showOptional,
     onChange,
+    placeholder,
     value,
     ...customProps
   } = props;
@@ -166,6 +172,7 @@ const TextareaField = (props) => {
         disabled={inputAttrs.disabled || disabled}
         id={inputId}
         onChange={onChange}
+        placeholder={placeholder || inputAttrs.placeholder}
         value={value}
         defaultValue={defaultValue}
         aria-describedby={ariaDescriptionIds}

--- a/packages/terra-form-textarea/src/terra-dev-site/doc/example/RequiredTextareaField.jsx
+++ b/packages/terra-form-textarea/src/terra-dev-site/doc/example/RequiredTextareaField.jsx
@@ -6,10 +6,10 @@ const DefaultTextAreaField = () => (
     inputId="requiredTextarea"
     label="Required Textarea"
     help="Note: This is help text"
+    placeholder="Textarea placeholder"
     required
     inputAttrs={{
       name: 'requiredTextarea',
-      placeholder: 'Textarea placeholder',
     }}
   />
 );

--- a/packages/terra-form-textarea/src/terra-dev-site/doc/example/TextareaField.jsx
+++ b/packages/terra-form-textarea/src/terra-dev-site/doc/example/TextareaField.jsx
@@ -6,9 +6,9 @@ const DefaultTextAreaField = () => (
     inputId="textarea"
     label="Textarea"
     help="Note: This is help text"
+    placeholder="Textarea placeholder"
     inputAttrs={{
       name: 'textarea',
-      placeholder: 'Textarea placeholder',
     }}
   />
 );

--- a/packages/terra-form-textarea/tests/jest/Textarea.test.jsx
+++ b/packages/terra-form-textarea/tests/jest/Textarea.test.jsx
@@ -42,7 +42,7 @@ it('should render as uncontrolled when just a default value is passed into the T
 });
 
 it('should render as controlled when just a default value is passed into the Textarea', () => {
-  const textarea = <Textarea ariaLabel="label" value="foo" onChange={() => {}} />;
+  const textarea = <Textarea ariaLabel="label" value="foo" onChange={() => { }} />;
   const wrapper = render(textarea);
   expect(wrapper).toMatchSnapshot();
 });
@@ -160,4 +160,10 @@ it('should set the ref when refCallback is passed into the component', () => {
   const wrapper = mount(textarea);
 
   expect(refCallback).toHaveBeenCalledWith(wrapper.find('textarea').instance());
+});
+
+it('should render a placeholder within the textarea', () => {
+  const textarea = <Textarea placeholder="placeholder" />;
+  const wrapper = render(textarea);
+  expect(wrapper).toMatchSnapshot();
 });

--- a/packages/terra-form-textarea/tests/jest/TextareaField.test.jsx
+++ b/packages/terra-form-textarea/tests/jest/TextareaField.test.jsx
@@ -40,7 +40,7 @@ it('should render a TextareaField with props', () => {
       isLabelHidden
       label="Label Test"
       labelAttrs={{ className: 'label' }}
-      onChange={() => {}}
+      onChange={() => { }}
       showOptional
       value="Value"
     />
@@ -69,12 +69,24 @@ it('should render a valid TextareaField with props', () => {
       labelAttrs={{
         className: 'label',
       }}
-      onChange={() => {}}
+      onChange={() => { }}
       showOptional
       value="Value"
     />
   );
 
+  const wrapper = shallow(textarea);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it('should render a placeholder within the textarea field', () => {
+  const textarea = <TextareaField inputId="test-input" label="Label" placeholder="placeholder" />;
+  const wrapper = shallow(textarea);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it('should render a placeholder within the textarea field when passed as an input attribute', () => {
+  const textarea = <TextareaField inputId="test-input" label="Label" inputAttrs={{ placeholder: 'Placeholder' }} />;
   const wrapper = shallow(textarea);
   expect(wrapper).toMatchSnapshot();
 });

--- a/packages/terra-form-textarea/tests/jest/__snapshots__/Textarea.test.jsx.snap
+++ b/packages/terra-form-textarea/tests/jest/__snapshots__/Textarea.test.jsx.snap
@@ -82,6 +82,14 @@ exports[`should render a medium textbox appropriately 1`] = `
 />
 `;
 
+exports[`should render a placeholder within the textarea 1`] = `
+<textarea
+  class="textarea"
+  placeholder="placeholder"
+  rows="2"
+/>
+`;
+
 exports[`should render a small textbox appropriately 1`] = `
 <textarea
   class="textarea"

--- a/packages/terra-form-textarea/tests/jest/__snapshots__/TextareaField.test.jsx.snap
+++ b/packages/terra-form-textarea/tests/jest/__snapshots__/TextareaField.test.jsx.snap
@@ -140,6 +140,74 @@ exports[`should render a disabled TextareaField component via inputAttrs 1`] = `
 </Field>
 `;
 
+exports[`should render a placeholder within the textarea field 1`] = `
+<Field
+  error={null}
+  errorIcon={
+    <IconError
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  }
+  help={null}
+  hideRequired={false}
+  htmlFor="test-input"
+  isInline={false}
+  isInvalid={false}
+  isLabelHidden={false}
+  label="Label"
+  labelAttrs={Object {}}
+  required={false}
+  showOptional={false}
+>
+  <Textarea
+    disabled={false}
+    id="test-input"
+    isAutoResizable={false}
+    isInvalid={false}
+    name={null}
+    placeholder="placeholder"
+    required={false}
+    rows={null}
+    size="small"
+  />
+</Field>
+`;
+
+exports[`should render a placeholder within the textarea field when passed as an input attribute 1`] = `
+<Field
+  error={null}
+  errorIcon={
+    <IconError
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  }
+  help={null}
+  hideRequired={false}
+  htmlFor="test-input"
+  isInline={false}
+  isInvalid={false}
+  isLabelHidden={false}
+  label="Label"
+  labelAttrs={Object {}}
+  required={false}
+  showOptional={false}
+>
+  <Textarea
+    disabled={false}
+    id="test-input"
+    isAutoResizable={false}
+    isInvalid={false}
+    name={null}
+    placeholder="Placeholder"
+    required={false}
+    rows={null}
+    size="small"
+  />
+</Field>
+`;
+
 exports[`should render a valid TextareaField with props 1`] = `
 <Field
   error="Text"


### PR DESCRIPTION
### Summary

This PR adds the `placeholder` attribute as a declared propType within the `<Textarea />` and `<TextareaField />` components. 

### Additional Details

Several [site examples](https://engineering.cerner.com/terra-ui/components/terra-form-textarea/form-textarea/textarea-field) are displaying placeholder text. The property should be shown within generated props table.

Resolves #2693

### Testing

Coincidentally there were already a couple tests for the placeholder attribute even though it was not a declared propType. https://github.com/cerner/terra-core/blob/master/packages/terra-form-textarea/tests/wdio/form-textarea-spec.js#L58-L72

I added a couple additional placeholder tests for the Textarea and Field.

Thanks for contributing to Terra.
@cerner/terra

[CONTRIBUTORS.md]: ../CONTRIBUTORS.md
[License]: ../LICENSE
