### PR TITLE
[terra-overlay] Correct inert property management during component update lifecycle

### DIFF
--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -4,6 +4,9 @@ ChangeLog
 Unreleased
 ----------
 
+### Fixed
+* Fixed inert property management during component update lifecycle
+
 3.31.0 - (October 14, 2019)
 ------------------
 ### Changed

--- a/packages/terra-overlay/src/Overlay.jsx
+++ b/packages/terra-overlay/src/Overlay.jsx
@@ -90,10 +90,10 @@ class Overlay extends React.Component {
     }
   }
 
-  componentDidUpdate() {
-    if (this.props.isOpen) {
+  componentDidUpdate(prevProps) {
+    if (this.props.isOpen && !prevProps.isOpen) {
       this.disableContainerChildrenFocus();
-    } else {
+    } else if (!this.props.isOpen && prevProps.isOpen) {
       this.enableContainerChildrenFocus();
     }
   }


### PR DESCRIPTION
### Summary

The overlay keeps track of all mounted overlay instances using an incrementing attribute. When we changed our inert attribute management logic with #2679, we started calling the inert management functions too often, causing the attribute to increment unnecessarily and the inert attribute to not be properly removed.

This change updates the componentDidUpdate implementation to only update the inert property when absolutely necessary, which is after a change to the isOpen prop.