### PR TITLE
Fixed lint warnings for multiple empty lines

### DIFF
--- a/packages/terra-action-footer/CHANGELOG.md
+++ b/packages/terra-action-footer/CHANGELOG.md
@@ -1,5 +1,7 @@
 ChangeLog
 =========
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 Unreleased
 ----------

--- a/packages/terra-action-footer/src/terra-dev-site/doc/example/centered/SingleAction.jsx
+++ b/packages/terra-action-footer/src/terra-dev-site/doc/example/centered/SingleAction.jsx
@@ -3,7 +3,6 @@ import Hyperlink from 'terra-hyperlink';
 import CenteredActionFooter from 'terra-action-footer/lib/CenteredActionFooter';
 import ExampleTemplate from '../../common/ExampleTemplate';
 
-
 export default () => (
   <ExampleTemplate>
     <CenteredActionFooter

--- a/packages/terra-action-header/CHANGELOG.md
+++ b/packages/terra-action-header/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
+
 ### Changed
 * Updated `--terra-action-header-icon-top` variable and added `vertical-align` to align inline svg .
 

--- a/packages/terra-action-header/src/ActionHeader.jsx
+++ b/packages/terra-action-header/src/ActionHeader.jsx
@@ -71,7 +71,6 @@ const defaultProps = {
   children: undefined,
 };
 
-
 const ActionHeader = ({
   title,
   level,

--- a/packages/terra-alert/CHANGELOG.md
+++ b/packages/terra-alert/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 4.13.0 - (October 3, 2019)
 ------------------

--- a/packages/terra-alert/src/terra-dev-site/test/alert/AlertType.test.jsx
+++ b/packages/terra-alert/src/terra-dev-site/test/alert/AlertType.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Alert from '../../../Alert';
 
-
 export default () => (
   <div>
     <Alert id="alertAlert" type={Alert.Opts.Types.ALERT}>Alert of type Alert</Alert>

--- a/packages/terra-avatar/CHANGELOG.md
+++ b/packages/terra-avatar/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 2.29.0 - (October 3, 2019)
 ------------------

--- a/packages/terra-avatar/src/common/AvatarUtils.jsx
+++ b/packages/terra-avatar/src/common/AvatarUtils.jsx
@@ -74,7 +74,6 @@ const generateImage = (image, alt, isAriaHidden, variant, handleFallback) => {
   return <TerraImage className={cx('image')} src={image} placeholder={icon} alt={alt} onError={handleFallback} fit="cover" />;
 };
 
-
 /**
  * Returns true if the given color exists within `COLOR_VARIANTS`.
  */

--- a/packages/terra-badge/CHANGELOG.md
+++ b/packages/terra-badge/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 3.25.0 - (October 3, 2019)
 ------------------

--- a/packages/terra-badge/src/terra-dev-site/test/Badge/BadgeDefault.test.jsx
+++ b/packages/terra-badge/src/terra-dev-site/test/Badge/BadgeDefault.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Badge from '../../../Badge';
 
-
 const BadgeDefault = () => (
   <Badge text="Default" id="default-badge" />
 );

--- a/packages/terra-badge/tests/jest/Badge.test.jsx
+++ b/packages/terra-badge/tests/jest/Badge.test.jsx
@@ -124,7 +124,6 @@ describe('Badge with icon and text', () => {
   });
 });
 
-
 describe('Badge with additional props', () => {
   // With custom props
   it('should have the class terra-Badge--primary, terra-Badge--small and has-icon with icon followed by text', () => {

--- a/packages/terra-button-group/CHANGELOG.md
+++ b/packages/terra-button-group/CHANGELOG.md
@@ -1,5 +1,7 @@
 ChangeLog
 =========
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 Unreleased
 ----------

--- a/packages/terra-button-group/tests/jest/ButtonGroup.test.jsx
+++ b/packages/terra-button-group/tests/jest/ButtonGroup.test.jsx
@@ -10,7 +10,6 @@ it('should render an empty component', () => {
   expect(buttonGroup).toMatchSnapshot();
 });
 
-
 it('should render a button group with children', () => {
   const buttonGroup = shallow((
     <ButtonGroup>

--- a/packages/terra-button/CHANGELOG.md
+++ b/packages/terra-button/CHANGELOG.md
@@ -1,5 +1,7 @@
 ChangeLog
 =========
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 Unreleased
 ----------

--- a/packages/terra-button/src/terra-dev-site/test/button/IconButton.test.jsx
+++ b/packages/terra-button/src/terra-dev-site/test/button/IconButton.test.jsx
@@ -10,7 +10,6 @@ const IconNeutralButton = () => <Button id="iconNeutralButton" text="Button with
 const IconOnlyButton = () => <Button id="iconOnlyButton" text="iconOnlyButton" isIconOnly icon={<IconSquare />} />;
 const IconReversedButton = () => <Button id="iconReversedButton" text="Button with Icon and reversed" icon={<IconSquare />} isReversed />;
 
-
 export default () => (
   <div>
     <IconNeutralButton />

--- a/packages/terra-card/CHANGELOG.md
+++ b/packages/terra-card/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 3.20.0 - (October 3, 2019)
 ------------------

--- a/packages/terra-card/src/Card.jsx
+++ b/packages/terra-card/src/Card.jsx
@@ -12,7 +12,6 @@ const CardVariants = {
   RAISED: 'raised',
 };
 
-
 const propTypes = {
   /**
    * Child Nodes

--- a/packages/terra-card/src/terra-dev-site/doc/card/Card.doc.jsx
+++ b/packages/terra-card/src/terra-dev-site/doc/card/Card.doc.jsx
@@ -25,7 +25,6 @@ import CardContentCenteredSrc from '!raw-loader!../../../../src/terra-dev-site/d
 import CardVisuallyHiddenText from '../example/CardVisuallyHiddenText';
 import CardVisuallyHiddenTextSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/CardVisuallyHiddenText';
 
-
 const DocPage = () => (
   <DocTemplate
     packageName={name}

--- a/packages/terra-card/src/terra-dev-site/doc/example/CardDefault.jsx
+++ b/packages/terra-card/src/terra-dev-site/doc/example/CardDefault.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Card from 'terra-card/lib/Card';
 
-
 const CardDefault = () => (
   <div>
     <Card>Hello World!!</Card>

--- a/packages/terra-card/src/terra-dev-site/doc/example/CardRaised.jsx
+++ b/packages/terra-card/src/terra-dev-site/doc/example/CardRaised.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Card from 'terra-card/lib/Card';
 
-
 const CardDefault = () => (
   <div>
     <Card variant="raised">Hello World!!</Card>

--- a/packages/terra-card/src/terra-dev-site/doc/example/CardVisuallyHiddenText.jsx
+++ b/packages/terra-card/src/terra-dev-site/doc/example/CardVisuallyHiddenText.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Card from 'terra-card/lib/Card';
 
-
 const CardVisuallyHiddenText = () => (
   <div>
     <Card visuallyHiddenText="This is a Hello World Card Introduction">Hello World!!</Card>

--- a/packages/terra-content-container/CHANGELOG.md
+++ b/packages/terra-content-container/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 3.19.0 - (October 3, 2019)
 ------------------

--- a/packages/terra-content-container/tests/jest/ContentContainer.test.jsx
+++ b/packages/terra-content-container/tests/jest/ContentContainer.test.jsx
@@ -9,7 +9,6 @@ it('should render a default component', () => {
   expect(wrapper).toMatchSnapshot();
 });
 
-
 // Prop Tests
 it('should have the class terra-ContentContainer', () => {
   const wrapper = shallow(defaultVariety);

--- a/packages/terra-doc-template/CHANGELOG.md
+++ b/packages/terra-doc-template/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 2.20.0 - (October 3, 2019)
 ------------------

--- a/packages/terra-doc-template/src/terra-dev-site/test/doc-template/DefaultDocTemplate.test.jsx
+++ b/packages/terra-doc-template/src/terra-dev-site/test/doc-template/DefaultDocTemplate.test.jsx
@@ -9,7 +9,6 @@ import exampleSrc from '!raw-loader!../../../../src/terra-dev-site/test/doc-temp
 import testComponentSrc from '!raw-loader!../../../../src/terra-dev-site/test/doc-template/common/TestComponent';
 /* eslint-enisable import/no-webpack-loader-syntax, import/first */
 
-
 const Index = () => {
   const propsTables = [
     { componentSrc: testComponentSrc, componentName: 'Test Component' },

--- a/packages/terra-doc-template/tests/jest/DocTemplate.test.jsx
+++ b/packages/terra-doc-template/tests/jest/DocTemplate.test.jsx
@@ -23,7 +23,6 @@ describe('DocTemplate', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-
   it('should show the readme', () => {
     const wrapper = shallow(<DocTemplate readme={readme} />);
     expect(wrapper).toMatchSnapshot();

--- a/packages/terra-dynamic-grid/CHANGELOG.md
+++ b/packages/terra-dynamic-grid/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 3.18.0 - (October 3, 2019)
 ------------------

--- a/packages/terra-dynamic-grid/src/DynamicGrid.jsx
+++ b/packages/terra-dynamic-grid/src/DynamicGrid.jsx
@@ -28,7 +28,6 @@ const templateShape = {
   style: PropTypes.object,
 };
 
-
 const propTypes = {
   /**
   * The child Region components that make up the grid.
@@ -65,7 +64,6 @@ const propTypes = {
   */
   huge: PropTypes.shape(templateShape),
 };
-
 
 const defaultProps = {
   defaultTemplate: {},

--- a/packages/terra-dynamic-grid/src/styles.js
+++ b/packages/terra-dynamic-grid/src/styles.js
@@ -16,7 +16,6 @@ const gridTemplate = (prop, layout) => {
   };
 };
 
-
 const gridLineStart = (prop, region) => {
   const start = region[`grid-${prop}-start`];
   if (start === undefined) {
@@ -29,7 +28,6 @@ const gridLineStart = (prop, region) => {
     [`-ms-grid-${prop}`]: `${(start * 2) - 1}`,
   };
 };
-
 
 const gridLineEnd = (prop, region) => {
   if (region[`grid-${prop}-end`] === undefined) {
@@ -48,7 +46,6 @@ const gridLineEnd = (prop, region) => {
     [`-ms-grid-${prop}-span`]: `${span}`,
   };
 };
-
 
 const gridGap = layout => (
   layout['grid-gap']
@@ -84,6 +81,5 @@ const region = position => ({
   ...gridLineEnd('row', position),
   ...(position.style || {}),
 });
-
 
 export { grid, region };

--- a/packages/terra-dynamic-grid/src/terra-dev-site/doc/example/Dashboard.jsx
+++ b/packages/terra-dynamic-grid/src/terra-dev-site/doc/example/Dashboard.jsx
@@ -50,7 +50,6 @@ const region3 = {
   },
 };
 
-
 const DashboardLayout = () => (
   <DynamicGrid defaultTemplate={template}>
     <DynamicGrid.Region defaultPosition={leftGutter}>

--- a/packages/terra-dynamic-grid/src/terra-dev-site/doc/example/ResponsiveGrid.jsx
+++ b/packages/terra-dynamic-grid/src/terra-dev-site/doc/example/ResponsiveGrid.jsx
@@ -40,7 +40,6 @@ const region2 = {
   },
 };
 
-
 const region3 = {
   defaultPosition: {
     'grid-column-start': 3,
@@ -88,7 +87,6 @@ const region5 = {
     'grid-column-start': 3,
   },
 };
-
 
 const ResponsiveGrid = () => (
   <DynamicGrid defaultTemplate={template}>

--- a/packages/terra-form-field/CHANGELOG.md
+++ b/packages/terra-form-field/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 3.28.0 - (October 15, 2019)
 ------------------

--- a/packages/terra-form-field/src/Field.jsx
+++ b/packages/terra-form-field/src/Field.jsx
@@ -142,7 +142,6 @@ const Field = (props) => {
     }
   }
 
-
   /**
    * IE + JAWS has trouble reading aria-describedby content with our form components.
    * Using feature detect for Microsoft browsers and injecting the help and error messages

--- a/packages/terra-form-radio/CHANGELOG.md
+++ b/packages/terra-form-radio/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 3.31.0 - (October 15, 2019)
 ------------------

--- a/packages/terra-form-radio/src/terra-dev-site/doc/example/field/InlineRadioField.jsx
+++ b/packages/terra-form-radio/src/terra-dev-site/doc/example/field/InlineRadioField.jsx
@@ -6,7 +6,6 @@ import styles from './RadioFieldCommon.module.scss';
 
 const cx = classNames.bind(styles);
 
-
 export default class extends React.Component {
   constructor(props) {
     super(props);

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
+
 ### Changed
 * Duplicate ID in examples changed.
 

--- a/packages/terra-form-select/src/TagSelect.jsx
+++ b/packages/terra-form-select/src/TagSelect.jsx
@@ -117,7 +117,6 @@ const defaultProps = {
   value: undefined,
 };
 
-
 class TagSelect extends React.Component {
   constructor(props) {
     super(props);

--- a/packages/terra-form-select/src/multiple/Menu.jsx
+++ b/packages/terra-form-select/src/multiple/Menu.jsx
@@ -380,7 +380,6 @@ class Menu extends React.Component {
       input, onDeselect, onSelect, value, intl, visuallyHiddenComponent,
     } = this.props;
 
-
     const shouldUnselectOption = MenuUtil.includes(value, option.props.value);
     const optionATClickText = (shouldUnselectOption
       ? intl.formatMessage({ id: 'Terra.form.select.unselectedText' }, { text: option.props.display })

--- a/packages/terra-form-select/src/shared/_OptGroup.jsx
+++ b/packages/terra-form-select/src/shared/_OptGroup.jsx
@@ -48,7 +48,6 @@ const OptGroup = ({
   </li>
 );
 
-
 OptGroup.propTypes = propTypes;
 OptGroup.defaultProps = defaultProps;
 OptGroup.isOptGroup = true;

--- a/packages/terra-form-select/src/single/Frame.jsx
+++ b/packages/terra-form-select/src/single/Frame.jsx
@@ -264,7 +264,6 @@ class Frame extends React.Component {
       return;
     }
 
-
     this.setState({ isFocused: false });
 
     this.closeDropdown();

--- a/packages/terra-form-select/tests/jest/Select.test.jsx
+++ b/packages/terra-form-select/tests/jest/Select.test.jsx
@@ -131,7 +131,6 @@ describe('Select', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-
   it('should render a select with an option', () => {
     const wrapper = renderWithIntl(
       <Select>
@@ -173,7 +172,6 @@ describe('Select', () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
-
 
   it('should call onBlur', () => {
     const mockBlur = jest.fn();

--- a/packages/terra-form-select/tests/jest/SelectField.test.jsx
+++ b/packages/terra-form-select/tests/jest/SelectField.test.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { shallowWithIntl } from 'terra-enzyme-intl';
 import SelectField from '../../src/SelectField';
 
-
 it('should render a default SelectField component', () => {
   const select = (
     <SelectField label="Label" defaultValue="blue" selectId="select-id">

--- a/packages/terra-icon/CHANGELOG.md
+++ b/packages/terra-icon/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 3.22.0 - (October 3, 2019)
 ------------------

--- a/packages/terra-icon/tests/jest/Icon.test.jsx
+++ b/packages/terra-icon/tests/jest/Icon.test.jsx
@@ -170,7 +170,6 @@ describe('Icon', () => {
     });
   });
 
-
   describe('IconComment', () => {
     it('should shallow IconBase', () => {
       const wrapper = shallow(<IconComment />);

--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 ### Changed
 * Updated wdio tests to cover update lifecycle handling

--- a/packages/terra-overlay/src/terra-dev-site/test/overlay/Overlay/OnRequestCloseOverlay.test.jsx
+++ b/packages/terra-overlay/src/terra-dev-site/test/overlay/Overlay/OnRequestCloseOverlay.test.jsx
@@ -49,7 +49,6 @@ class OverlayExample extends React.Component {
     );
   }
 
-
   render() {
     return (
       <OverlayContainer className={cx('overlay-container2')} overlay={this.addOverlay()}>

--- a/packages/terra-paginator/CHANGELOG.md
+++ b/packages/terra-paginator/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 2.31.0 - (October 15, 2019)
 ------------------

--- a/packages/terra-paginator/src/terra-dev-site/doc/example/PaginatorExample.jsx
+++ b/packages/terra-paginator/src/terra-dev-site/doc/example/PaginatorExample.jsx
@@ -6,7 +6,6 @@ import styles from './PaginatorExampleCommon.module.scss';
 
 const cx = classNames.bind(styles);
 
-
 const totalCount = 450;
 
 const fillArray = (value, len) => {

--- a/packages/terra-paginator/src/terra-dev-site/test/paginator/ControlledProgressivePaginator.test.jsx
+++ b/packages/terra-paginator/src/terra-dev-site/test/paginator/ControlledProgressivePaginator.test.jsx
@@ -6,7 +6,6 @@ import styles from './ControlledPaginatorTestCommon.module.scss';
 
 const cx = classNames.bind(styles);
 
-
 const totalCount = 450;
 
 class ProgressivePaginatorExample extends React.Component {

--- a/packages/terra-props-table/CHANGELOG.md
+++ b/packages/terra-props-table/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 2.41.0 - (September 19, 2019)
 ------------------

--- a/packages/terra-props-table/tests/jest/generateMarkdown.test.js
+++ b/packages/terra-props-table/tests/jest/generateMarkdown.test.js
@@ -10,7 +10,6 @@ describe('generateMarkdown with invalid input', () => {
   });
 });
 
-
 describe('generateMarkdown with valid input', () => {
   it('should generate a markdown table', () => {
     const validInput = {

--- a/packages/terra-props-table/tests/jest/generatePropRow.test.js
+++ b/packages/terra-props-table/tests/jest/generatePropRow.test.js
@@ -1,6 +1,5 @@
 const generatePropRow = require('../../bin/generateMarkdown/generatePropRow');
 
-
 it('should return a markdown row', () => {
   const propName = 'children';
   const prop = {
@@ -56,7 +55,6 @@ describe('when propName is an empty string', () => {
     expect(generatePropRow(propName, prop)).toMatchSnapshot();
   });
 });
-
 
 describe('when propName is null', () => {
   it('should return a markdown row with an empty propName', () => {

--- a/packages/terra-search-field/CHANGELOG.md
+++ b/packages/terra-search-field/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 3.32.0 - (October 15, 2019)
 ------------------

--- a/packages/terra-search-field/src/terra-dev-site/doc/example/SearchFieldDisableAutoSearch.jsx
+++ b/packages/terra-search-field/src/terra-dev-site/doc/example/SearchFieldDisableAutoSearch.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import SearchField from 'terra-search-field';
 
-
 const SearchFieldDisableAutoSearch = () => (
   <div>
     <SearchField disableAutoSearch />

--- a/packages/terra-search-field/src/terra-dev-site/doc/example/SearchFieldFocus.jsx
+++ b/packages/terra-search-field/src/terra-dev-site/doc/example/SearchFieldFocus.jsx
@@ -29,5 +29,4 @@ const SearchFieldFocus = () => {
   );
 };
 
-
 export default SearchFieldFocus;

--- a/packages/terra-show-hide/CHANGELOG.md
+++ b/packages/terra-show-hide/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 2.24.0 - (October 3, 2019)
 ------------------

--- a/packages/terra-show-hide/src/ShowHide.jsx
+++ b/packages/terra-show-hide/src/ShowHide.jsx
@@ -64,7 +64,6 @@ const ShowHide = (props) => {
     customProps.className,
   ]);
 
-
   let intlButtonText = '';
 
   if (!buttonText) {

--- a/packages/terra-show-hide/src/_ShowHideButton.jsx
+++ b/packages/terra-show-hide/src/_ShowHideButton.jsx
@@ -5,7 +5,6 @@ import classNames from 'classnames/bind';
 import * as KeyCode from 'keycode-js';
 import styles from './_ShowHideButton.module.scss';
 
-
 const cx = classNames.bind(styles);
 
 const propTypes = {

--- a/packages/terra-show-hide/tests/jest/ShowHide.test.jsx
+++ b/packages/terra-show-hide/tests/jest/ShowHide.test.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { mountWithIntl } from 'terra-enzyme-intl';
 import ShowHide from '../../src/ShowHide';
 
-
 describe('ShowHide', () => {
   // Snapshot Tests
   it('should render a default show-hide component', () => {

--- a/packages/terra-signature/CHANGELOG.md
+++ b/packages/terra-signature/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 2.22.0 - (October 3, 2019)
 ------------------

--- a/packages/terra-signature/src/Signature.jsx
+++ b/packages/terra-signature/src/Signature.jsx
@@ -167,7 +167,6 @@ class Signature extends React.Component {
     }));
   }
 
-
   draw() {
     const context = this.canvas.getContext('2d');
 

--- a/packages/terra-status/CHANGELOG.md
+++ b/packages/terra-status/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 4.19.0 - (October 3, 2019)
 ------------------

--- a/packages/terra-status/src/Status.jsx
+++ b/packages/terra-status/src/Status.jsx
@@ -4,7 +4,6 @@ import classNames from 'classnames/bind';
 import VisuallyHiddenText from 'terra-visually-hidden-text';
 import styles from './Status.module.scss';
 
-
 const cx = classNames.bind(styles);
 
 const propTypes = {

--- a/packages/terra-status/src/terra-dev-site/test/status/StatusNoColor.test.jsx
+++ b/packages/terra-status/src/terra-dev-site/test/status/StatusNoColor.test.jsx
@@ -5,7 +5,6 @@ import styles from '../../doc/example/colors.module.scss';
 
 const cx = classNames.bind(styles);
 
-
 const simpleText = <div className={cx('text-wrapper')}>Sample text</div>;
 
 const StatusNoColor = () => (

--- a/packages/terra-toggle-button/CHANGELOG.md
+++ b/packages/terra-toggle-button/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
+
 ### Changed
 * Inline SVG aligned for IE and wdio screenshots Updated.
 

--- a/packages/terra-toggle-button/src/terra-dev-site/test/toggle-button/OnCloseToggleButton.test.jsx
+++ b/packages/terra-toggle-button/src/terra-dev-site/test/toggle-button/OnCloseToggleButton.test.jsx
@@ -26,5 +26,4 @@ class OnCloseToggleButton extends React.Component {
   }
 }
 
-
 export default OnCloseToggleButton;

--- a/packages/terra-toggle-button/src/terra-dev-site/test/toggle-button/OnOpenToggleButton.test.jsx
+++ b/packages/terra-toggle-button/src/terra-dev-site/test/toggle-button/OnOpenToggleButton.test.jsx
@@ -26,5 +26,4 @@ class OnOpenToggleButton extends React.Component {
   }
 }
 
-
 export default OnOpenToggleButton;

--- a/packages/terra-toggle-button/tests/jest/ToggleButton.test.jsx
+++ b/packages/terra-toggle-button/tests/jest/ToggleButton.test.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import IconCaretRight from 'terra-icon/lib/icon/IconCaretRight';
 import ToggleButton from '../../src/ToggleButton';
 
-
 describe('ToggleButton', () => {
   // Snapshot Tests
   it('should render a default toggle-button', () => {

--- a/packages/terra-toggle/CHANGELOG.md
+++ b/packages/terra-toggle/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
+
 ### Changed
 * Duplicate IDs in example changed.
 

--- a/packages/terra-toggle/src/terra-dev-site/doc/example/AnimatedToggle.jsx
+++ b/packages/terra-toggle/src/terra-dev-site/doc/example/AnimatedToggle.jsx
@@ -35,5 +35,4 @@ adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna ali
   }
 }
 
-
 export default ToggleDefault;

--- a/packages/terra-toggle/src/terra-dev-site/doc/example/DefaultToggle.jsx
+++ b/packages/terra-toggle/src/terra-dev-site/doc/example/DefaultToggle.jsx
@@ -35,5 +35,4 @@ adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna ali
   }
 }
 
-
 export default ToggleDefault;

--- a/packages/terra-toggle/src/terra-dev-site/test/toggle/AnimatedToggle.test.jsx
+++ b/packages/terra-toggle/src/terra-dev-site/test/toggle/AnimatedToggle.test.jsx
@@ -52,5 +52,4 @@ adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna ali
   }
 }
 
-
 export default AnimatedToggle;

--- a/packages/terra-toggle/src/terra-dev-site/test/toggle/DefaultToggle.test.jsx
+++ b/packages/terra-toggle/src/terra-dev-site/test/toggle/DefaultToggle.test.jsx
@@ -53,5 +53,4 @@ class ToggleDefault extends React.Component {
   }
 }
 
-
 export default ToggleDefault;

--- a/packages/terra-toggle/src/terra-dev-site/test/toggle/OpenToggle.test.jsx
+++ b/packages/terra-toggle/src/terra-dev-site/test/toggle/OpenToggle.test.jsx
@@ -26,5 +26,4 @@ class OpenToggle extends React.Component {
   }
 }
 
-
 export default OpenToggle;

--- a/packages/terra-visually-hidden-text/CHANGELOG.md
+++ b/packages/terra-visually-hidden-text/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed lint warnings for multiple empty lines
 
 2.19.0 - (October 3, 2019)
 ------------------

--- a/packages/terra-visually-hidden-text/src/terra-dev-site/doc/VisuallyHiddenText/VisuallyHiddenText.1.doc.jsx
+++ b/packages/terra-visually-hidden-text/src/terra-dev-site/doc/VisuallyHiddenText/VisuallyHiddenText.1.doc.jsx
@@ -12,7 +12,6 @@ import DefaultVisuallyHiddenTextSrc from '!raw-loader!../../../../src/terra-dev-
 import RefCallbackVisuallyHiddenText from '../example/RefCallbackVisuallyHiddenText';
 import RefCallbackVisuallyHiddenTextSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/RefCallbackVisuallyHiddenText.jsx';
 
-
 const DocPage = () => (
   <DocTemplate
     packageName={name}


### PR DESCRIPTION
### Summary

This PR removes multiple-empty-line occurrences. A rule override was introduced in [this PR](https://github.com/cerner/eslint-config-terra/pull/41) to disallowed more than 1 consecutive empty newline.

### Additional Details

This change is passive even without the rule override. It removes any duplicate newlines from files with js/jsx extension.

Thanks for contributing to Terra.
@cerner/terra

