### PR TITLE
[terra-responsive-element] - Add deprecated flag to uncontrolled prop descriptions

### DIFF
--- a/packages/terra-responsive-element/CHANGELOG.md
+++ b/packages/terra-responsive-element/CHANGELOG.md
@@ -3,9 +3,6 @@ Changelog
 
 Unreleased
 ----------
-
-5.11.0 - (October 29, 2019)
-------------------
 ### Added
 * Added a warning in dev environment about uncontrolled responsive elements being deprecated in the next major release
 

--- a/packages/terra-responsive-element/CHANGELOG.md
+++ b/packages/terra-responsive-element/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Added
 * Added a warning in dev environment about uncontrolled responsive elements being deprecated in the next major release
+* Added deprecated flag to the uncontrolled props descriptions
 
 5.10.0 - (October 3, 2019)
 ------------------

--- a/packages/terra-responsive-element/src/ResponsiveElement.jsx
+++ b/packages/terra-responsive-element/src/ResponsiveElement.jsx
@@ -22,27 +22,27 @@ const propTypes = {
    */
   onResize: PropTypes.func,
   /**
-   * An element to be displayed at tiny breakpoints.
+   * [Deprecated] An element to be displayed at tiny breakpoints.
    */
   tiny: PropTypes.element,
   /**
-   * An element to be displayed at small breakpoints.
+   * [Deprecated] An element to be displayed at small breakpoints.
    */
   small: PropTypes.element,
   /**
-   * An element to be displayed at medium breakpoints.
+   * [Deprecated] An element to be displayed at medium breakpoints.
    */
   medium: PropTypes.element,
   /**
-   * An element to be displayed at large breakpoints.
+   * [Deprecated] An element to be displayed at large breakpoints.
    */
   large: PropTypes.element,
   /**
-   * An element to be displayed at huge breakpoints.
+   * [Deprecated] An element to be displayed at huge breakpoints.
    */
   huge: PropTypes.element,
   /**
-   * An element to be displayed at enormous breakpoints.
+   * [Deprecated] An element to be displayed at enormous breakpoints.
    */
   enormous: PropTypes.element,
   /**

--- a/packages/terra-responsive-element/src/terra-dev-site/doc/responsive-element/ResponsiveElement.1.doc.jsx
+++ b/packages/terra-responsive-element/src/terra-dev-site/doc/responsive-element/ResponsiveElement.1.doc.jsx
@@ -39,7 +39,7 @@ const DocPage = () => (
         source: ResizeExampleSrc,
       },
       {
-        title: 'Uncontrolled Example',
+        title: '[Deprecated] Uncontrolled Example',
         description: 'An example of an uncontrolled implementation of the ResponsiveElement.',
         example: <UncontrolledBreakpointExample />,
         source: UncontrolledBreakpointExampleSrc,


### PR DESCRIPTION
### Summary

This PR updates the changelog entry for the responsive element.

### Additional Details

A recent entry was added to a released section. This released hasn't been cut yet. Removed the unreleased release section.

Thanks for contributing to Terra.
@cerner/terra