### PR TITLE
Fixing terra-overlay tests that broke with consumption of the new version of terra-application 

### DIFF
--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -4,6 +4,9 @@ ChangeLog
 Unreleased
 ----------
 
+### Changed
+* Updating tests to be better isolated from terra-dev-site markup.
+
 3.33.0 - (October 30, 2019)
 ------------------
 ### Fixed

--- a/packages/terra-overlay/src/terra-dev-site/test/overlay/Overlay/OnRequestCloseOverlay.test.jsx
+++ b/packages/terra-overlay/src/terra-dev-site/test/overlay/Overlay/OnRequestCloseOverlay.test.jsx
@@ -51,7 +51,7 @@ class OverlayExample extends React.Component {
 
   render() {
     return (
-      <OverlayContainer className={cx('overlay-container2')} overlay={this.addOverlay()}>
+      <OverlayContainer className={cx('overlay-container2')} overlay={this.addOverlay()} id="test-overlay-container">
         <button type="button" id="trigger_container" onClick={this.handleTriggerOverlay}>Trigger Container Overlay</button>
         <button type="button" id="trigger_fullscreen" onClick={this.handleTriggerFullScreenOverlay}>Trigger Fullscreen Overlay</button>
       </OverlayContainer>

--- a/packages/terra-overlay/tests/wdio/overlay-spec.js
+++ b/packages/terra-overlay/tests/wdio/overlay-spec.js
@@ -106,8 +106,8 @@ Terra.describeViewports('Overlay', ['huge'], () => {
 
       it('Clicks on Container Overlay', () => {
         browser.click('#trigger_container');
-        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'inert')).to.equal('true');
-        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'aria-hidden')).to.equal('true');
+        expect(browser.getAttribute('#test-overlay-container > [data-terra-overlay-container-content="true"]', 'inert')).to.equal('true');
+        expect(browser.getAttribute('#test-overlay-container > [data-terra-overlay-container-content="true"]', 'aria-hidden')).to.equal('true');
       });
 
       it('Container Overlay- Background can scroll when Overlay relative to container is open', () => {
@@ -119,22 +119,22 @@ Terra.describeViewports('Overlay', ['huge'], () => {
       it('closes overlay on escape keydown', () => {
         browser.keys('Escape');
         browser.waitForExist('#terra-Overlay--container', DEFAULT_TIMEOUT, SHOULD_NOT_EXIST);
-        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'inert')).to.equal('false');
-        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'aria-hidden')).to.equal(null);
+        expect(browser.getAttribute('#test-overlay-container > [data-terra-overlay-container-content="true"]', 'inert')).to.equal('false');
+        expect(browser.getAttribute('#test-overlay-container > [data-terra-overlay-container-content="true"]', 'aria-hidden')).to.equal(null);
       });
 
       it('reopens the overlay', () => {
         browser.click('#trigger_container');
         browser.waitForExist('#terra-Overlay--container');
-        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'inert')).to.equal('true');
-        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'aria-hidden')).to.equal('true');
+        expect(browser.getAttribute('#test-overlay-container > [data-terra-overlay-container-content="true"]', 'inert')).to.equal('true');
+        expect(browser.getAttribute('#test-overlay-container > [data-terra-overlay-container-content="true"]', 'aria-hidden')).to.equal('true');
       });
 
       it('closes the overlay when clicking inside of the Overlay', () => {
         browser.click('#terra-Overlay--container');
         browser.waitForExist('#terra-Overlay--container', DEFAULT_TIMEOUT, SHOULD_NOT_EXIST);
-        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'inert')).to.equal('false');
-        expect(browser.getAttribute('[data-terra-overlay-container-content="true"]', 'aria-hidden')).to.equal(null);
+        expect(browser.getAttribute('#test-overlay-container > [data-terra-overlay-container-content="true"]', 'inert')).to.equal('false');
+        expect(browser.getAttribute('#test-overlay-container > [data-terra-overlay-container-content="true"]', 'aria-hidden')).to.equal(null);
       });
     });
   });


### PR DESCRIPTION
# Summary
The newest version of terra-application includes an OverlayContainer within its component hierarchy. When terra-dev-site started consuming it, the terra-overlay tests that assumed that only a single OverlayContainer was rendered started to fail.

I updated the selectors used for the test to specifically retrieve the overlay elements created for the test.