### PR TITLE
[terra-image] Leverage react fragment to prevent double requests from…

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -83,6 +83,7 @@ Cerner Corporation
 - Philip Meznar [@prmeznar]
 - Saket Bajaj [@saket2403]
 - Prachi Gotkhindikar [@prachigotkhindikar1]
+- Jeff Merten [@jeffmerten]
 
 Community
 
@@ -193,3 +194,4 @@ Community
 [@prmeznar]: https://github.com/prmeznar
 [@saket2403]:https://github.com/saket2403
 [@vobango]:https://github.com/vobango
+[@jeffmerten]: https://github.com/jeffmerten

--- a/packages/terra-avatar/CHANGELOG.md
+++ b/packages/terra-avatar/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Updated snapshots for terra-image change.
 
 2.30.0 - (October 30, 2019)
 ------------------

--- a/packages/terra-avatar/tests/jest/__snapshots__/Avatar.test.jsx.snap
+++ b/packages/terra-avatar/tests/jest/__snapshots__/Avatar.test.jsx.snap
@@ -119,26 +119,18 @@ exports[`Avatar should render fallback user avatar when invalid image is passed 
 <div
   class="avatar five image"
 >
-  <div>
-    <div
-      class="hidden"
-    >
-      <img
-        alt="placeholder"
-        class="image cover default image"
-        src="https://path/to/invalid_image.jpg"
-      />
-    </div>
-    <div>
-      <span
-        alt="placeholder"
-        aria-hidden="false"
-        aria-label="placeholder"
-        class="icon user"
-        role="img"
-      />
-    </div>
-  </div>
+  <img
+    alt="placeholder"
+    class="image cover default image hidden"
+    src="https://path/to/invalid_image.jpg"
+  />
+  <span
+    alt="placeholder"
+    aria-hidden="false"
+    aria-label="placeholder"
+    class="icon user"
+    role="img"
+  />
 </div>
 `;
 
@@ -160,26 +152,18 @@ exports[`Avatar should render image avatar when image is passed in 1`] = `
 <div
   class="avatar five image"
 >
-  <div>
-    <div
-      class="hidden"
-    >
-      <img
-        alt="placeholder"
-        class="image cover default image"
-        src="test-file-stub"
-      />
-    </div>
-    <div>
-      <span
-        alt="placeholder"
-        aria-hidden="false"
-        aria-label="placeholder"
-        class="icon user"
-        role="img"
-      />
-    </div>
-  </div>
+  <img
+    alt="placeholder"
+    class="image cover default image hidden"
+    src="test-file-stub"
+  />
+  <span
+    alt="placeholder"
+    aria-hidden="false"
+    aria-label="placeholder"
+    class="icon user"
+    role="img"
+  />
 </div>
 `;
 

--- a/packages/terra-avatar/tests/jest/__snapshots__/Facility.test.jsx.snap
+++ b/packages/terra-avatar/tests/jest/__snapshots__/Facility.test.jsx.snap
@@ -89,26 +89,18 @@ exports[`Facility should render fallback facility avatar when invalid image is p
 <div
   class="avatar five image"
 >
-  <div>
-    <div
-      class="hidden"
-    >
-      <img
-        alt="London"
-        class="image cover default image"
-        src="https://path/to/invalid_image.jpg"
-      />
-    </div>
-    <div>
-      <span
-        alt="London"
-        aria-hidden="false"
-        aria-label="London"
-        class="icon facility"
-        role="img"
-      />
-    </div>
-  </div>
+  <img
+    alt="London"
+    class="image cover default image hidden"
+    src="https://path/to/invalid_image.jpg"
+  />
+  <span
+    alt="London"
+    aria-hidden="false"
+    aria-label="London"
+    class="icon facility"
+    role="img"
+  />
 </div>
 `;
 
@@ -116,26 +108,18 @@ exports[`Facility should render image facility avatar when image is passed in 1`
 <div
   class="avatar five image"
 >
-  <div>
-    <div
-      class="hidden"
-    >
-      <img
-        alt="London"
-        class="image cover default image"
-        src="test-file-stub"
-      />
-    </div>
-    <div>
-      <span
-        alt="London"
-        aria-hidden="false"
-        aria-label="London"
-        class="icon facility"
-        role="img"
-      />
-    </div>
-  </div>
+  <img
+    alt="London"
+    class="image cover default image hidden"
+    src="test-file-stub"
+  />
+  <span
+    alt="London"
+    aria-hidden="false"
+    aria-label="London"
+    class="icon facility"
+    role="img"
+  />
 </div>
 `;
 

--- a/packages/terra-image/CHANGELOG.md
+++ b/packages/terra-image/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* One request made instead of two when image is rendered with a placeholder.
 
 3.20.0 - (October 30, 2019)
 ------------------

--- a/packages/terra-image/src/Image.jsx
+++ b/packages/terra-image/src/Image.jsx
@@ -143,13 +143,20 @@ class Image extends React.Component {
       src, variant, isFluid, alt, placeholder, height, width, onLoad, onError, fit, ...customProps
     } = this.props;
 
-    const imageClasses = cx([
+    const imageClassAttributes = [
       'image',
       fit,
       variant,
       customProps.className,
       { fluid: isFluid },
-    ]);
+    ];
+
+    if (placeholder && this.state.isLoading) {
+      imageClassAttributes.push('hidden');
+    }
+
+    const imageClasses = cx(imageClassAttributes);
+
     delete customProps.className;
     if (!this.state.isLoading) {
       objectFitImages(this.ImageRef.current);
@@ -157,14 +164,14 @@ class Image extends React.Component {
     if (placeholder) {
       if (this.state.isLoading) {
         return (
-          <div>
-            <div className={cx('hidden')}>{this.createImage(customProps, imageClasses)}</div>
-            <div>{placeholder}</div>
-          </div>
+          <React.Fragment>
+            {this.createImage(customProps, imageClasses)}
+            {placeholder}
+          </React.Fragment>
         );
       }
 
-      return this.state.isError ? placeholder : this.createImage(customProps, imageClasses);
+      return this.state.isError ? placeholder : <React.Fragment>{this.createImage(customProps, imageClasses)}</React.Fragment>;
     }
 
     return this.createImage(customProps, imageClasses);

--- a/packages/terra-image/src/Image.jsx
+++ b/packages/terra-image/src/Image.jsx
@@ -171,7 +171,7 @@ class Image extends React.Component {
         );
       }
 
-      return this.state.isError ? placeholder : <>{this.createImage(customProps, imageClasses)}</>;
+      return this.state.isError ? placeholder : this.createImage(customProps, imageClasses);
     }
 
     return this.createImage(customProps, imageClasses);

--- a/packages/terra-image/src/Image.jsx
+++ b/packages/terra-image/src/Image.jsx
@@ -143,19 +143,14 @@ class Image extends React.Component {
       src, variant, isFluid, alt, placeholder, height, width, onLoad, onError, fit, ...customProps
     } = this.props;
 
-    const imageClassAttributes = [
+    const imageClasses = cx([
       'image',
       fit,
       variant,
       customProps.className,
       { fluid: isFluid },
-    ];
-
-    if (placeholder && this.state.isLoading) {
-      imageClassAttributes.push('hidden');
-    }
-
-    const imageClasses = cx(imageClassAttributes);
+      { hidden: placeholder && this.state.isLoading },
+    ]);
 
     delete customProps.className;
     if (!this.state.isLoading) {

--- a/packages/terra-image/src/Image.jsx
+++ b/packages/terra-image/src/Image.jsx
@@ -164,14 +164,14 @@ class Image extends React.Component {
     if (placeholder) {
       if (this.state.isLoading) {
         return (
-          <React.Fragment>
+          <>
             {this.createImage(customProps, imageClasses)}
             {placeholder}
-          </React.Fragment>
+          </>
         );
       }
 
-      return this.state.isError ? placeholder : <React.Fragment>{this.createImage(customProps, imageClasses)}</React.Fragment>;
+      return this.state.isError ? placeholder : <>{this.createImage(customProps, imageClasses)}</>;
     }
 
     return this.createImage(customProps, imageClasses);

--- a/packages/terra-image/tests/jest/__snapshots__/Image.test.jsx.snap
+++ b/packages/terra-image/tests/jest/__snapshots__/Image.test.jsx.snap
@@ -60,15 +60,13 @@ exports[`should render the placeholder image 1`] = `
 `;
 
 exports[`should render the src image 1`] = `
-<Fragment>
-  <img
-    alt="profile"
-    className="image fill default"
-    height="75"
-    onError={[Function]}
-    onLoad={[Function]}
-    src="profile.jpg"
-    width="75"
-  />
-</Fragment>
+<img
+  alt="profile"
+  className="image fill default"
+  height="75"
+  onError={[Function]}
+  onLoad={[Function]}
+  src="profile.jpg"
+  width="75"
+/>
 `;

--- a/packages/terra-image/tests/jest/__snapshots__/Image.test.jsx.snap
+++ b/packages/terra-image/tests/jest/__snapshots__/Image.test.jsx.snap
@@ -21,26 +21,20 @@ exports[`should render a circle image component with fluid behavior 1`] = `
 `;
 
 exports[`should render a hidden src image and a visible placeholder image 1`] = `
-<div>
-  <div
-    className="hidden"
-  >
-    <img
-      alt=" "
-      className="image fill default"
-      height="75"
-      onError={[Function]}
-      onLoad={[Function]}
-      src="profile.jpg"
-      width="75"
-    />
-  </div>
+<Fragment>
+  <img
+    alt=" "
+    className="image fill default hidden"
+    height="75"
+    onError={[Function]}
+    onLoad={[Function]}
+    src="profile.jpg"
+    width="75"
+  />
   <div>
-    <div>
-      placeholder text
-    </div>
+    placeholder text
   </div>
-</div>
+</Fragment>
 `;
 
 exports[`should render a thumbail image component with fluid behavior 1`] = `
@@ -66,13 +60,15 @@ exports[`should render the placeholder image 1`] = `
 `;
 
 exports[`should render the src image 1`] = `
-<img
-  alt="profile"
-  className="image fill default"
-  height="75"
-  onError={[Function]}
-  onLoad={[Function]}
-  src="profile.jpg"
-  width="75"
-/>
+<Fragment>
+  <img
+    alt="profile"
+    className="image fill default"
+    height="75"
+    onError={[Function]}
+    onLoad={[Function]}
+    src="profile.jpg"
+    width="75"
+  />
+</Fragment>
 `;


### PR DESCRIPTION
… occuring

### Summary
Use React Fragment to wrap placeholder and image in order to prevent the img request from happening twice.

### Additional Details
Previously the img element would be created twice as it was in a div structure that changed when the state changed to on the initial image load. The re-render would cause a new img element to be created. 

The fix is to wrap the img element in react fragment so it doesn't get recreated by react.

The change has been tested by myself in one of our single page applications for our demographics thumbnail image.

Closes #2757 