### PR TITLE
[DO NOT MERGE] Testing terra-dev-site loader performance update

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "stylelint": "^11.0.0",
     "stylelint-config-terra": "^3.2.0",
     "terra-aggregate-translations": "^1.0.0",
-    "terra-dev-site": "^6.5.0",
+    "terra-dev-site": "github:cerner/terra-dev-site#loader-performance",
     "terra-disclosure-manager": "^4.9.0",
     "terra-enzyme-intl": "^3.0.0",
     "terra-toolkit": "^5.18.0",


### PR DESCRIPTION
### Summary
This is a test for the terra-dev-site loader performance update.

### Additional Details
I will add build time performance info here after the build has run.

Before:
<img width="979" alt="Screen Shot 2020-02-12 at 9 56 14 PM" src="https://user-images.githubusercontent.com/1588747/74400087-8ce53280-4de2-11ea-8c82-d8b50218eb8b.png">

After:
<img width="1013" alt="Screen Shot 2020-02-12 at 9 55 47 PM" src="https://user-images.githubusercontent.com/1588747/74400109-a1292f80-4de2-11ea-8842-d18e682d3076.png">


Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra.
@cerner/terra

[CONTRIBUTORS.md]: ../CONTRIBUTORS.md
[License]: ../LICENSE
