### PR TITLE
[terra-i18n] Updating Intl Checks

### DIFF
--- a/packages/terra-i18n/CHANGELOG.md
+++ b/packages/terra-i18n/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changes
+* Be explict when checking when checking if Intl, Intl.DateTimeFormat and Int.NumberFormat are available on the browser.
 
 4.22.0 - (February 11, 2020)
 ------------------

--- a/packages/terra-i18n/src/i18nLoader.js
+++ b/packages/terra-i18n/src/i18nLoader.js
@@ -20,7 +20,7 @@ export default (locale, callback, scope) => {
   let hasIntl;
   try {
     // eslint-disable-next-line compat/compat
-    hasIntl = typeof (Intl) !== 'undefined' && Intl.DateTimeFormat !== 'undefined' && Intl.NumberFormat !== 'undefined';
+    hasIntl = typeof (Intl) !== 'undefined' && typeof (Intl.DateTimeFormat) !== 'undefined' && typeof (Intl.NumberFormat) !== 'undefined';
   } catch (error) {
     hasIntl = false;
   }

--- a/packages/terra-i18n/src/intlLoaders.js
+++ b/packages/terra-i18n/src/intlLoaders.js
@@ -11,7 +11,7 @@ const supportedIntlConstructors = () => {
    */
   let constructors;
   try {
-    if (typeof (Intl) !== 'undefined' && Intl.DateTimeFormat !== 'undefined' && Intl.NumberFormat !== 'undefined') {
+    if (typeof (Intl) !== 'undefined' && typeof (Intl.DateTimeFormat) !== 'undefined' && typeof (Intl.NumberFormat) !== 'undefined') {
       constructors = [
         Intl.DateTimeFormat,
         Intl.NumberFormat,

--- a/packages/terra-i18n/tests/jest/i18nLoader.test.js
+++ b/packages/terra-i18n/tests/jest/i18nLoader.test.js
@@ -24,7 +24,7 @@ describe('i18nLoader', () => {
   describe('when intl is provided by browser', () => {
     beforeAll(() => {
       defaultLoadIntl.mockClear();
-      global.Intl = {};
+      global.Intl = { DateTimeFormat: {}, NumberFormat: {} };
       i18nLoader('en', jest.fn());
     });
     afterAll(() => { global.Intl = undefined; });


### PR DESCRIPTION
### Summary
Recent conversations mentioned some teams have discovered:

>  the latest Microsoft patch causes some form of oddity in the Microsoft JS engine, where now the test "typeof(Intl.DateTimeFormat)" will return "unknown" on the first invocation (subsequent invocations will return "undefined", per the previous behavior relied upon by the polyfill test.).

Updating these checks to be more robust.