### PR TITLE
[terra-form-select] Fix onBlur event handling when selecting an option

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* Fixed `onBlur` event to not trigger when selecting an option
+* Fixed `onBlur` event to not be triggered when selecting an option
 
 5.44.0 - (March 10, 2020)
 ------------------

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-* Fixed `onBlur` event to not be triggered when selecting an option
+* Fixed `onBlur` event for mobile to not be triggered when selecting an option
 
 5.44.0 - (March 10, 2020)
 ------------------

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Fixed `onBlur` event to not trigger when selecting an option
 
 5.44.0 - (March 10, 2020)
 ------------------

--- a/packages/terra-form-select/src/combobox/Frame.jsx
+++ b/packages/terra-form-select/src/combobox/Frame.jsx
@@ -329,7 +329,7 @@ class Frame extends React.Component {
     // and if the relatedTarget is falsey. The relatedTarget will be null when
     // dismissing the onscreen keyboard, else set to another element when
     // tapping elsewhere on the page
-    if (focusedByTouch && !relatedTarget) {
+    if (focusedByTouch && (relatedTarget === this.input)) {
       return;
     }
 
@@ -467,6 +467,8 @@ class Frame extends React.Component {
       isOpen: false,
       isAbove: false,
     });
+
+    this.input.focus();
 
     if (this.props.onSelect) {
       this.props.onSelect(value, option);

--- a/packages/terra-form-select/src/combobox/Frame.jsx
+++ b/packages/terra-form-select/src/combobox/Frame.jsx
@@ -326,9 +326,7 @@ class Frame extends React.Component {
 
     // Don't blur if we dismissed the onscreen keyboard
     // Determined by if we have have interacted with the frame via onTouchStart
-    // and if the relatedTarget is falsey. The relatedTarget will be null when
-    // dismissing the onscreen keyboard, else set to another element when
-    // tapping elsewhere on the page
+    // and if the focus is on input.
     if (focusedByTouch && (relatedTarget === this.input)) {
       return;
     }

--- a/packages/terra-form-select/src/combobox/Frame.jsx
+++ b/packages/terra-form-select/src/combobox/Frame.jsx
@@ -468,8 +468,6 @@ class Frame extends React.Component {
       isAbove: false,
     });
 
-    this.input.focus();
-
     if (this.props.onSelect) {
       this.props.onSelect(value, option);
     }

--- a/packages/terra-form-select/src/multiple/Frame.jsx
+++ b/packages/terra-form-select/src/multiple/Frame.jsx
@@ -319,9 +319,7 @@ class Frame extends React.Component {
 
     // Don't blur if we dismissed the onscreen keyboard
     // Determined by if we have have interacted with the frame via onTouchStart
-    // and if the relatedTarget is falsey. The relatedTarget will be null when
-    // dismissing the onscreen keyboard, else set to another element when
-    // tapping elsewhere on the page
+    // and if the focus is on input.
     if (focusedByTouch && (relatedTarget === this.input)) {
       return;
     }

--- a/packages/terra-form-select/src/multiple/Frame.jsx
+++ b/packages/terra-form-select/src/multiple/Frame.jsx
@@ -322,7 +322,7 @@ class Frame extends React.Component {
     // and if the relatedTarget is falsey. The relatedTarget will be null when
     // dismissing the onscreen keyboard, else set to another element when
     // tapping elsewhere on the page
-    if (focusedByTouch && !relatedTarget) {
+    if (focusedByTouch && (relatedTarget === this.input)) {
       return;
     }
 

--- a/packages/terra-form-select/src/search/Frame.jsx
+++ b/packages/terra-form-select/src/search/Frame.jsx
@@ -442,7 +442,7 @@ class Frame extends React.Component {
       searchValue: '',
       hasSearchChanged: false,
       isOpen: false,
-      // isAbove: false,
+      isAbove: false,
     });
 
     if (this.props.onSelect) {

--- a/packages/terra-form-select/src/search/Frame.jsx
+++ b/packages/terra-form-select/src/search/Frame.jsx
@@ -303,9 +303,7 @@ class Frame extends React.Component {
 
     // Don't blur if we dismissed the onscreen keyboard
     // Determined by if we have have interacted with the frame via onTouchStart
-    // and if the relatedTarget is falsey. The relatedTarget will be null when
-    // dismissing the onscreen keyboard, else set to another element when
-    // tapping elsewhere on the page
+    // and if the focus is on input.
     if (focusedByTouch && (relatedTarget === this.input)) {
       return;
     }

--- a/packages/terra-form-select/src/search/Frame.jsx
+++ b/packages/terra-form-select/src/search/Frame.jsx
@@ -306,7 +306,7 @@ class Frame extends React.Component {
     // and if the relatedTarget is falsey. The relatedTarget will be null when
     // dismissing the onscreen keyboard, else set to another element when
     // tapping elsewhere on the page
-    if (focusedByTouch && !relatedTarget) {
+    if (focusedByTouch && (relatedTarget === this.input)) {
       return;
     }
 
@@ -442,7 +442,7 @@ class Frame extends React.Component {
       searchValue: '',
       hasSearchChanged: false,
       isOpen: false,
-      isAbove: false,
+      // isAbove: false,
     });
 
     if (this.props.onSelect) {

--- a/packages/terra-form-select/src/single/Frame.jsx
+++ b/packages/terra-form-select/src/single/Frame.jsx
@@ -234,6 +234,7 @@ class Frame extends React.Component {
 
     // Don't blur while focus is on select.
     if (event.relatedTarget === this.select) {
+      this.closeDropdown();
       return;
     }
 

--- a/packages/terra-form-select/src/single/Frame.jsx
+++ b/packages/terra-form-select/src/single/Frame.jsx
@@ -232,6 +232,11 @@ class Frame extends React.Component {
       return;
     }
 
+    // Don't blur while focus is on select.
+    if (event.relatedTarget === this.select) {
+      return;
+    }
+
     // eslint-disable-next-line no-underscore-dangle
     const _onBlur = () => {
       this.setState({ isFocused: false });
@@ -249,7 +254,7 @@ class Frame extends React.Component {
      * the select menu from being closed.
      */
     // event.relatedTarget returns null in IE 10 / IE 11
-    if (event.relatedTarget == null) {
+    if (event.relatedTarget === null) {
       // Allow 10ms timeout hack for the browser to set document.activeElement so that the currently
       // focused page element is available when the blur event is fired.
       // See discussion on https://github.com/facebook/react/issues/3751

--- a/packages/terra-form-select/src/tag/Frame.jsx
+++ b/packages/terra-form-select/src/tag/Frame.jsx
@@ -341,9 +341,7 @@ class Frame extends React.Component {
 
     // Don't blur if we dismissed the onscreen keyboard
     // Determined by if we have have interacted with the frame via onTouchStart
-    // and if the relatedTarget is falsey. The relatedTarget will be null when
-    // dismissing the onscreen keyboard, else set to another element when
-    // tapping elsewhere on the page
+    // and if the focus is on input.
     if (focusedByTouch && (relatedTarget === this.input)) {
       return;
     }

--- a/packages/terra-form-select/src/tag/Frame.jsx
+++ b/packages/terra-form-select/src/tag/Frame.jsx
@@ -344,7 +344,7 @@ class Frame extends React.Component {
     // and if the relatedTarget is falsey. The relatedTarget will be null when
     // dismissing the onscreen keyboard, else set to another element when
     // tapping elsewhere on the page
-    if (focusedByTouch && !relatedTarget) {
+    if (focusedByTouch && (relatedTarget === this.input)) {
       return;
     }
 


### PR DESCRIPTION
### Summary
I have added condition, such that whenever `relatedTarget === this.input` onBlur event should not be triggered for mobile.

Resolves #2845