### PR TITLE
[terra-i18n] Intl polyfills in IE10

### DIFF
--- a/packages/terra-i18n/CHANGELOG.md
+++ b/packages/terra-i18n/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Check if Intl.DateTimeFormat and Int.NumberFormat have the `supportedLocalesOf` property before adding as constructors for intl-locales-supported. 
 
 4.25.0 - (March 10, 2020)
 ------------------

--- a/packages/terra-i18n/src/intlLoaders.js
+++ b/packages/terra-i18n/src/intlLoaders.js
@@ -12,10 +12,19 @@ const supportedIntlConstructors = () => {
   let constructors;
   try {
     if (typeof (Intl) === 'object' && typeof (Intl.DateTimeFormat) === 'function' && typeof (Intl.NumberFormat) === 'function') {
-      constructors = [
-        Intl.DateTimeFormat,
-        Intl.NumberFormat,
-      ];
+      /**
+       * intl-locales-supported accesses the 'supportedLocalesOf' property of each of these constructors.
+       * When certain polyfills are used, the polyfill may not have the 'supportedLocalesOf' property.
+       * For example, when using the date-time-format-timezone Intl.DateTimeFormat becomes Intl.DateTimeFormatPolyfill which does not support this property.
+       */
+      if (Object.prototype.hasOwnProperty.call(Intl.DateTimeFormat, 'supportedLocalesOf') && Object.prototype.hasOwnProperty.call(Intl.NumberFormat, 'supportedLocalesOf')) {
+        constructors = [
+          Intl.DateTimeFormat,
+          Intl.NumberFormat,
+        ];
+      } else {
+        constructors = [];
+      }
     }
   } catch (error) {
     constructors = [];

--- a/packages/terra-i18n/tests/jest/intlLoaders.test.js
+++ b/packages/terra-i18n/tests/jest/intlLoaders.test.js
@@ -166,5 +166,12 @@ describe('intlLoaders', () => {
       expect(hasIntlData).toHaveBeenNthCalledWith(1, ['es-US'], supportedIntlConstructors);
       expect(intlLoaders.en).not.toBeCalled();
     });
+
+    it('does not add supported Intl constructors if supportedLocalesOf property does not exist', () => {
+      delete Intl.DateTimeFormat.supportedLocalesOf;
+      delete Intl.NumberFormat.supportedLocalesOf;
+      defaultLoadIntl('en');
+      expect(hasIntlData).toHaveBeenNthCalledWith(1, ['en'], []);
+    });
   });
 });


### PR DESCRIPTION
### Summary
Check if Intl.DateTimeFormat and Int.NumberFormat have the `supportedLocalesOf` property before adding as constructors for intl-locales-supported.

### Additional Details
Fixes #2914 2914


Thanks for contributing to Terra.
@cerner/terra

[CONTRIBUTORS.md]: ../CONTRIBUTORS.md
[License]: ../LICENSE
