### PR TITLE
[terra-form-select] Update isTouchAccessible prop description

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Updated the `isTouchAccessible` prop descriptions to include information about overflow behavior
 
 6.0.0 - (March 31, 2020)
 ------------------

--- a/packages/terra-form-select/src/Combobox.jsx
+++ b/packages/terra-form-select/src/Combobox.jsx
@@ -42,9 +42,10 @@ const propTypes = {
    */
   isInvalid: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices.
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
    */
   isTouchAccessible: PropTypes.bool,
   /**

--- a/packages/terra-form-select/src/ComboboxField.jsx
+++ b/packages/terra-form-select/src/ComboboxField.jsx
@@ -55,9 +55,10 @@ const propTypes = {
    */
   isLabelHidden: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices.
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
    */
   isTouchAccessible: PropTypes.bool,
   /**

--- a/packages/terra-form-select/src/MultiSelect.jsx
+++ b/packages/terra-form-select/src/MultiSelect.jsx
@@ -39,9 +39,10 @@ const propTypes = {
    */
   isInvalid: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices.
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
    */
   isTouchAccessible: PropTypes.bool,
   /**

--- a/packages/terra-form-select/src/MultiSelectField.jsx
+++ b/packages/terra-form-select/src/MultiSelectField.jsx
@@ -57,9 +57,10 @@ const propTypes = {
    */
   isLabelHidden: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices.
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
    */
   isTouchAccessible: PropTypes.bool,
   /**

--- a/packages/terra-form-select/src/SearchSelect.jsx
+++ b/packages/terra-form-select/src/SearchSelect.jsx
@@ -42,9 +42,10 @@ const propTypes = {
    */
   isInvalid: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices.
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
    */
   isTouchAccessible: PropTypes.bool,
   /**

--- a/packages/terra-form-select/src/SearchSelectField.jsx
+++ b/packages/terra-form-select/src/SearchSelectField.jsx
@@ -55,9 +55,10 @@ const propTypes = {
    */
   isLabelHidden: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices.
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
    */
   isTouchAccessible: PropTypes.bool,
   /**

--- a/packages/terra-form-select/src/Select.jsx
+++ b/packages/terra-form-select/src/Select.jsx
@@ -41,10 +41,12 @@ const propTypes = {
    */
   isInvalid: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices. Only applicable to variants
-   * that include an input (e.g. `combobox`, `multiple`, `search`, and `tag`).
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
+   *
+   * Only applicable to variants that include an input (e.g. `combobox`, `multiple`, `search`, and `tag`).
    */
   isTouchAccessible: PropTypes.bool,
   /**

--- a/packages/terra-form-select/src/SelectField.jsx
+++ b/packages/terra-form-select/src/SelectField.jsx
@@ -61,10 +61,12 @@ const propTypes = {
    */
   isLabelHidden: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices. Only applicable to variants
-   * that include an input (e.g. `combobox`, `multiple`, `search`, and `tag`).
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
+   *
+   * Only applicable to variants that include an input (e.g. `combobox`, `multiple`, `search`, and `tag`).
    */
   isTouchAccessible: PropTypes.bool,
   /**

--- a/packages/terra-form-select/src/TagSelect.jsx
+++ b/packages/terra-form-select/src/TagSelect.jsx
@@ -39,9 +39,10 @@ const propTypes = {
    */
   isInvalid: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices.
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
    */
   isTouchAccessible: PropTypes.bool,
   /**

--- a/packages/terra-form-select/src/TagSelectField.jsx
+++ b/packages/terra-form-select/src/TagSelectField.jsx
@@ -57,9 +57,10 @@ const propTypes = {
    */
   isLabelHidden: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices.
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
    */
   isTouchAccessible: PropTypes.bool,
   /**

--- a/packages/terra-form-select/src/combobox/Frame.jsx
+++ b/packages/terra-form-select/src/combobox/Frame.jsx
@@ -56,9 +56,10 @@ const propTypes = {
    */
   isInvalid: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices.
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
    */
   isTouchAccessible: PropTypes.bool,
   /**

--- a/packages/terra-form-select/src/multiple/Frame.jsx
+++ b/packages/terra-form-select/src/multiple/Frame.jsx
@@ -53,9 +53,10 @@ const propTypes = {
    */
   isInvalid: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices.
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
    */
   isTouchAccessible: PropTypes.bool,
   /**

--- a/packages/terra-form-select/src/search/Frame.jsx
+++ b/packages/terra-form-select/src/search/Frame.jsx
@@ -56,9 +56,10 @@ const propTypes = {
    */
   isInvalid: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices.
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
    */
   isTouchAccessible: PropTypes.bool,
   /**

--- a/packages/terra-form-select/src/shared/_Dropdown.jsx
+++ b/packages/terra-form-select/src/shared/_Dropdown.jsx
@@ -20,9 +20,10 @@ const propTypes = {
    */
   isEnabled: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices.
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
    */
   isTouchAccessible: PropTypes.bool,
   /**

--- a/packages/terra-form-select/src/tag/Frame.jsx
+++ b/packages/terra-form-select/src/tag/Frame.jsx
@@ -53,9 +53,10 @@ const propTypes = {
    */
   isInvalid: PropTypes.bool,
   /**
-   * Ensure accessibility on touch devices. Will render the dropdown menu in
-   * normal DOM flow with position absolute. By default, the menu renders in a
-   * portal, which is inaccessible on touch devices.
+   * Ensures touch accessibility by rendering the dropdown inline without a portal.
+   *
+   * Note: When enabled the dropdown will clip if rendered within a container that has an overflow: hidden ancestor.
+   * The dropdown may also appear beneath content if rendered within a container that has an overflow: auto ancestor.
    */
   isTouchAccessible: PropTypes.bool,
   /**


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

This PR updates the `isTouchAccessible` prop description to include information about overflow behavior. The `isTouchAccessible` prop renders the dropdown inline without a portal. This disables the ability for the dropdown to "break out" of modals and other content. The dropdown will clip if rendered within a content region that has overflow set to hidden. The dropdown may also appear beneath content if rendered within a content region that has a scrolling overflow. 

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes https://github.com/cerner/terra-core/issues/2913

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-2916.herokuapp.com/