### PR TITLE
Improves data-load performance of form-select-default variant

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added `isLazyLoadEnabled` to enable lazy loading of options in default form-select
 
 6.2.0 - (April 22, 2020)
 ------------------

--- a/packages/terra-form-select/src/Select.jsx
+++ b/packages/terra-form-select/src/Select.jsx
@@ -107,6 +107,10 @@ const propTypes = {
    */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
   /**
+   *  Enables lazy loading options when set to true.
+   */
+  isLazyLoadEnabled: PropTypes.bool,
+  /**
    * The behavior of the select. One of `default`, `combobox`, `multiple`, `tag`, or `search`.
    */
   variant: PropTypes.oneOf([

--- a/packages/terra-form-select/src/SingleSelect.jsx
+++ b/packages/terra-form-select/src/SingleSelect.jsx
@@ -85,6 +85,10 @@ const propTypes = {
    * The selected value. Can be a string, number, or array of strings/numbers.
    */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
+  /**
+   *  Enables lazy loading options when set to true.
+   */
+  isLazyLoadEnabled: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/packages/terra-form-select/src/multiple/Menu.jsx
+++ b/packages/terra-form-select/src/multiple/Menu.jsx
@@ -474,7 +474,7 @@ class Menu extends React.Component {
         {...(this.state.active !== null ? { 'aria-activedescendant': `terra-select-option-${this.state.active}` } : {})}
         tabIndex="0"
       >
-        {this.clone(this.state.children)}
+        {this.state.children}
       </ul>
     );
   }

--- a/packages/terra-form-select/src/multiple/Menu.jsx
+++ b/packages/terra-form-select/src/multiple/Menu.jsx
@@ -474,7 +474,7 @@ class Menu extends React.Component {
         {...(this.state.active !== null ? { 'aria-activedescendant': `terra-select-option-${this.state.active}` } : {})}
         tabIndex="0"
       >
-        {this.state.children}
+        {this.clone(this.state.children)}
       </ul>
     );
   }

--- a/packages/terra-form-select/src/shared/_FrameUtil.js
+++ b/packages/terra-form-select/src/shared/_FrameUtil.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import Variants from './_variants';
 
 class FrameUtil {
@@ -136,6 +137,30 @@ class FrameUtil {
       return '0';
     }
     return '-1';
+  }
+
+  /**
+   * Returns the initial number of options to be rendered.
+   * @param {number} frameHeight - The max height of the dropdown.
+   * @param {ReactNode} select - The select component.
+   * @param {array} children - The form-select options.
+   * @return {array} - A Initial set of options to render.
+   */
+  static getInitialOptions(frameHeight, select, children) {
+    const initialOptions = [];
+    const optionHeight = select.getBoundingClientRect().height;
+    // to enable scroll extra optionHeight is added to frameHeight
+    const contentNodeHeight = (frameHeight) ? (frameHeight + optionHeight) : (select.parentNode.getBoundingClientRect().bottom);
+    let totalHeight = 0;
+    React.Children.forEach(children, (option) => {
+      if (contentNodeHeight <= totalHeight) {
+        return;
+      }
+      initialOptions.push(option);
+      totalHeight += optionHeight;
+    });
+
+    return initialOptions;
   }
 }
 

--- a/packages/terra-form-select/src/shared/_FrameUtil.js
+++ b/packages/terra-form-select/src/shared/_FrameUtil.js
@@ -149,8 +149,8 @@ class FrameUtil {
   static getInitialOptions(frameHeight, select, children) {
     const initialOptions = [];
     const optionHeight = select.getBoundingClientRect().height;
-    // to enable scroll extra optionHeight is added to frameHeight
-    const contentNodeHeight = (frameHeight) ? (frameHeight + optionHeight) : (select.parentNode.getBoundingClientRect().bottom);
+    // Adding optionHeight to ContentNodeHeight to add space for extra options. extra options are needed to enable scrollbar
+    const contentNodeHeight = (frameHeight) ? (frameHeight + (optionHeight * 2)) : (window.innerHeight + (optionHeight * 2));
     let totalHeight = 0;
     React.Children.forEach(children, (option) => {
       if (contentNodeHeight <= totalHeight) {

--- a/packages/terra-form-select/src/single/Frame.jsx
+++ b/packages/terra-form-select/src/single/Frame.jsx
@@ -91,6 +91,10 @@ const propTypes = {
    * The select value.
    */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
+  /**
+   *  Enables lazy loading options when set to true.
+   */
+  isLazyLoadEnabled: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -158,9 +162,11 @@ class Frame extends React.Component {
   }
 
   componentDidMount() {
-    this.options = FrameUtil.getInitialOptions(this.props.maxHeight, this.select, this.props.children);
-    this.initialOptionCount = React.Children.count(this.options);
-    this.lastOptioinIndex = this.initialOptionCount;
+    if (this.props.isLazyLoadEnabled) {
+      this.options = FrameUtil.getInitialOptions(this.props.maxHeight, this.select, this.props.children);
+      this.initialOptionCount = React.Children.count(this.options);
+      this.lastOptioinIndex = this.initialOptionCount;
+    }
   }
 
   componentDidUpdate(previousProps, previousState) {
@@ -535,12 +541,12 @@ class Frame extends React.Component {
             isAbove={this.state.isAbove}
             isEnabled={this.state.isPositioned}
             onResize={this.positionDropdown}
-            onScroll={this.handleScroll}
+            onScroll={(this.props.isLazyLoadEnabled) ? this.handleScroll : undefined}
             refCallback={(ref) => { this.dropdown = ref; }}
             style={FrameUtil.dropdownStyle(dropdownAttrs, this.state)} // eslint-disable-line react/forbid-component-props
           >
             <Menu {...menuProps}>
-              {this.options}
+              {(this.props.isLazyLoadEnabled) ? this.options : this.props.children}
             </Menu>
           </Dropdown>
         )}

--- a/packages/terra-form-select/src/single/Frame.jsx
+++ b/packages/terra-form-select/src/single/Frame.jsx
@@ -154,6 +154,13 @@ class Frame extends React.Component {
     this.role = this.role.bind(this);
     this.visuallyHiddenComponent = React.createRef();
     this.setSelectMenuRef = this.setSelectMenuRef.bind(this);
+    this.handleScroll = this.handleScroll.bind(this);
+  }
+
+  componentDidMount() {
+    this.options = FrameUtil.getInitialOptions(this.props.maxHeight, this.select, this.props.children);
+    this.initialOptionCount = React.Children.count(this.options);
+    this.lastOptioinIndex = this.initialOptionCount;
   }
 
   componentDidUpdate(previousProps, previousState) {
@@ -345,6 +352,17 @@ class Frame extends React.Component {
     }
   }
 
+  handleScroll() {
+    if (this.lastOptioinIndex < this.props.totalOptions) {
+      const newLastOptionIndex = this.lastOptioinIndex + this.initialOptionCount;
+      const tempArray = React.Children.toArray(this.props.children).slice(this.lastOptioinIndex, newLastOptionIndex);
+      React.Children.forEach(tempArray, (option) => {
+        this.options.push(option);
+      });
+      this.lastOptioinIndex = React.Children.count(this.options);
+    }
+  }
+
   /**
    * Toggles the dropdown open or closed.
    */
@@ -517,11 +535,12 @@ class Frame extends React.Component {
             isAbove={this.state.isAbove}
             isEnabled={this.state.isPositioned}
             onResize={this.positionDropdown}
+            onScroll={this.handleScroll}
             refCallback={(ref) => { this.dropdown = ref; }}
             style={FrameUtil.dropdownStyle(dropdownAttrs, this.state)} // eslint-disable-line react/forbid-component-props
           >
             <Menu {...menuProps}>
-              {children}
+              {this.options}
             </Menu>
           </Dropdown>
         )}

--- a/packages/terra-form-select/src/terra-dev-site/doc/example/single/SingleSelectWithLargeData.jsx
+++ b/packages/terra-form-select/src/terra-dev-site/doc/example/single/SingleSelectWithLargeData.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import SingleSelect from 'terra-form-select/lib/SingleSelect';
+import classNames from 'classnames/bind';
+import styles from '../FormSelectDocCommon.module.scss';
+
+const cx = classNames.bind(styles);
+
+const SingleSelectWithLargeData = () => {
+  const options = [];
+
+  for (let index = 1; index <= 1000; index += 1) {
+    options.push(<SingleSelect.Option key={index} value={index} display={`${index}`} />);
+  }
+
+  return (
+    <SingleSelect placeholder="Select a number" className={cx('form-select')}>
+      {options}
+    </SingleSelect>
+  );
+};
+
+export default SingleSelectWithLargeData;

--- a/packages/terra-form-select/src/terra-dev-site/doc/example/single/SingleSelectWithLargeData.jsx
+++ b/packages/terra-form-select/src/terra-dev-site/doc/example/single/SingleSelectWithLargeData.jsx
@@ -13,7 +13,7 @@ const SingleSelectWithLargeData = () => {
   }
 
   return (
-    <SingleSelect placeholder="Select a number" className={cx('form-select')}>
+    <SingleSelect placeholder="Select a number" isLazyLoadEnabled className={cx('form-select')}>
       {options}
     </SingleSelect>
   );

--- a/packages/terra-form-select/src/terra-dev-site/doc/form-select/SingleSelect.03.doc.mdx
+++ b/packages/terra-form-select/src/terra-dev-site/doc/form-select/SingleSelect.03.doc.mdx
@@ -8,6 +8,7 @@ import InvalidExample from '../example/single/Invalid?dev-site-example';
 import IncompleteExample from '../example/single/Incomplete?dev-site-example';
 import MaxHeightExample from '../example/single/MaxHeight?dev-site-example';
 import OptGroupExample from '../example/single/OptGroup?dev-site-example';
+import SingleSelectWithLargeDataExample from '../example/single/SingleSelectWithLargeData?dev-site-example';
 
 import SingleSelectPropsTable from 'terra-form-select/src/SingleSelect?dev-site-props-table';
 import OptionPropsTable from 'terra-form-select/src/shared/_Option?dev-site-props-table';
@@ -70,6 +71,7 @@ import SingleSelect from 'terra-form-select/lib/SingleSelect';
 <MaxHeightExample title="Ability to set a Maximum Height" description="An example of implementing a custom max height of the dropdown." />
 <AllowClearExample title="Ability to Clear Selection" description="An example with an option to clear the selected item." />
 <ControlledExample title="Create a Controlled Single Select" description="An example of implementing a controlled Single Select." />
+<SingleSelectWithLargeDataExample title="Single Select with Large data" description="An example of implementing Lazy Loading options in a Single Select." />
 
 ## Single Select Props
 <SingleSelectPropsTable />

--- a/packages/terra-form-select/src/terra-dev-site/test/form-select/DefaultSelectWithLazyLoading.test.jsx
+++ b/packages/terra-form-select/src/terra-dev-site/test/form-select/DefaultSelectWithLazyLoading.test.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import classNames from 'classnames/bind';
+import Select from '../../../Select';
+import styles from './common/Select.test.module.scss';
+
+const cx = classNames.bind(styles);
+
+const DefaultSelectWithLazyLoading = () => {
+  const options = [];
+
+  for (let index = 1; index <= 1000; index += 1) {
+    options.push(<Select.Option key={index} value={index} display={`${index}`} />);
+  }
+
+  return (
+    <div className={cx('content-wrapper')}>
+      <p> Default Form Select without isLazyLoadEnabled </p>
+      <Select id="defaultWithOutLazyLoad">
+        {options}
+      </Select>
+      <p> Default Form Select with isLazyLoadEnabled </p>
+      <Select id="defaultWithLazyLoad" isLazyLoadEnabled>
+        {options}
+      </Select>
+      <p> Default Form Select with maxheight and isLazyLoadEnabled </p>
+      <Select id="defaultWithLazyLoad" isLazyLoadEnabled maxHeight={400}>
+        {options}
+      </Select>
+    </div>
+  );
+};
+
+export default DefaultSelectWithLazyLoading;


### PR DESCRIPTION
### Summary
To address the delay in load performance of form-select which was happening with large datasets implemented lazy loading for single-form-select. Options that will be visible on dropdown open will be rendered initially and rest of the options will be added to list as we scroll down the list.

With this approach the time taken to render the options has been considerably reduced compared to existing form-select. Since number of options rendered on open is reduced to certain count form-select takes less time to render the options.

**Time taken to load 1000 options by existing form-select** : 

<img width="1368" alt="Screen Shot 2020-04-23 at 4 55 42 PM" src="https://user-images.githubusercontent.com/12869809/80095328-5fa4c580-8585-11ea-8e85-96aeb772d793.png">

**Time taken to load 1000 options by new form-select** : 

<img width="1371" alt="Screen Shot 2020-04-23 at 4 59 51 PM" src="https://user-images.githubusercontent.com/12869809/80095374-70edd200-8585-11ea-87e5-0bb6fb24e314.png">


Number of Initial options to be rendered are calculated with comparison of dropdown `maxHeight` prop if provided else with parentWindow height which will be used to calculate the number of options to be rendered initially. Later as we scroll down the list same set of options gets added into dropdown to keep the scrolling behaviour aligned with existing behaviour.

Closes #2161 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-2938.herokuapp.com/components/terra-form-select/form-select/single-select

### Testing
Tested with Chrome Profiler Tools by recording time-taken to load same number of options by both existing and new form-select. 

Thank you for contributing to Terra.
@cerner/terra
