### PR TITLE
[terra-action-footer] Fix text in footer not wrapping in ie 10

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,6 +85,7 @@ Cerner Corporation
 - Saket Bajaj [@saket2403]
 - Prachi Gotkhindikar [@prachigotkhindikar1]
 - Jeff Merten [@jeffmerten]
+- Jackson Nowotny [@JacksonJN]
 
 Community
 
@@ -196,3 +197,4 @@ Community
 [@saket2403]:https://github.com/saket2403
 [@vobango]:https://github.com/vobango
 [@jeffmerten]: https://github.com/jeffmerten
+[@JacksonJN]: https://github.com/JacksonJN

--- a/packages/terra-action-footer/CHANGELOG.md
+++ b/packages/terra-action-footer/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Text in footer not wrapping in IE 10
 
 2.44.0 - (June 2, 2020)
 ------------------

--- a/packages/terra-action-footer/src/ActionFooter.module.scss
+++ b/packages/terra-action-footer/src/ActionFooter.module.scss
@@ -17,5 +17,6 @@
   .start-actions,
   .end-actions {
     align-self: center;
+    flex: 0 1 auto; //Needed for IE 10 to wrap things properly
   }
 }


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
Fixes issue of text in action footer not wrapping in ie 10. Occurs when using the terra `Text` component inside terra `ActionFooter` component, even when setting `isWordWrapping` prop to true of the `Text` component.

Issue is due to bug in IE with word wrapping inside a flexbox, which action-footer uses. 

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #3009 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
Ran linter and jest tests locally. Manually tested in local build of terra dev site in various browsers and resolutions.

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->
More details in issue logged #3009.

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
