### PR TITLE
[terra-divider] Add display style on hr element

### DIFF
--- a/packages/terra-divider/CHANGELOG.md
+++ b/packages/terra-divider/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Added display to `block` on hr element in the divider component
 
 3.28.0 - (June 9, 2020)
 ------------------

--- a/packages/terra-divider/src/Divider.module.scss
+++ b/packages/terra-divider/src/Divider.module.scss
@@ -14,6 +14,7 @@
 
   .divider {
     @include terra-divider;
+    display: block;
     margin: 0; // remove browser default margin
   }
 


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This PR adds style `display` to `block` on the hr element in the divider component.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #3033 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
