### PR TITLE
[terra-divider] Fix custom props spread on the text divider

### DIFF
--- a/packages/terra-divider/CHANGELOG.md
+++ b/packages/terra-divider/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed custom props spread on the text divider
+
 ## 3.31.0 - (August 4, 2020)
 
 * Changed

--- a/packages/terra-divider/src/Divider.jsx
+++ b/packages/terra-divider/src/Divider.jsx
@@ -7,8 +7,8 @@ import styles from './Divider.module.scss';
 
 const propTypes = {
   /**
-  * String to be displayed inline with the divider.
-  */
+   * String to be displayed inline with the divider.
+   */
   text: PropTypes.string,
 };
 
@@ -21,7 +21,8 @@ const Divider = (props) => {
 
   const dividerClassNames = classNames(
     cx([
-      'divider',
+      { divider: !text },
+      { 'divider-container': text },
       theme.className,
     ]),
     customProps.className,
@@ -30,8 +31,9 @@ const Divider = (props) => {
   if (!text) {
     return <hr {...customProps} className={dividerClassNames} aria-hidden="true" />;
   }
+
   return (
-    <div className={cx(['divider-container', theme.className])}>
+    <div {...customProps} className={dividerClassNames}>
       <span className={cx(['divider-text'])}>{text}</span>
     </div>
   );

--- a/packages/terra-divider/tests/jest/Divider.test.jsx
+++ b/packages/terra-divider/tests/jest/Divider.test.jsx
@@ -20,7 +20,7 @@ describe('Divider', () => {
 
   // Inline Custom Text Test
   it('it should pass in a string of text', () => {
-    const wrapper = shallow(<Divider id="testDivider" text="Divider Test String" />);
+    const wrapper = shallow(<Divider text="Divider Test String" />);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -31,5 +31,49 @@ describe('Divider', () => {
       </ThemeContextProvider>,
     );
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should spread a custom class onto the hr divider', () => {
+    const wrapper = shallow(<Divider className="custom-class" />);
+
+    expect(wrapper.hasClass('custom-class')).toBe(true);
+  });
+
+  it('should spread a custom class onto the text divider', () => {
+    const wrapper = shallow(<Divider className="custom-class" text="custom-text" />);
+
+    expect(wrapper.hasClass('custom-class')).toBe(true);
+  });
+
+  it('should spread a custom prop onto the hr divider', () => {
+    const wrapper = shallow(<Divider id="custom-id" />);
+
+    expect(wrapper.is('#custom-id')).toBe(true);
+  });
+
+  it('should spread a custom prop onto the text divider', () => {
+    const wrapper = shallow(<Divider id="custom-id" text="custom-text" />);
+
+    expect(wrapper.is('#custom-id')).toBe(true);
+  });
+
+  it('should apply the theme context className to the hr divider', () => {
+    const wrapper = mount(
+      <ThemeContextProvider theme={{ className: 'theme-class-name' }}>
+        <Divider />
+      </ThemeContextProvider>,
+    );
+
+    expect(wrapper.find('hr').hasClass('theme-class-name')).toBe(true);
+  });
+
+  it('should apply the theme context className to the text divider', () => {
+    const wrapper = mount(
+      <ThemeContextProvider theme={{ className: 'theme-class-name' }}>
+        <Divider text="custom-text" />
+      </ThemeContextProvider>,
+    );
+
+    expect(wrapper.find('div').hasClass('theme-class-name')).toBe(true);
   });
 });


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

When rendering a terra-divider with text custom props are not spread onto the rendered dom node.

```jsx
<Divider className="custom-class" text="Text" /> // custom-class will not be spread onto the rendered dom node.
```

The terra divider renders one of two elements depending on the presence of the `text` prop.

When text is not present the terra-divider [renders an `hr` element](https://github.com/cerner/terra-core/blob/d69436408771e8acbe453b54250c6f275b20f8fb/packages/terra-divider/src/Divider.jsx#L31) and appropriately spreads custom props onto the dom node.

When text is present the terra-divider [renders a `div` element](https://github.com/cerner/terra-core/blob/d69436408771e8acbe453b54250c6f275b20f8fb/packages/terra-divider/src/Divider.jsx#L34) and does not spread custom props.


<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #3128

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
