### PR TITLE
[terra-overlay] Fix CSP unsafe-inline violation.

### DIFF
--- a/packages/terra-overlay/CHANGELOG.md
+++ b/packages/terra-overlay/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Changed
+  * Provide [inert styles](https://github.com/WICG/inert/pull/148/files#diff-04c6e90faac2675aa89e2176d2eec7d8R101-R111) as global styles.
+  * Injecting an empty link with id `inert-style` to head in order avoid CSP violations.
+
 ## 3.56.0 - (August 18, 2020)
 
 * Changed

--- a/packages/terra-overlay/src/Overlay.jsx
+++ b/packages/terra-overlay/src/Overlay.jsx
@@ -81,6 +81,12 @@ class Overlay extends React.Component {
   componentDidMount() {
     // eslint-disable-next-line no-prototype-builtins
     if (!Element.prototype.hasOwnProperty('inert')) {
+      const { head } = document;
+      if (!head.querySelector('link#inert-style')) {
+        const link = document.createElement('link');
+        link.id = 'inert-style';
+        head.appendChild(link);
+      }
       // IE10 throws an error if wicg-inert is imported too early, as wicg-inert tries to set an observer on document.body which may not exist on import
       // eslint-disable-next-line global-require
       require('wicg-inert/dist/inert');

--- a/packages/terra-overlay/src/Overlay.module.scss
+++ b/packages/terra-overlay/src/Overlay.module.scss
@@ -132,3 +132,19 @@
     }
   }
 }
+
+:global {
+  [inert] {
+    cursor: default;
+    pointer-events: none;
+  }
+
+  [inert],
+  [inert] * {
+    /* stylelint-disable property-no-vendor-prefix */
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+}


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This PR provides [inert styles](https://github.com/WICG/inert/pull/148/files#diff-04c6e90faac2675aa89e2176d2eec7d8R101-R111) as global styles and injects an empty link with id inert-style to head to avoid CSP violation

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #3165 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
