### PR TITLE
[terra-base] Add throwOnI18nError prop

### DIFF
--- a/packages/terra-base/CHANGELOG.md
+++ b/packages/terra-base/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added `throwOnI18nLoadError` prop to opt into throwing the error when i18n data fails to load instead of logging the error to the console
+
 ## 5.39.0 - (August 4, 2020)
 
 * Changed

--- a/packages/terra-base/CHANGELOG.md
+++ b/packages/terra-base/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Added
-  * Added `throwOnI18nLoadError` prop to opt into throwing the error when i18n data fails to load instead of logging the error to the console
+  * Added `throwOnI18nLoadError` prop to opt into logging and throwing the error when i18n data fails to load instead of only logging the error to the console
 
 ## 5.39.0 - (August 4, 2020)
 

--- a/packages/terra-base/src/Base.jsx
+++ b/packages/terra-base/src/Base.jsx
@@ -26,10 +26,14 @@ const propTypes = {
    */
   strictMode: PropTypes.bool,
   /**
-   * The component(s) that will be wrapped by `<Base />` ONLY
-   * in the event that translations have not been loaded yet.
-   * NOTE: Absolutely no locale-dependent logic should be
-   * utilized in this placeholder.
+   * Whether or not the error should be thrown if something goes wrong. When false, the error will be logged to the
+   * console an error. This can be used when an ErrorBoundary is provided around terra-base to prevent app crashes.
+  * NOTE: Absolutely no locale-dependent logic should be utilized in the ErrorBoundary wrapping it.
+   */
+  throwOnI18nLoadError: PropTypes.bool,
+  /**
+   * The component(s) that will be wrapped by `<Base />` ONLY in the event that translations have not been loaded yet.
+   * NOTE: Absolutely no locale-dependent logic should be utilized in this placeholder.
    */
   translationsLoadingPlaceholder: PropTypes.node,
 };
@@ -37,6 +41,7 @@ const propTypes = {
 const defaultProps = {
   customMessages: {},
   strictMode: false,
+  throwOnI18nLoadError: false,
 };
 
 class Base extends React.Component {
@@ -54,8 +59,12 @@ class Base extends React.Component {
       try {
         i18nLoader(this.props.locale, this.setState, this);
       } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(e);
+        if (this.props.throwOnI18nLoadError) {
+          throw e;
+        } else {
+          // eslint-disable-next-line no-console
+          console.error(e);
+        }
       }
     }
   }
@@ -65,8 +74,12 @@ class Base extends React.Component {
       try {
         i18nLoader(this.props.locale, this.setState, this);
       } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(e);
+        if (this.props.throwOnI18nLoadError) {
+          throw e;
+        } else {
+          // eslint-disable-next-line no-console
+          console.error(e);
+        }
       }
     }
   }

--- a/packages/terra-base/src/Base.jsx
+++ b/packages/terra-base/src/Base.jsx
@@ -28,7 +28,7 @@ const propTypes = {
   /**
    * Whether or not the error should be thrown if something goes wrong. When false, the error will be logged to the
    * console an error. This can be used when an ErrorBoundary is provided around terra-base to prevent app crashes.
-  * NOTE: Absolutely no locale-dependent logic should be utilized in the ErrorBoundary wrapping it.
+   * NOTE: Absolutely no locale-dependent logic should be utilized in the ErrorBoundary wrapping it.
    */
   throwOnI18nLoadError: PropTypes.bool,
   /**

--- a/packages/terra-base/src/Base.jsx
+++ b/packages/terra-base/src/Base.jsx
@@ -26,9 +26,8 @@ const propTypes = {
    */
   strictMode: PropTypes.bool,
   /**
-   * Whether or not the error should be thrown if something goes wrong. When false, the error will be logged to the
-   * console an error. This can be used when an ErrorBoundary is provided around terra-base to prevent app crashes.
-   * NOTE: Absolutely no locale-dependent logic should be utilized in the ErrorBoundary wrapping it.
+   * Whether or not the error should be logged and thrown if something goes wrong. When false, the error will only be logged to the
+   * console an error.
    */
   throwOnI18nLoadError: PropTypes.bool,
   /**
@@ -59,11 +58,11 @@ class Base extends React.Component {
       try {
         i18nLoader(this.props.locale, this.setState, this);
       } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+
         if (this.props.throwOnI18nLoadError) {
           throw e;
-        } else {
-          // eslint-disable-next-line no-console
-          console.error(e);
         }
       }
     }
@@ -74,11 +73,11 @@ class Base extends React.Component {
       try {
         i18nLoader(this.props.locale, this.setState, this);
       } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+
         if (this.props.throwOnI18nLoadError) {
           throw e;
-        } else {
-          // eslint-disable-next-line no-console
-          console.error(e);
         }
       }
     }

--- a/packages/terra-base/tests/jest/Base.test.jsx
+++ b/packages/terra-base/tests/jest/Base.test.jsx
@@ -1,15 +1,16 @@
 import React from 'react';
+import * as terraI18n from 'terra-i18n';
+
 import Base from '../../src/Base';
+
+jest.mock('terra-i18n');
 
 // Missing locale test
 it('throws error for missing required locale', () => {
   const messages = { Terra: 'Terra' };
 
-  try {
-    shallow(<Base customMessages={messages}>String</Base>);
-  } catch (e) {
-    expect(e.message).toContain('The prop `locale` is marked as required in `Base`');
-  }
+  expect(() => shallow(<Base customMessages={messages}>String</Base>))
+    .toThrowError(/The prop `locale` is marked as required in `Base`/);
 });
 
 // Snapshot Tests
@@ -19,18 +20,56 @@ it('should support rendering a string', () => {
 });
 
 it('should support rendering an array of children', () => {
-  /* eslint-disable comma-dangle */
   const base = shallow(
     <Base>
       <div>1</div>
       <div>2</div>
-    </Base>
+    </Base>,
   );
   expect(base).toMatchSnapshot();
-  /* eslint-enable comma-dangle */
 });
 
 it('should render with strict mode when strict mode enabled', () => {
   const base = shallow(<Base strictMode>String</Base>);
   expect(base).toMatchSnapshot();
+});
+
+describe('base handles i18n data loading', () => {
+  beforeAll(() => {
+    // eslint-disable-next-line no-console
+    console.error = jest.fn();
+  });
+
+  beforeEach(() => {
+    // eslint-disable-next-line no-console
+    console.error.mockClear();
+  });
+
+  it('renders as expected when i18n data loads successfully', () => {
+    terraI18n.i18nLoader = jest.fn();
+    expect(() => shallow(<Base locale="en">String</Base>)).not.toThrowError();
+    expect(terraI18n.i18nLoader).toHaveBeenCalled();
+    // eslint-disable-next-line no-console
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('logs error when i18n data fails to load', () => {
+    terraI18n.i18nLoader = jest.fn(() => {
+      throw new Error('failed to load data.');
+    });
+    expect(() => shallow(<Base locale="en">String</Base>)).not.toThrowError();
+    expect(terraI18n.i18nLoader).toHaveBeenCalled();
+    // eslint-disable-next-line no-console
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('throws error when i18n data fails to load', () => {
+    terraI18n.i18nLoader = jest.fn(() => {
+      throw new Error('failed to load data.');
+    });
+    expect(() => shallow(<Base locale="en" throwOnI18nLoadError>String</Base>)).toThrowError();
+    expect(terraI18n.i18nLoader).toHaveBeenCalled();
+    // eslint-disable-next-line no-console
+    expect(console.error).not.toHaveBeenCalled();
+  });
 });

--- a/packages/terra-base/tests/jest/Base.test.jsx
+++ b/packages/terra-base/tests/jest/Base.test.jsx
@@ -70,6 +70,6 @@ describe('base handles i18n data loading', () => {
     expect(() => shallow(<Base locale="en" throwOnI18nLoadError>String</Base>)).toThrowError();
     expect(terraI18n.i18nLoader).toHaveBeenCalled();
     // eslint-disable-next-line no-console
-    expect(console.error).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
Add new prop called `throwOnI18nError` to throw any errors that occur when the i18n data is loaded. Currently the error message is caught and logged as an error the console.

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
- Unit tests
- Manual validation

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
