### PR TITLE
[terra-i18n] Disabled regex cache from intl polyfill

### DIFF
--- a/packages/terra-i18n/CHANGELOG.md
+++ b/packages/terra-i18n/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Disable the regex cached maintained by the Intl Polyfill that can result in regex syntax errors.
+
 ## 4.32.0 - (August 4, 2020)
 
 * Changed

--- a/packages/terra-i18n/src/i18nLoader.js
+++ b/packages/terra-i18n/src/i18nLoader.js
@@ -33,12 +33,14 @@ export default (locale, callback, scope) => {
     /**
      * Intl polyfill attempts to cache and restore static RegExp properties before executing any regular expressions in order
      * to comply with ECMA-402. There are times this results in regex syntax error so we are disabling this feature.
-     * 
+     *
      * Reference: https://github.com/andyearnshaw/Intl.js#regexp-cache--restore
      */
+    /* eslint-disable no-underscore-dangle */
     if (Intl.__disableRegExpRestore && typeof Intl.__disableRegExpRestore === 'function') {
-      Intl.__disableRegExpRestore(); 
-     }
+      Intl.__disableRegExpRestore();
+    }
+    /* eslint-enable no-underscore-dangle */
 
     loadIntl(locale);
   }

--- a/packages/terra-i18n/src/i18nLoader.js
+++ b/packages/terra-i18n/src/i18nLoader.js
@@ -30,6 +30,16 @@ export default (locale, callback, scope) => {
   }
 
   if (global.IntlPolyfill) {
+    /**
+     * Intl polyfill attempts to cache and restore static RegExp properties before executing any regular expressions in order
+     * to comply with ECMA-402. There are times this results in regex syntax error so we are disabling this feature.
+     * 
+     * Reference: https://github.com/andyearnshaw/Intl.js#regexp-cache--restore
+     */
+    if (Intl.__disableRegExpRestore && typeof Intl.__disableRegExpRestore === 'function') {
+      Intl.__disableRegExpRestore(); 
+     }
+
     loadIntl(locale);
   }
 


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
  * Disable the regex cached maintained by the Intl Polyfill that can result in regex syntax errors.

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

