### PR TITLE
[terra-form-select] Added mutation observer shim to better support inert in IE10.

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added mutation observer-shim to better support inert in IE10.
+
 ## 6.17.0 - (September 29, 2020)
 
 * Changed

--- a/packages/terra-form-select/package.json
+++ b/packages/terra-form-select/package.json
@@ -31,6 +31,7 @@
     "classnames": "^2.2.5",
     "keycode-js": "^2.0.1",
     "lodash.uniqueid": "^4.0.1",
+    "mutationobserver-shim": "0.3.3",
     "prop-types": "^15.5.8",
     "react-lifecycles-compat": "^3.0.2",
     "terra-form-field": "^4.9.0",

--- a/packages/terra-form-select/src/combobox/Frame.jsx
+++ b/packages/terra-form-select/src/combobox/Frame.jsx
@@ -10,6 +10,9 @@ import Dropdown from '../shared/_Dropdown';
 import Menu from './Menu';
 import FrameUtil from '../shared/_FrameUtil';
 import styles from '../shared/_Frame.module.scss';
+import 'mutationobserver-shim';
+import '../shared/_contains-polyfill';
+import '../shared/_matches-polyfill';
 
 const cx = classNamesBind.bind(styles);
 

--- a/packages/terra-form-select/src/multiple/Frame.jsx
+++ b/packages/terra-form-select/src/multiple/Frame.jsx
@@ -11,6 +11,9 @@ import Menu from './Menu';
 import FrameUtil from '../shared/_FrameUtil';
 import styles from '../shared/_Frame.module.scss';
 import MenuUtil from '../shared/_MenuUtil';
+import 'mutationobserver-shim';
+import '../shared/_contains-polyfill';
+import '../shared/_matches-polyfill';
 
 const cx = classNamesBind.bind(styles);
 

--- a/packages/terra-form-select/src/search/Frame.jsx
+++ b/packages/terra-form-select/src/search/Frame.jsx
@@ -10,6 +10,9 @@ import Dropdown from '../shared/_Dropdown';
 import Menu from './Menu';
 import FrameUtil from '../shared/_FrameUtil';
 import styles from '../shared/_Frame.module.scss';
+import 'mutationobserver-shim';
+import '../shared/_contains-polyfill';
+import '../shared/_matches-polyfill';
 
 const cx = classNamesBind.bind(styles);
 

--- a/packages/terra-form-select/src/shared/_contains-polyfill.js
+++ b/packages/terra-form-select/src/shared/_contains-polyfill.js
@@ -1,0 +1,19 @@
+// Source: https://github.com/Financial-Times/polyfill-service/pull/183/files
+// Needed for IE11 and IE10
+if (!Node.prototype.contains) {
+  Node.prototype.contains = function contains(node) {
+    /* eslint-disable-next-line prefer-rest-params */
+    if (!(0 in arguments)) {
+      throw new TypeError('1 argument is required');
+    }
+    /* eslint-disable no-cond-assign */
+    do {
+      if (this === node) {
+        return true;
+      }
+      /* eslint-disable-next-line no-param-reassign */
+    } while (node = node && node.parentNode);
+    return false;
+  /* eslint-enable no-cond-assign */
+  };
+}

--- a/packages/terra-form-select/src/shared/_matches-polyfill.js
+++ b/packages/terra-form-select/src/shared/_matches-polyfill.js
@@ -1,0 +1,5 @@
+// Source: https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
+// Needed for IE11 and IE10
+if (!Element.prototype.matches) {
+  Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
+}

--- a/packages/terra-form-select/src/single/Frame.jsx
+++ b/packages/terra-form-select/src/single/Frame.jsx
@@ -11,6 +11,9 @@ import Menu from './Menu';
 import FrameUtil from '../shared/_FrameUtil';
 import SharedUtil from '../shared/_SharedUtil';
 import styles from '../shared/_Frame.module.scss';
+import 'mutationobserver-shim';
+import '../shared/_contains-polyfill';
+import '../shared/_matches-polyfill';
 
 const cx = classNamesBind.bind(styles);
 

--- a/packages/terra-form-select/src/tag/Frame.jsx
+++ b/packages/terra-form-select/src/tag/Frame.jsx
@@ -11,6 +11,9 @@ import Menu from './Menu';
 import FrameUtil from '../shared/_FrameUtil';
 import styles from '../shared/_Frame.module.scss';
 import MenuUtil from '../shared/_MenuUtil';
+import 'mutationobserver-shim';
+import '../shared/_contains-polyfill';
+import '../shared/_matches-polyfill';
 
 const cx = classNamesBind.bind(styles);
 


### PR DESCRIPTION
### Summary
Added mutation observer shim and node contains polyfill to better support inert polyfill in IE10.
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #3184 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
