### PR TITLE
[terra-alert] Fix action button alignment for multiple line message.

### DIFF
--- a/packages/terra-alert/CHANGELOG.md
+++ b/packages/terra-alert/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed action button alignment.
+
 * Changed
   * Updated to be compatible with `react-intl` v2-v5
   * Removed usage of `FormattedMessage` in favor of `injectIntl`

--- a/packages/terra-alert/src/Alert.module.scss
+++ b/packages/terra-alert/src/Alert.module.scss
@@ -74,7 +74,7 @@
   }
 
   .actions {
-    align-items: flex-start;
+    align-items: center;
     display: flex;
     flex-direction: row;
     flex-shrink: 0;


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This PR updates `align-items` from `flex-start` to `center`.
<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #3296 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
