### PR TITLE
[terra-form-textarea] Add first class props to textarea-field from textarea

### DIFF
--- a/packages/terra-form-textarea/CHANGELOG.md
+++ b/packages/terra-form-textarea/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
- * Added similar props from textarea to textarea-field.
+ * Added `size`, `rows`, `disableResize` and `isAutoResizable` props to textarea-field.
 
 ## 5.11.0 - (January 5, 2021)
 

--- a/packages/terra-form-textarea/CHANGELOG.md
+++ b/packages/terra-form-textarea/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+ * Added similar props from textarea to textarea-field.
+
 ## 5.11.0 - (January 5, 2021)
 
 * Fixed

--- a/packages/terra-form-textarea/src/Textarea.jsx
+++ b/packages/terra-form-textarea/src/Textarea.jsx
@@ -75,7 +75,7 @@ const propTypes = {
    */
   required: PropTypes.bool,
   /**
-   * Value to set for the rows attribute of the textarea. This takes presidence over size when
+   * Value to set for the rows attribute of the textarea. This takes precedence over size when
    * setting the height of the textarea.
    */
   rows: PropTypes.number,

--- a/packages/terra-form-textarea/src/Textarea.jsx
+++ b/packages/terra-form-textarea/src/Textarea.jsx
@@ -110,7 +110,7 @@ const defaultProps = {
   onChange: undefined,
   onInput: undefined,
   required: false,
-  rows: null,
+  rows: undefined,
   size: 'small',
   value: undefined,
   refCallback: undefined,

--- a/packages/terra-form-textarea/src/TextareaField.jsx
+++ b/packages/terra-form-textarea/src/TextareaField.jsx
@@ -96,7 +96,6 @@ const propTypes = {
    * The size of the textarea. _(Sizes the textarea by setting the rows attribute a corresponding preset value.)_
    */
   size: PropTypes.oneOf(['small', 'medium', 'large', 'full']),
-
   /**
    * Whether or not to append the 'optional' label to a non-required field label.
    */
@@ -132,7 +131,7 @@ const defaultProps = {
   maxWidth: undefined,
   onChange: undefined,
   onInput: undefined,
-  rows: null,
+  rows: undefined,
   size: 'small',
   required: false,
   showOptional: false,
@@ -208,16 +207,16 @@ const TextareaField = (props) => {
         {...inputAttrs}
         disabled={inputAttrs.disabled || disabled}
         id={inputId}
-        isAutoResizable={isAutoResizable}
+        isAutoResizable={inputAttrs.isAutoResizable || isAutoResizable}
         isIncomplete={isIncomplete}
         onChange={onChange}
         onInput={onInput}
         value={value}
         defaultValue={defaultValue}
         aria-describedby={ariaDescriptionIds}
-        rows={rows}
-        size={size}
-        disableResize={disableResize}
+        rows={inputAttrs.rows || rows}
+        size={inputAttrs.size || size}
+        disableResize={inputAttrs.disableResize || disableResize}
       />
     </Field>
   );

--- a/packages/terra-form-textarea/src/TextareaField.jsx
+++ b/packages/terra-form-textarea/src/TextareaField.jsx
@@ -46,6 +46,10 @@ const propTypes = {
   // eslint-disable-next-line react/forbid-prop-types
   inputAttrs: PropTypes.object,
   /**
+   * Whether the textarea can be auto-resized vertically. _(Will be ignored if size attribute is set to "full".)_
+   */
+  isAutoResizable: PropTypes.bool,
+  /**
    * Whether the field displays as Incomplete. Use when no value has been provided. _(usage note: `required` must also be set)_.
    */
   isIncomplete: PropTypes.bool,
@@ -84,6 +88,16 @@ const propTypes = {
    */
   required: PropTypes.bool,
   /**
+   * Value to set for the rows attribute of the textarea. This takes precedence over size when
+   * setting the height of the textarea.
+   */
+  rows: PropTypes.number,
+  /**
+   * The size of the textarea. _(Sizes the textarea by setting the rows attribute a corresponding preset value.)_
+   */
+  size: PropTypes.oneOf(['small', 'medium', 'large', 'full']),
+
+  /**
    * Whether or not to append the 'optional' label to a non-required field label.
    */
   showOptional: PropTypes.bool,
@@ -94,6 +108,11 @@ const propTypes = {
     PropTypes.string,
     PropTypes.number,
   ]),
+  /**
+   * Whether or not the textarea is resizable.
+   * `Disabled` textarea and the ones with size `full` are always non-resizable.
+   */
+  disableResize: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -103,6 +122,7 @@ const defaultProps = {
   errorIcon: <IconError />,
   help: null,
   hideRequired: false,
+  isAutoResizable: false,
   inputAttrs: {},
   isIncomplete: false,
   isInline: false,
@@ -112,21 +132,26 @@ const defaultProps = {
   maxWidth: undefined,
   onChange: undefined,
   onInput: undefined,
+  rows: null,
+  size: 'small',
   required: false,
   showOptional: false,
   value: undefined,
+  disableResize: false,
 };
 
 const TextareaField = (props) => {
   const {
     defaultValue,
     disabled,
+    disableResize,
     error,
     errorIcon,
     help,
     hideRequired,
     inputAttrs,
     inputId,
+    isAutoResizable,
     isIncomplete,
     isInline,
     isInvalid,
@@ -135,6 +160,8 @@ const TextareaField = (props) => {
     labelAttrs,
     maxWidth,
     required,
+    rows,
+    size,
     showOptional,
     onChange,
     onInput,
@@ -181,12 +208,16 @@ const TextareaField = (props) => {
         {...inputAttrs}
         disabled={inputAttrs.disabled || disabled}
         id={inputId}
+        isAutoResizable={isAutoResizable}
         isIncomplete={isIncomplete}
         onChange={onChange}
         onInput={onInput}
         value={value}
         defaultValue={defaultValue}
         aria-describedby={ariaDescriptionIds}
+        rows={rows}
+        size={size}
+        disableResize={disableResize}
       />
     </Field>
   );

--- a/packages/terra-form-textarea/tests/jest/TextareaField.test.jsx
+++ b/packages/terra-form-textarea/tests/jest/TextareaField.test.jsx
@@ -35,8 +35,9 @@ it('should render a TextareaField with props', () => {
       hideRequired
       inputAttrs={{
         name: 'test',
-        rows: 15,
       }}
+      rows={15}
+      isAutoResizable
       isInline
       isInvalid
       isLabelHidden

--- a/packages/terra-form-textarea/tests/jest/__snapshots__/Textarea.test.jsx.snap
+++ b/packages/terra-form-textarea/tests/jest/__snapshots__/Textarea.test.jsx.snap
@@ -17,7 +17,6 @@ exports[`correctly applies the theme context className 1`] = `
     isInvalid={false}
     name={null}
     required={false}
-    rows={null}
     size="small"
   >
     <textarea

--- a/packages/terra-form-textarea/tests/jest/__snapshots__/TextareaField.test.jsx.snap
+++ b/packages/terra-form-textarea/tests/jest/__snapshots__/TextareaField.test.jsx.snap
@@ -30,7 +30,6 @@ exports[`correctly applies the theme context className 1`] = `
     label="Label"
     labelAttrs={Object {}}
     required={false}
-    rows={null}
     showOptional={false}
     size="small"
   >
@@ -115,7 +114,6 @@ exports[`correctly applies the theme context className 1`] = `
           key=".0"
           name={null}
           required={false}
-          rows={null}
           size="small"
         >
           <textarea
@@ -207,7 +205,6 @@ exports[`should render a default TextareaField component 1`] = `
     isInvalid={false}
     name={null}
     required={false}
-    rows={null}
     size="small"
   />
 </Field>
@@ -242,7 +239,6 @@ exports[`should render a disabled TextareaField component 1`] = `
     isInvalid={false}
     name={null}
     required={false}
-    rows={null}
     size="small"
   />
 </Field>
@@ -277,7 +273,6 @@ exports[`should render a disabled TextareaField component via inputAttrs 1`] = `
     isInvalid={false}
     name={null}
     required={false}
-    rows={null}
     size="small"
   />
 </Field>
@@ -319,7 +314,6 @@ exports[`should render a valid TextareaField with props 1`] = `
     name="test"
     onChange={[Function]}
     required={false}
-    rows={null}
     size="small"
     type="number"
     value="Value"

--- a/packages/terra-form-textarea/tests/jest/__snapshots__/TextareaField.test.jsx.snap
+++ b/packages/terra-form-textarea/tests/jest/__snapshots__/TextareaField.test.jsx.snap
@@ -9,6 +9,7 @@ exports[`correctly applies the theme context className 1`] = `
   }
 >
   <TextareaField
+    disableResize={false}
     disabled={false}
     error={null}
     errorIcon={
@@ -21,6 +22,7 @@ exports[`correctly applies the theme context className 1`] = `
     hideRequired={false}
     inputAttrs={Object {}}
     inputId="test-input"
+    isAutoResizable={false}
     isIncomplete={false}
     isInline={false}
     isInvalid={false}
@@ -28,7 +30,9 @@ exports[`correctly applies the theme context className 1`] = `
     label="Label"
     labelAttrs={Object {}}
     required={false}
+    rows={null}
     showOptional={false}
+    size="small"
   >
     <Field
       error={null}
@@ -161,7 +165,7 @@ exports[`should render a TextareaField with props 1`] = `
     disableResize={false}
     disabled={false}
     id="test-input"
-    isAutoResizable={false}
+    isAutoResizable={true}
     isIncomplete={false}
     isInvalid={false}
     name="test"


### PR DESCRIPTION
### Summary
Add first class props to textarea-field from textarea.
Closes #3291 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
Updated jest tests for validating the props.
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
