### PR TITLE
[terra-i18n] Avoid bad publish of intl-locales-supported

### DIFF
--- a/packages/terra-i18n/CHANGELOG.md
+++ b/packages/terra-i18n/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Unreleased
 
+* Fixed
+  * Avoid version 1.8.12 of intl-locales-supported as it is a bad publish.
+
 ## 4.35.0 - (January 5, 2021)
 
 * Fixed
- * Fixed broken links in documentation.
- 
+  * Fixed broken links in documentation.
+
 ## 4.34.0 - (December 8, 2020)
 
 * Changed

--- a/packages/terra-i18n/package.json
+++ b/packages/terra-i18n/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "intl": "^1.2.5",
-    "intl-locales-supported": "^1.8.4",
+    "intl-locales-supported": ">=1.8.4 <1.8.12 || ^1.8.13",
     "prop-types": "^15.5.8"
   },
   "scripts": {


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

When installing terra-i18n you will get this deprecation notice:

> npm WARN deprecated intl-locales-supported@1.8.12: bad publish

To avoid this version i've updated the dependencies. The new statement references 1.8.13 which has not been released, and might never get released, but it's referenced to pull in any future minor/patch versions.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
