### PR TITLE
[CONNECT-30881] Allow terra-list-item to render an id in the dom

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -89,6 +89,7 @@ Cerner Corporation
 - Jackson Nowotny [@JacksonJN]
 - Manjuraghavendra Sathrasala [@manjusr]
 - Saurabh Khare [@saurabhkhare86]
+- Andrew Shoemake [@andrewshoemake]
 
 Community
 
@@ -204,3 +205,4 @@ Community
 [@JacksonJN]: https://github.com/JacksonJN
 [@manjusr]: https://github.com/manjusr
 [@saurabhkhare86]: https://github.com/SaurabhKhare86
+[@andrewshoemake]: https://github.com/Andrew-Shoemake

--- a/packages/terra-list/src/ListItem.jsx
+++ b/packages/terra-list/src/ListItem.jsx
@@ -32,6 +32,10 @@ const propTypes = {
   // eslint-disable-next-line react/forbid-prop-types
   metaData: PropTypes.object,
   /**
+   * An identifier used to identify the list item
+   */
+  id: PropTypes.string,
+  /**
    * Function callback for when the appropriate click or key action is performed.
    * Callback contains the javascript evnt and prop metadata, e.g. onSelect(event, metaData)
    */
@@ -71,6 +75,7 @@ const ListItem = ({
   isSelected,
   isSelectable,
   metaData,
+  id,
   onBlur,
   onClick,
   onKeyDown,
@@ -104,7 +109,7 @@ const ListItem = ({
   }
 
   return (
-    <li {...customProps} {...attrSpread} className={listItemClassNames} ref={refCallback}>
+    <li {...customProps} {...attrSpread} className={listItemClassNames} ref={refCallback} id={id}>
       <div className={cx('item-fill')} key="item-fill">{children}</div>
       {hasChevron && <div className={cx('item-end')} key="item-end"><span className={cx('chevron')}><ChevronRight height="1em" width="1em" /></span></div>}
     </li>

--- a/packages/terra-list/src/terra-dev-site/doc/example/ListItem.jsx
+++ b/packages/terra-list/src/terra-dev-site/doc/example/ListItem.jsx
@@ -10,23 +10,27 @@ const ListSectionExample = () => (
   <List role="listbox" aria-label="example-label">
     <Item
       key="default"
+      id="default_list_item"
     >
       <Placeholder title="Default ListItem" className={cx('placeholder')} />
     </Item>
     <Item
       key="chevron"
+      id="chevron_list_item"
       hasChevron
     >
       <Placeholder title="Chevron ListItem" className={cx('placeholder')} />
     </Item>
     <Item
       key="selectable"
+      id="selectable_list_item"
       isSelectable
     >
       <Placeholder title="Selectable ListItem" className={cx('placeholder')} />
     </Item>
     <Item
       key="selected"
+      id="selected_list_item"
       isSelectable
       isSelected
     >

--- a/packages/terra-list/tests/jest/ListItem.test.jsx
+++ b/packages/terra-list/tests/jest/ListItem.test.jsx
@@ -24,6 +24,11 @@ it('should render with isSelectable', () => {
   expect(shallowComponent).toMatchSnapshot();
 });
 
+it('should render with an id', () => {
+  const shallowComponent = shallow(<ListItem id="test_id" />);
+  expect(shallowComponent).toMatchSnapshot();
+});
+
 it('should render with hasChevron', () => {
   const shallowComponent = shallow(<ListItem hasChevron />);
   expect(shallowComponent).toMatchSnapshot();

--- a/packages/terra-list/tests/jest/__snapshots__/ListItem.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/ListItem.test.jsx.snap
@@ -25,6 +25,18 @@ exports[`correctly applies the theme context className 1`] = `
 </ThemeContextProvider>
 `;
 
+exports[`should render with an id 1`] = `
+<li
+  className="list-item"
+  id="test_id"
+>
+  <div
+    className="item-fill"
+    key="item-fill"
+  />
+</li>
+`;
+
 exports[`should render with callback functions 1`] = `
 <li
   aria-selected={false}


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

Updating terra-list-item to allow passing an id to the li of terra-list-item element for easier feature/element tracking using Pendo

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
N/A

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

Added an additional unit test to validate the id is being set, inspected the dom to validate the id being set, and ran wdio tests to ensure no UI broke.

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
