### PR TITLE
[terra-form-select] Fixed focus not getting remove in IE for Search and Combobox variants.

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed `focus` issue in IE for search and combobox variants.
+
 ## 6.26.0 - (February 17, 2021)
 
 * Fixed

--- a/packages/terra-form-select/src/combobox/Frame.jsx
+++ b/packages/terra-form-select/src/combobox/Frame.jsx
@@ -214,7 +214,7 @@ class Frame extends React.Component {
    * Handles the blur event.
    */
   handleBlur(event) {
-    const { relatedTarget } = event;
+    const relatedTarget = event.relatedTarget || document.activeElement;
 
     // The check for dropdown.contains(activeElement) is necessary to prevent IE11 from closing dropdown on click of scrollbar in certain contexts.
     if (this.dropdown && (this.dropdown === document.activeElement && this.dropdown.contains(document.activeElement))) {

--- a/packages/terra-form-select/src/search/Frame.jsx
+++ b/packages/terra-form-select/src/search/Frame.jsx
@@ -204,7 +204,7 @@ class Frame extends React.Component {
    * Handles the blur event.
    */
   handleBlur(event) {
-    const { relatedTarget } = event;
+    const relatedTarget = event.relatedTarget || document.activeElement;
 
     // The check for dropdown.contains(activeElement) is necessary to prevent IE11 from closing dropdown on click of scrollbar in certain contexts.
     if (this.dropdown && (this.dropdown === document.activeElement && this.dropdown.contains(document.activeElement))) {


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This PR fixes focus `not getting removed` in IE for search and combobox variants by making `relatedTarget` to fallback to `document.activeElement` when `event.relatedTarget` is null.

In IE the relatedTarget for Search and Combobox is `null` due to which [this](https://github.com/cerner/terra-core/blob/main/packages/terra-form-select/src/search/Frame.jsx#L217) condition returns `true` due to `this.selectMenu` for these 2 variants is also null.
<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #3366 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
Tested on:
IE and Chrome in Windows10.
Safari and Chrome in Mac.

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
