### PR TITLE
tabIndex is honored unless the button is disabled

### DIFF
--- a/packages/terra-button/CHANGELOG.md
+++ b/packages/terra-button/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* Changed
+  * TabIndex is honored unless the button is disabled.
 
 ## 3.60.0 - (November 2, 2021)
 

--- a/packages/terra-button/src/Button.jsx
+++ b/packages/terra-button/src/Button.jsx
@@ -307,7 +307,7 @@ class Button extends React.Component {
         className={buttonClasses}
         type={type}
         disabled={isDisabled}
-        tabIndex={isDisabled ? '-1' : undefined}
+        tabIndex={isDisabled ? '-1' : customProps.tabIndex}
         aria-disabled={isDisabled}
         aria-label={ariaLabel}
         onKeyDown={this.handleKeyDown}

--- a/packages/terra-button/tests/jest/Button.test.jsx
+++ b/packages/terra-button/tests/jest/Button.test.jsx
@@ -84,6 +84,11 @@ it('should render as disabled when set', () => {
   expect(button).toMatchSnapshot();
 });
 
+it('should render with tabIndex when set', () => {
+  const button = shallow(<Button text="Tab Index" tabIndex="-1" />);
+  expect(button).toMatchSnapshot();
+});
+
 // Prop Tests
 it('should have the class neutral', () => {
   const button = shallow(<Button text="text" />);

--- a/packages/terra-button/tests/jest/__snapshots__/Button.test.jsx.snap
+++ b/packages/terra-button/tests/jest/__snapshots__/Button.test.jsx.snap
@@ -728,3 +728,29 @@ exports[`should render text then an icon when reversed 1`] = `
   </span>
 </button>
 `;
+
+exports[`should render with tabIndex when set 1`] = `
+<button
+  aria-disabled={false}
+  className="button neutral"
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  tabIndex="-1"
+  type="button"
+>
+  <span
+    className="button-label text-only"
+  >
+    <span
+      className=""
+    >
+      Tab Index
+    </span>
+  </span>
+</button>
+`;


### PR DESCRIPTION
### Summary
This is my 2nd try at fixing tabIndex so that it can be set to -1 even if the button is enabled.

### Deployment Link
https://terra-core-tabindex2-xjy2tsayd.herokuapp.com/

### Testing
See new spec and snap.