### PR TITLE
Removed tabIndex="-1" from form-field  divs

### DIFF
--- a/packages/terra-form-field/CHANGELOG.md
+++ b/packages/terra-form-field/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Changed
   * Migrate docs to terra-core-docs.
+  * No longer assign tabIndex -1 to the error and help divs.
 
 ## 4.20.0 - (September 21, 2021)
 

--- a/packages/terra-form-field/CHANGELOG.md
+++ b/packages/terra-form-field/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 * Changed
   * No longer assign tabIndex -1 to the error and help divs.
-
-## Unreleased
-
-* Changed
   * Migrate docs to terra-core-docs.
 
 ## 4.20.0 - (September 21, 2021)

--- a/packages/terra-form-field/CHANGELOG.md
+++ b/packages/terra-form-field/CHANGELOG.md
@@ -3,8 +3,12 @@
 ## Unreleased
 
 * Changed
-  * Migrate docs to terra-core-docs.
   * No longer assign tabIndex -1 to the error and help divs.
+
+## Unreleased
+
+* Changed
+  * Migrate docs to terra-core-docs.
 
 ## 4.20.0 - (September 21, 2021)
 

--- a/packages/terra-form-field/src/Field.jsx
+++ b/packages/terra-form-field/src/Field.jsx
@@ -200,8 +200,8 @@ const Field = (props) => {
     <div style={customStyles} {...customProps} className={fieldClasses}>
       {labelGroup}
       {content}
-      {isInvalid && error && <div aria-live="assertive" tabIndex="-1" id={htmlFor ? `${htmlFor}-error` : undefined} className={cx('error-text')}>{error}</div>}
-      {help && <div tabIndex="-1" id={htmlFor ? `${htmlFor}-help` : undefined} className={cx('help-text')}>{help}</div>}
+      {isInvalid && error && <div aria-live="assertive" id={htmlFor ? `${htmlFor}-error` : undefined} className={cx('error-text')}>{error}</div>}
+      {help && <div id={htmlFor ? `${htmlFor}-help` : undefined} className={cx('help-text')}>{help}</div>}
     </div>
   );
   /* eslint-enable react/forbid-dom-props */

--- a/packages/terra-form-field/tests/jest/__snapshots__/Field.test.jsx.snap
+++ b/packages/terra-form-field/tests/jest/__snapshots__/Field.test.jsx.snap
@@ -215,7 +215,6 @@ exports[`should render a field help message 1`] = `
   <div
     className="help-text"
     id="test-help"
-    tabIndex="-1"
   >
     Help Text
   </div>
@@ -275,14 +274,12 @@ exports[`should render a field in error 1`] = `
     aria-live="assertive"
     className="error-text"
     id="test-error"
-    tabIndex="-1"
   >
     Error Text
   </div>
   <div
     className="help-text"
     id="test-help"
-    tabIndex="-1"
   >
     Help Text
   </div>
@@ -674,14 +671,12 @@ exports[`should render a field with a hidden label in error 1`] = `
     aria-live="assertive"
     className="error-text"
     id="test-error"
-    tabIndex="-1"
   >
     Error Text
   </div>
   <div
     className="help-text"
     id="test-help"
-    tabIndex="-1"
   >
     Help Text
   </div>
@@ -835,14 +830,12 @@ exports[`should render a required field in error 1`] = `
     aria-live="assertive"
     className="error-text"
     id="test-error"
-    tabIndex="-1"
   >
     Error Text
   </div>
   <div
     className="help-text"
     id="test-help"
-    tabIndex="-1"
   >
     Help Text
   </div>
@@ -1275,14 +1268,12 @@ exports[`should render a required field with a hidden label in error 1`] = `
     aria-live="assertive"
     className="error-text"
     id="test-error"
-    tabIndex="-1"
   >
     Error Text
   </div>
   <div
     className="help-text"
     id="test-help"
-    tabIndex="-1"
   >
     Help Text
   </div>
@@ -1443,7 +1434,6 @@ exports[`should render an inline field with most of the possible props are passe
   <div
     className="help-text"
     id="test-help"
-    tabIndex="-1"
   >
     This is a test input
   </div>
@@ -2361,14 +2351,12 @@ exports[`should render an optional field in error 1`] = `
     aria-live="assertive"
     className="error-text"
     id="test-error"
-    tabIndex="-1"
   >
     Error Text
   </div>
   <div
     className="help-text"
     id="test-help"
-    tabIndex="-1"
   >
     Help Text
   </div>

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 * Changed
   * Help text div no longer has a tabIndex of -1.
-
-* Changed
   * Updated dependencies to not be hard-coded.
 
 ## 6.35.0 - (September 21, 2021)

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 * Changed
+  * Help text div no longer has a tabIndex of -1.
+
+* Changed
   * Updated dependencies to not be hard-coded.
 
 ## 6.35.0 - (September 21, 2021)

--- a/packages/terra-form-select/tests/jest/__snapshots__/SelectField.test.jsx.snap
+++ b/packages/terra-form-select/tests/jest/__snapshots__/SelectField.test.jsx.snap
@@ -389,7 +389,6 @@ exports[`should render a multiple SelectField component that limits the selectio
   <div
     className="help-text"
     id="select-id-help"
-    tabIndex="-1"
   >
     <span>
       Terra.form.select.maxSelectionHelp


### PR DESCRIPTION
### Summary
For some reason we were hard-coding tabIndex="-1" into the devs for Form Field's help and error text. This caused the accessibility tree to give the div a duplicative name to that div - this caused my screen reader to read extra junk.

I removed the -1, because divs aren't focusable anyway. Removing the tabIndex fixed the accessibility tree without changes keyboard navigation.

### Deployment Link
https://terra-core-form-field-d-w8i5zv.herokuapp.com/

### Testing
See updated snaps. I also manually checked with my screen reader. Not sure if there is a way to probe the accessibility tree in Jest or not.
