### PR TITLE
Add terra-core-docs whitespace layout helper

### DIFF
--- a/packages/terra-core-docs/src/terra-dev-site/common/layout-helpers/Whitespace.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/common/layout-helpers/Whitespace.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import classNamesBind from 'classnames/bind';
+import styles from './Whitespace.module.scss';
+
+const cx = classNamesBind.bind(styles);
+
+const propTypes = {
+  /**
+   * Sets the height of a newline spacer, equivalent to number of lines based on lineheight, not fontsize.
+   * One of `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, default is `1`.
+   */
+  newline: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8]),
+};
+
+const defaultProps = {
+  newline: 1,
+};
+
+const Whitespace = ({
+  newline,
+  ...customProps
+}) => {
+  const WhitespaceClassNames = classNames(
+    cx(
+      'whitespace',
+      `newline-${newline}`,
+    ),
+    customProps.className,
+  );
+
+  return <div {...customProps} className={WhitespaceClassNames} aria-hidden="true" />;
+};
+
+Whitespace.propTypes = propTypes;
+Whitespace.defaultProps = defaultProps;
+
+export default Whitespace;

--- a/packages/terra-core-docs/src/terra-dev-site/common/layout-helpers/Whitespace.module.scss
+++ b/packages/terra-core-docs/src/terra-dev-site/common/layout-helpers/Whitespace.module.scss
@@ -1,0 +1,48 @@
+/* 
+ * SASS calculation 
+ * based on lineheight of 20px (1.42857) for fontsize of 14px (1rem)
+ */
+@mixin terra-newline-height ($number-of-lines) {
+  height: 1.4285714286em * $number-of-lines;
+}
+
+:local {
+  .whitespace {
+    display: block;
+    margin: 0;
+    min-height: 0;
+    padding: 0;
+  }
+
+  .newline-1 {
+    @include terra-newline-height(1);
+  }
+
+  .newline-2 {
+    @include terra-newline-height(2);
+  }
+
+  .newline-3 {
+    @include terra-newline-height(3);
+  }
+
+  .newline-4 {
+    @include terra-newline-height(4);
+  }
+
+  .newline-5 {
+    @include terra-newline-height(5);
+  }
+
+  .newline-6 {
+    @include terra-newline-height(6);
+  }
+
+  .newline-7 {
+    @include terra-newline-height(7);
+  }
+
+  .newline-8 {
+    @include terra-newline-height(8);
+  }
+}


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

Adds new docs page whitespace layout-helper to create more hierarchy and visual separation between sections.

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/
