### PR TITLE
Removing webpack devServer manual port assignment

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,10 +11,6 @@ const coreConfig = (env = {}) => ({
       defaultLocale: env.defaultLocale,
     }),
   ],
-  devServer: {
-    host: '0.0.0.0',
-    port: 8083,
-  },
 });
 
 const mergedConfig = (env, argv) => (


### PR DESCRIPTION
### Summary
Removing manual port assignment meant only for local testing.


### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
<!--- https://terra-core-deployed-pr-#.herokuapp.com/ -->

