### PR TITLE
Add programmatic context to communicate hierarchal relationships

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -5,26 +5,13 @@
 * Added
   * Added Higher Order examples for `terra-profile-image`.
   * Added Accessibility Guide for `terra-Profile-image`.
-
-* Changed
-  * Added Accessibility Guide for `terra-Profile-image`.
+  * Added ariaLabel and ariaLabelledBy examples for `terra-toolbar`.
+  * Added Accordion Examples for `terra-section-header`.
+  * Added accessibility guide for `terra-divider`.
 
 * Changed
   * Updated `terra-list` section guide to not use listbox role.
-
-* Changed
-  * Added Higher Order examples for `terra-profile-image`.
-  * Added Accessibility Guide for `terra-Profile-image`.
-
-* Changed
-  * Added ariaLabel and ariaLabelledBy examples for `terra-toolbar`.
-
-* Changed
   * Updated `terra-divider` tests and doc examples to include heading level prop.
-
-* Added
-  * Added Accordion Examples for `terra-section-header`.
-  * Added accessibility guide for `terra-divider`
 
 ## 1.15.1 - (September 8, 2022)
 

--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -7,6 +7,16 @@
   * Added Accessibility Guide for `terra-Profile-image`.
 
 * Changed
+  * Added Accessibility Guide for `terra-Profile-image`.
+
+* Changed
+  * Updated `terra-list` section guide to not use listbox role.
+
+* Changed
+  * Added Higher Order examples for `terra-profile-image`.
+  * Added Accessibility Guide for `terra-Profile-image`.
+
+* Changed
   * Added ariaLabel and ariaLabelledBy examples for `terra-toolbar`.
 
 * Changed

--- a/packages/terra-core-docs/src/terra-dev-site/doc/list/guides/SectionList.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/list/guides/SectionList.jsx
@@ -48,7 +48,7 @@ class SectionList extends React.Component {
 
   render() {
     return (
-      <List role="listbox">
+      <List>
         {this.createSections(mockData)}
       </List>
     );

--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Sections and subsections updated to add programmatic context to communicate hierarchal relationships
+
 ## 4.51.5 - (July 5, 2022)
 
 * Changed

--- a/packages/terra-list/src/ListSection.jsx
+++ b/packages/terra-list/src/ListSection.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import classNamesBind from 'classnames/bind';
+import ThemeContext from 'terra-theme-context';
 import SectionHeader from './ListSectionHeader';
+import styles from './List.module.scss';
+
+const cx = classNamesBind.bind(styles);
 
 const propTypes = {
   /**
@@ -57,11 +63,24 @@ const ListSection = ({
     sectionItems = children;
   }
 
+  const theme = React.useContext(ThemeContext);
+  const listClassNames = classNames(
+    cx(
+      'list',
+      theme.className,
+    ),
+    customProps.className,
+  );
+
   return (
-    <React.Fragment>
+    <>
       <SectionHeader {...customProps} isCollapsible={isCollapsible} isCollapsed={isCollapsed} />
-      {sectionItems}
-    </React.Fragment>
+      <li>
+        <ul {...customProps} className={listClassNames}>
+          {sectionItems}
+        </ul>
+      </li>
+    </>
   );
 };
 

--- a/packages/terra-list/src/ListSectionHeader.jsx
+++ b/packages/terra-list/src/ListSectionHeader.jsx
@@ -90,7 +90,7 @@ const ListSectionHeader = ({
 
   const attrSpread = {};
   const Element = `h${level}`;
-  let titleElement = <Element className={cx('title')}>{title}</Element>;
+  const titleElement = <div className={cx('fill')}>{title}</div>;
   let accordionIcon;
   if (isCollapsible) {
     accordionIcon = (
@@ -98,27 +98,25 @@ const ListSectionHeader = ({
         <span className={cx(['accordion-icon', { 'is-open': !isCollapsed }])} />
       </div>
     );
-    titleElement = (
-      <div className={cx('fill')}>
-        {titleElement}
-      </div>
-    );
 
     attrSpread.onClick = ListUtils.wrappedOnClickForItem(onClick, onSelect, metaData);
     attrSpread.onKeyDown = ListUtils.wrappedOnKeyDownForItem(onKeyDown, onSelect, metaData);
     attrSpread.tabIndex = '0';
-    attrSpread.role = 'heading';
+    attrSpread.role = 'button';
     attrSpread['aria-expanded'] = !isCollapsed;
-    attrSpread['aria-level'] = 1;
     attrSpread['data-item-show-focus'] = 'true';
     attrSpread.onBlur = ListUtils.wrappedEventCallback(onBlur, event => event.currentTarget.setAttribute('data-item-show-focus', 'true'));
     attrSpread.onMouseDown = ListUtils.wrappedEventCallback(onMouseDown, event => event.currentTarget.setAttribute('data-item-show-focus', 'false'));
   }
 
   return (
-    <li {...customProps} {...attrSpread} className={sectionHeaderClassNames} ref={refCallback}>
-      {accordionIcon}
-      {titleElement}
+    <li>
+      <Element className={cx('title')}>
+        <div {...customProps} {...attrSpread} className={sectionHeaderClassNames} ref={refCallback}>
+          {accordionIcon}
+          {titleElement}
+        </div>
+      </Element>
     </li>
   );
 };

--- a/packages/terra-list/src/ListSubsection.jsx
+++ b/packages/terra-list/src/ListSubsection.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import classNamesBind from 'classnames/bind';
+import ThemeContext from 'terra-theme-context';
 import SubsectionHeader from './ListSubsectionHeader';
+import styles from './List.module.scss';
+
+const cx = classNamesBind.bind(styles);
 
 const propTypes = {
   /**
@@ -57,11 +63,24 @@ const ListSubsection = ({
     sectionItems = children;
   }
 
+  const theme = React.useContext(ThemeContext);
+  const listClassNames = classNames(
+    cx(
+      'list',
+      theme.className,
+    ),
+    customProps.className,
+  );
+
   return (
-    <React.Fragment>
+    <>
       <SubsectionHeader {...customProps} isCollapsible={isCollapsible} isCollapsed={isCollapsed} />
-      {sectionItems}
-    </React.Fragment>
+      <li>
+        <ul {...customProps} className={listClassNames}>
+          {sectionItems}
+        </ul>
+      </li>
+    </>
   );
 };
 

--- a/packages/terra-list/src/ListSubsectionHeader.jsx
+++ b/packages/terra-list/src/ListSubsectionHeader.jsx
@@ -90,7 +90,7 @@ const ListSubsectionHeader = ({
 
   const attrSpread = {};
   const Element = `h${level}`;
-  let titleElement = <Element className={cx('title')}>{title}</Element>;
+  const titleElement = <div className={cx('fill')}>{title}</div>;
   let accordionIcon;
   if (isCollapsible) {
     accordionIcon = (
@@ -98,27 +98,25 @@ const ListSubsectionHeader = ({
         <span className={cx(['accordion-icon', { 'is-open': !isCollapsed }])} />
       </div>
     );
-    titleElement = (
-      <div className={cx('fill')}>
-        {titleElement}
-      </div>
-    );
 
     attrSpread.onClick = ListUtils.wrappedOnClickForItem(onClick, onSelect, metaData);
     attrSpread.onKeyDown = ListUtils.wrappedOnKeyDownForItem(onKeyDown, onSelect, metaData);
     attrSpread.tabIndex = '0';
-    attrSpread.role = 'heading';
+    attrSpread.role = 'button';
     attrSpread['aria-expanded'] = !isCollapsed;
-    attrSpread['aria-level'] = 2;
     attrSpread['data-item-show-focus'] = 'true';
     attrSpread.onBlur = ListUtils.wrappedEventCallback(onBlur, event => event.currentTarget.setAttribute('data-item-show-focus', 'true'));
     attrSpread.onMouseDown = ListUtils.wrappedEventCallback(onMouseDown, event => event.currentTarget.setAttribute('data-item-show-focus', 'false'));
   }
 
   return (
-    <li {...customProps} {...attrSpread} className={sectionHeaderClassNames} ref={refCallback}>
-      {accordionIcon}
-      {titleElement}
+    <li>
+      <Element className={cx('title')}>
+        <div {...customProps} {...attrSpread} className={sectionHeaderClassNames} ref={refCallback}>
+          {accordionIcon}
+          {titleElement}
+        </div>
+      </Element>
     </li>
   );
 };

--- a/packages/terra-list/tests/jest/ListSectionHeader.test.jsx
+++ b/packages/terra-list/tests/jest/ListSectionHeader.test.jsx
@@ -28,12 +28,12 @@ it('should render with callback functions', () => {
   const mockCallBack = jest.fn();
 
   const shallowComponent = shallow(
-    <ListSectionHeader title="test" isCollapsible onSelect={mockCallBack} refCallback={jest.fn()} />,
+    <ListSectionHeader title="test" level={1} isCollapsible onSelect={mockCallBack} refCallback={jest.fn()} />,
   );
   expect(shallowComponent).toMatchSnapshot();
-  shallowComponent.find('li').simulate('click');
-  shallowComponent.find('li').simulate('keydown', { nativeEvent: { keyCode: 13 } });
-  shallowComponent.find('li').simulate('keydown', { nativeEvent: { keyCode: 32 } });
+  shallowComponent.find('div').first().simulate('click');
+  shallowComponent.find('div').first().simulate('keydown', { nativeEvent: { keyCode: 13 } });
+  shallowComponent.find('div').first().simulate('keydown', { nativeEvent: { keyCode: 32 } });
   expect(mockCallBack.mock.calls.length).toEqual(3);
 });
 

--- a/packages/terra-list/tests/jest/ListSubsectionHeader.test.jsx
+++ b/packages/terra-list/tests/jest/ListSubsectionHeader.test.jsx
@@ -31,9 +31,9 @@ it('should render with callback functions', () => {
     <ListSubsectionHeader title="test" isCollapsible onSelect={mockCallBack} refCallback={jest.fn()} />,
   );
   expect(shallowComponent).toMatchSnapshot();
-  shallowComponent.find('li').simulate('click');
-  shallowComponent.find('li').simulate('keydown', { nativeEvent: { keyCode: 13 } });
-  shallowComponent.find('li').simulate('keydown', { nativeEvent: { keyCode: 32 } });
+  shallowComponent.find('div').first().simulate('click');
+  shallowComponent.find('div').first().simulate('keydown', { nativeEvent: { keyCode: 13 } });
+  shallowComponent.find('div').first().simulate('keydown', { nativeEvent: { keyCode: 32 } });
   expect(mockCallBack.mock.calls.length).toEqual(3);
 });
 

--- a/packages/terra-list/tests/jest/__snapshots__/ListSection.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/ListSection.test.jsx.snap
@@ -20,16 +20,29 @@ exports[`correctly applies the theme context className 1`] = `
       level={1}
       title="test"
     >
-      <li
-        className="section-header orion-fusion-theme"
-      >
+      <li>
         <h1
           className="title"
         >
-          test
+          <div
+            className="section-header orion-fusion-theme"
+          >
+            <div
+              className="fill"
+            >
+              test
+            </div>
+          </div>
         </h1>
       </li>
     </ListSectionHeader>
+    <li>
+      <ul
+        className="list orion-fusion-theme"
+        level={1}
+        title="test"
+      />
+    </li>
   </ListSection>
 </ThemeContextProvider>
 `;
@@ -44,6 +57,15 @@ exports[`should render with callback functions 1`] = `
     refCallback={[MockFunction]}
     title="test"
   />
+  <li>
+    <ul
+      className="list"
+      level={1}
+      onSelect={[MockFunction]}
+      refCallback={[MockFunction]}
+      title="test"
+    />
+  </li>
 </Fragment>
 `;
 
@@ -55,6 +77,13 @@ exports[`should render with isCollapsed 1`] = `
     level={1}
     title="test"
   />
+  <li>
+    <ul
+      className="list"
+      level={1}
+      title="test"
+    />
+  </li>
 </Fragment>
 `;
 
@@ -66,6 +95,13 @@ exports[`should render with isCollapsible 1`] = `
     level={1}
     title="test"
   />
+  <li>
+    <ul
+      className="list"
+      level={1}
+      title="test"
+    />
+  </li>
 </Fragment>
 `;
 
@@ -77,36 +113,44 @@ exports[`should render with items 1`] = `
     level={1}
     title="test"
   />
-  <ListItem
-    hasChevron={false}
-    isSelectable={false}
-    isSelected={false}
-    key="123"
-  />
-  <ListItem
-    hasChevron={false}
-    isSelectable={false}
-    isSelected={false}
-    key="124"
-  />
-  <ListItem
-    hasChevron={false}
-    isSelectable={false}
-    isSelected={false}
-    key="125"
-  />
-  <ListItem
-    hasChevron={false}
-    isSelectable={false}
-    isSelected={false}
-    key="126"
-  />
-  <ListItem
-    hasChevron={false}
-    isSelectable={false}
-    isSelected={false}
-    key="127"
-  />
+  <li>
+    <ul
+      className="list"
+      level={1}
+      title="test"
+    >
+      <ListItem
+        hasChevron={false}
+        isSelectable={false}
+        isSelected={false}
+        key="123"
+      />
+      <ListItem
+        hasChevron={false}
+        isSelectable={false}
+        isSelected={false}
+        key="124"
+      />
+      <ListItem
+        hasChevron={false}
+        isSelectable={false}
+        isSelected={false}
+        key="125"
+      />
+      <ListItem
+        hasChevron={false}
+        isSelectable={false}
+        isSelected={false}
+        key="126"
+      />
+      <ListItem
+        hasChevron={false}
+        isSelectable={false}
+        isSelected={false}
+        key="127"
+      />
+    </ul>
+  </li>
 </Fragment>
 `;
 
@@ -118,6 +162,13 @@ exports[`should render with level 1`] = `
     level={3}
     title="test"
   />
+  <li>
+    <ul
+      className="list"
+      level={3}
+      title="test"
+    />
+  </li>
 </Fragment>
 `;
 
@@ -129,5 +180,12 @@ exports[`should render with no items 1`] = `
     level={1}
     title="test"
   />
+  <li>
+    <ul
+      className="list"
+      level={1}
+      title="test"
+    />
+  </li>
 </Fragment>
 `;

--- a/packages/terra-list/tests/jest/__snapshots__/ListSectionHeader.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/ListSectionHeader.test.jsx.snap
@@ -14,13 +14,19 @@ exports[`correctly applies the theme context className 1`] = `
     level={1}
     title="test"
   >
-    <li
-      className="section-header orion-fusion-theme"
-    >
+    <li>
       <h1
         className="title"
       >
-        test
+        <div
+          className="section-header orion-fusion-theme"
+        >
+          <div
+            className="fill"
+          >
+            test
+          </div>
+        </div>
       </h1>
     </li>
   </ListSectionHeader>
@@ -28,99 +34,119 @@ exports[`correctly applies the theme context className 1`] = `
 `;
 
 exports[`should render default 1`] = `
-<li
-  className="section-header"
->
+<li>
   <h1
     className="title"
   >
-    test
+    <div
+      className="section-header"
+    >
+      <div
+        className="fill"
+      >
+        test
+      </div>
+    </div>
   </h1>
 </li>
 `;
 
 exports[`should render with callback functions 1`] = `
-<li
-  aria-expanded={true}
-  aria-level={1}
-  className="section-header is-collapsible"
-  data-item-show-focus="true"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onMouseDown={[Function]}
-  role="heading"
-  tabIndex="0"
->
-  <div
-    className="start"
+<li>
+  <h1
+    className="title"
   >
-    <span
-      className="accordion-icon is-open"
-    />
-  </div>
-  <div
-    className="fill"
-  >
-    <h1
-      className="title"
+    <div
+      aria-expanded={true}
+      className="section-header is-collapsible"
+      data-item-show-focus="true"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onMouseDown={[Function]}
+      role="button"
+      tabIndex="0"
     >
-      test
-    </h1>
-  </div>
+      <div
+        className="start"
+      >
+        <span
+          className="accordion-icon is-open"
+        />
+      </div>
+      <div
+        className="fill"
+      >
+        test
+      </div>
+    </div>
+  </h1>
 </li>
 `;
 
 exports[`should render with isCollapsed 1`] = `
-<li
-  className="section-header"
->
+<li>
   <h1
     className="title"
   >
-    test
+    <div
+      className="section-header"
+    >
+      <div
+        className="fill"
+      >
+        test
+      </div>
+    </div>
   </h1>
 </li>
 `;
 
 exports[`should render with isCollapsible 1`] = `
-<li
-  aria-expanded={true}
-  aria-level={1}
-  className="section-header is-collapsible"
-  data-item-show-focus="true"
-  onBlur={[Function]}
-  onMouseDown={[Function]}
-  role="heading"
-  tabIndex="0"
->
-  <div
-    className="start"
+<li>
+  <h1
+    className="title"
   >
-    <span
-      className="accordion-icon is-open"
-    />
-  </div>
-  <div
-    className="fill"
-  >
-    <h1
-      className="title"
+    <div
+      aria-expanded={true}
+      className="section-header is-collapsible"
+      data-item-show-focus="true"
+      onBlur={[Function]}
+      onMouseDown={[Function]}
+      role="button"
+      tabIndex="0"
     >
-      test
-    </h1>
-  </div>
+      <div
+        className="start"
+      >
+        <span
+          className="accordion-icon is-open"
+        />
+      </div>
+      <div
+        className="fill"
+      >
+        test
+      </div>
+    </div>
+  </h1>
 </li>
 `;
 
 exports[`should render with level 1`] = `
-<li
-  className="section-header"
->
+<li>
   <h3
     className="title"
   >
-    test
+    <div
+      className="section-header"
+    >
+      <div
+        className="fill"
+      >
+        test
+      </div>
+    </div>
   </h3>
 </li>
 `;

--- a/packages/terra-list/tests/jest/__snapshots__/ListSubsection.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/ListSubsection.test.jsx.snap
@@ -20,16 +20,29 @@ exports[`correctly applies the theme context className 1`] = `
       level={2}
       title="test"
     >
-      <li
-        className="subsection-header orion-fusion-theme"
-      >
+      <li>
         <h2
           className="title"
         >
-          test
+          <div
+            className="subsection-header orion-fusion-theme"
+          >
+            <div
+              className="fill"
+            >
+              test
+            </div>
+          </div>
         </h2>
       </li>
     </ListSubsectionHeader>
+    <li>
+      <ul
+        className="list orion-fusion-theme"
+        level={2}
+        title="test"
+      />
+    </li>
   </ListSubsection>
 </ThemeContextProvider>
 `;
@@ -44,6 +57,15 @@ exports[`should render with callback functions 1`] = `
     refCallback={[MockFunction]}
     title="test"
   />
+  <li>
+    <ul
+      className="list"
+      level={2}
+      onSelect={[MockFunction]}
+      refCallback={[MockFunction]}
+      title="test"
+    />
+  </li>
 </Fragment>
 `;
 
@@ -55,6 +77,13 @@ exports[`should render with isCollapsed 1`] = `
     level={2}
     title="test"
   />
+  <li>
+    <ul
+      className="list"
+      level={2}
+      title="test"
+    />
+  </li>
 </Fragment>
 `;
 
@@ -66,6 +95,13 @@ exports[`should render with isCollapsible 1`] = `
     level={2}
     title="test"
   />
+  <li>
+    <ul
+      className="list"
+      level={2}
+      title="test"
+    />
+  </li>
 </Fragment>
 `;
 
@@ -77,36 +113,44 @@ exports[`should render with items 1`] = `
     level={2}
     title="test"
   />
-  <ListItem
-    hasChevron={false}
-    isSelectable={false}
-    isSelected={false}
-    key="123"
-  />
-  <ListItem
-    hasChevron={false}
-    isSelectable={false}
-    isSelected={false}
-    key="124"
-  />
-  <ListItem
-    hasChevron={false}
-    isSelectable={false}
-    isSelected={false}
-    key="125"
-  />
-  <ListItem
-    hasChevron={false}
-    isSelectable={false}
-    isSelected={false}
-    key="126"
-  />
-  <ListItem
-    hasChevron={false}
-    isSelectable={false}
-    isSelected={false}
-    key="127"
-  />
+  <li>
+    <ul
+      className="list"
+      level={2}
+      title="test"
+    >
+      <ListItem
+        hasChevron={false}
+        isSelectable={false}
+        isSelected={false}
+        key="123"
+      />
+      <ListItem
+        hasChevron={false}
+        isSelectable={false}
+        isSelected={false}
+        key="124"
+      />
+      <ListItem
+        hasChevron={false}
+        isSelectable={false}
+        isSelected={false}
+        key="125"
+      />
+      <ListItem
+        hasChevron={false}
+        isSelectable={false}
+        isSelected={false}
+        key="126"
+      />
+      <ListItem
+        hasChevron={false}
+        isSelectable={false}
+        isSelected={false}
+        key="127"
+      />
+    </ul>
+  </li>
 </Fragment>
 `;
 
@@ -118,6 +162,13 @@ exports[`should render with level 1`] = `
     level={3}
     title="test"
   />
+  <li>
+    <ul
+      className="list"
+      level={3}
+      title="test"
+    />
+  </li>
 </Fragment>
 `;
 
@@ -129,5 +180,12 @@ exports[`should render with no items 1`] = `
     level={2}
     title="test"
   />
+  <li>
+    <ul
+      className="list"
+      level={2}
+      title="test"
+    />
+  </li>
 </Fragment>
 `;

--- a/packages/terra-list/tests/jest/__snapshots__/ListSubsectionHeader.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/ListSubsectionHeader.test.jsx.snap
@@ -14,13 +14,19 @@ exports[`correctly applies the theme context className 1`] = `
     level={2}
     title="test"
   >
-    <li
-      className="subsection-header orion-fusion-theme"
-    >
+    <li>
       <h2
         className="title"
       >
-        test
+        <div
+          className="subsection-header orion-fusion-theme"
+        >
+          <div
+            className="fill"
+          >
+            test
+          </div>
+        </div>
       </h2>
     </li>
   </ListSubsectionHeader>
@@ -28,99 +34,119 @@ exports[`correctly applies the theme context className 1`] = `
 `;
 
 exports[`should render default 1`] = `
-<li
-  className="subsection-header"
->
+<li>
   <h2
     className="title"
   >
-    test
+    <div
+      className="subsection-header"
+    >
+      <div
+        className="fill"
+      >
+        test
+      </div>
+    </div>
   </h2>
 </li>
 `;
 
 exports[`should render with callback functions 1`] = `
-<li
-  aria-expanded={true}
-  aria-level={2}
-  className="subsection-header is-collapsible"
-  data-item-show-focus="true"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onMouseDown={[Function]}
-  role="heading"
-  tabIndex="0"
->
-  <div
-    className="start"
+<li>
+  <h2
+    className="title"
   >
-    <span
-      className="accordion-icon is-open"
-    />
-  </div>
-  <div
-    className="fill"
-  >
-    <h2
-      className="title"
+    <div
+      aria-expanded={true}
+      className="subsection-header is-collapsible"
+      data-item-show-focus="true"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onMouseDown={[Function]}
+      role="button"
+      tabIndex="0"
     >
-      test
-    </h2>
-  </div>
+      <div
+        className="start"
+      >
+        <span
+          className="accordion-icon is-open"
+        />
+      </div>
+      <div
+        className="fill"
+      >
+        test
+      </div>
+    </div>
+  </h2>
 </li>
 `;
 
 exports[`should render with isCollapsed 1`] = `
-<li
-  className="subsection-header"
->
+<li>
   <h2
     className="title"
   >
-    test
+    <div
+      className="subsection-header"
+    >
+      <div
+        className="fill"
+      >
+        test
+      </div>
+    </div>
   </h2>
 </li>
 `;
 
 exports[`should render with isCollapsible 1`] = `
-<li
-  aria-expanded={true}
-  aria-level={2}
-  className="subsection-header is-collapsible"
-  data-item-show-focus="true"
-  onBlur={[Function]}
-  onMouseDown={[Function]}
-  role="heading"
-  tabIndex="0"
->
-  <div
-    className="start"
+<li>
+  <h2
+    className="title"
   >
-    <span
-      className="accordion-icon is-open"
-    />
-  </div>
-  <div
-    className="fill"
-  >
-    <h2
-      className="title"
+    <div
+      aria-expanded={true}
+      className="subsection-header is-collapsible"
+      data-item-show-focus="true"
+      onBlur={[Function]}
+      onMouseDown={[Function]}
+      role="button"
+      tabIndex="0"
     >
-      test
-    </h2>
-  </div>
+      <div
+        className="start"
+      >
+        <span
+          className="accordion-icon is-open"
+        />
+      </div>
+      <div
+        className="fill"
+      >
+        test
+      </div>
+    </div>
+  </h2>
 </li>
 `;
 
 exports[`should render with level 1`] = `
-<li
-  className="subsection-header"
->
+<li>
   <h3
     className="title"
   >
-    test
+    <div
+      className="subsection-header"
+    >
+      <div
+        className="fill"
+      >
+        test
+      </div>
+    </div>
   </h3>
 </li>
 `;


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
As a screen reader user of the terra-list component that displays hierarchal relationships I need for the screen reader to accurately convey any hierarchal relationships between rows that display and any instructions on how to interact with them as well as be able to interact with them.

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
- Jest tests have been added.
- Tested with several screen readers and several platforms including:
  - MacOS and VoiceOver (Chrome)
  - Windows and JAWS (IE, Chrome)
  - Windows and NVDA (IE, Chrome)
### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
