### PR TITLE
[terra-section-header] toggle button a11y updates

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added
   * Added Accordion Examples for `terra-section-header`.
+  * Updated `terra-section-header` tests and examples.
 
 ## 1.15.1 - (September 8, 2022)
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/AccordionExampleTemplate.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/AccordionExampleTemplate.jsx
@@ -95,7 +95,7 @@ class AccoordianExampleTemplate extends React.Component {
           {...sectionHeaderProps}
           aria-expanded={this.state.isOpen}
           isOpen={this.state.isOpen}
-          title={title}
+          text={title}
         />
         <Toggle isOpen={this.state.isOpen} isAnimated>
           {children}

--- a/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/ClosedSectionHeader.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/ClosedSectionHeader.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import SectionHeaderExampleTemplate from './SectionHeaderExampleTemplate';
 
 const sectionHeaderProps = {
-  title: 'Closed',
+  text: 'Closed',
   onClick: () => {},
 };
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/DefaultSectionHeader.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/DefaultSectionHeader.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SectionHeaderExampleTemplate from './SectionHeaderExampleTemplate';
 
-const DefaultSectionHeader = () => <SectionHeaderExampleTemplate title="Default" exampleProps={{ title: 'Default Section Header' }} />;
+const DefaultSectionHeader = () => <SectionHeaderExampleTemplate title="Default" exampleProps={{ text: 'Default Section Header' }} />;
 
 export default DefaultSectionHeader;

--- a/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/LongTitleSectionHeader.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/LongTitleSectionHeader.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SectionHeaderExampleTemplate from './SectionHeaderExampleTemplate';
 
-const LongTitleSectionHeader = () => <SectionHeaderExampleTemplate title="Long Title" exampleProps={{ title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteu' }} />;
+const LongTitleSectionHeader = () => <SectionHeaderExampleTemplate title="Long Title" exampleProps={{ text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteu' }} />;
 
 export default LongTitleSectionHeader;

--- a/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/OnClickSectionHeader.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/OnClickSectionHeader.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import SectionHeaderExampleTemplate from './SectionHeaderExampleTemplate';
 
 const sectionHeaderProps = {
-  title: 'I\'m clickable, click me',
+  text: 'I\'m clickable, click me',
   onClick: () => {
     // eslint-disable-next-line no-alert
     window.alert('The accordion has been clicked!');

--- a/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/OpenSectionHeader.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/OpenSectionHeader.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import SectionHeaderExampleTemplate from './SectionHeaderExampleTemplate';
 
 const sectionHeaderProps = {
-  title: 'Open',
+  text: 'Open',
   isOpen: true,
   onClick: () => {},
 };

--- a/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/TransparentSectionHeader.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/TransparentSectionHeader.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import SectionHeaderExampleTemplate from './SectionHeaderExampleTemplate';
 
 const sectionHeaderProps = {
-  title: 'I\'m clickable, click me',
+  text: 'I\'m clickable, click me',
   onClick: () => {
     // eslint-disable-next-line no-alert
     window.alert('The accordion has been clicked!');

--- a/packages/terra-core-docs/src/terra-dev-site/test/section-header/ClosedSectionHeader.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/section-header/ClosedSectionHeader.test.jsx
@@ -3,7 +3,7 @@ import SectionHeader from 'terra-section-header';
 
 export default () => (
   <SectionHeader
-    title="Closed Section Header"
+    text="Closed Section Header"
     onClick={() => {}}
   />
 );

--- a/packages/terra-core-docs/src/terra-dev-site/test/section-header/DefaultSectionHeader.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/section-header/DefaultSectionHeader.test.jsx
@@ -1,4 +1,4 @@
 import React from 'react';
 import SectionHeader from 'terra-section-header';
 
-export default () => <SectionHeader title="Default" className="defaultSectionHeader" />;
+export default () => <SectionHeader text="Default" className="defaultSectionHeader" />;

--- a/packages/terra-core-docs/src/terra-dev-site/test/section-header/LongTitleAccordionSectionHeader.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/section-header/LongTitleAccordionSectionHeader.test.jsx
@@ -3,7 +3,7 @@ import SectionHeader from 'terra-section-header';
 
 const LongTitleAccordionSectionHeader = () => (
   <SectionHeader
-    title="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteu"
+    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteu"
     onClick={() => {}}
     isOpen
     className="accordionContent"

--- a/packages/terra-core-docs/src/terra-dev-site/test/section-header/OnClickSectionHeader.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/section-header/OnClickSectionHeader.test.jsx
@@ -3,7 +3,7 @@ import SectionHeader from 'terra-section-header';
 
 const OnClickSectionHeader = () => (
   <SectionHeader
-    title="OnClick Section Header"
+    text="OnClick Section Header"
     // eslint-disable-next-line no-alert
     onClick={() => { window.alert('The accordion has been clicked!'); }}
     className="onClickHeader"

--- a/packages/terra-core-docs/src/terra-dev-site/test/section-header/OpenSectionHeader.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/section-header/OpenSectionHeader.test.jsx
@@ -3,7 +3,7 @@ import SectionHeader from 'terra-section-header';
 
 export default () => (
   <SectionHeader
-    title="Open Section Header"
+    text="Open Section Header"
     onClick={() => {}}
     isOpen
   />

--- a/packages/terra-core-docs/src/terra-dev-site/test/section-header/TransparentOnClickSectionHeader.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/section-header/TransparentOnClickSectionHeader.test.jsx
@@ -3,7 +3,7 @@ import SectionHeader from 'terra-section-header';
 
 const TransparentOnClickSectionHeader = () => (
   <SectionHeader
-    title="Transparent OnClick Section Header"
+    text="Transparent OnClick Section Header"
     // eslint-disable-next-line no-alert
     onClick={() => { window.alert('The accordion has been clicked!'); }}
     data-id="section-header"

--- a/packages/terra-core-docs/src/terra-dev-site/test/section-header/TransparentSectionHeader.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/section-header/TransparentSectionHeader.test.jsx
@@ -1,4 +1,4 @@
 import React from 'react';
 import SectionHeader from 'terra-section-header';
 
-export default () => <SectionHeader title="Transparent Section Header" isTransparent />;
+export default () => <SectionHeader text="Transparent Section Header" isTransparent />;

--- a/packages/terra-docs/CHANGELOG.md
+++ b/packages/terra-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated `terra-section-header` tests and examples.
+
 ## 1.7.1 - (July 5, 2022)
 
 * Changed

--- a/packages/terra-section-header/CHANGELOG.md
+++ b/packages/terra-section-header/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+* Changed
+  * Renamed title prop to text to avoid conflict with native html attribute
+  * Updated WDIO Screenshots for DOM changes
+
+* Added
+  * Assigned button role to the actionable section of component
+  * Added aria-label and aria-expanded attribute to the actionable section of component
+
 ## 2.56.0 - (July 14, 2022)
 
 * Fixed

--- a/packages/terra-section-header/src/SectionHeader.jsx
+++ b/packages/terra-section-header/src/SectionHeader.jsx
@@ -13,7 +13,7 @@ const propTypes = {
   /**
    * Text to be displayed on the SectionHeader.
    */
-  title: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
   /**
    * Callback function triggered when the accordion icon is clicked.
    */
@@ -81,7 +81,7 @@ class SectionHeader extends React.Component {
 
   render() {
     const {
-      title,
+      text,
       onClick,
       isOpen,
       isTransparent,
@@ -91,6 +91,12 @@ class SectionHeader extends React.Component {
 
     const theme = this.context;
 
+    let headerText = text;
+    if (text === undefined && customProps.title !== undefined) {
+      headerText = customProps.title;
+      customProps.title = undefined;
+    }
+
     if ((process.env.NODE_ENV !== 'production') && (!onClick && isOpen)) {
       // eslint-disable-next-line no-console
       console.warn('\'isOpen\' are intended to be used only when \'onClick\' is provided.');
@@ -99,10 +105,8 @@ class SectionHeader extends React.Component {
     const attributes = { ...customProps };
 
     if (onClick) {
-      attributes.tabIndex = '0';
       attributes.onKeyDown = this.wrapOnKeyDown(attributes.onKeyDown);
       attributes.onKeyUp = this.wrapOnKeyUp(attributes.onKeyUp);
-      attributes.role = 'button';
     }
 
     const iconClassNames = cx([
@@ -111,7 +115,7 @@ class SectionHeader extends React.Component {
     ]);
 
     const accordionIcon = (
-      <div className={cx('accordion-icon-wrapper')}>
+      <div className={cx('accordion-icon-wrapper')} role="button" aria-expanded={isOpen} aria-label={headerText} tabIndex="-1">
         <span className={iconClassNames} />
       </div>
     );
@@ -135,13 +139,13 @@ class SectionHeader extends React.Component {
     /* eslint-disable jsx-a11y/click-events-have-key-events */
     /* eslint-disable jsx-a11y/no-static-element-interactions */
     return (
-      <div {...attributes} onClick={onClick} className={sectionHeaderClassNames}>
+      <Element {...attributes} onClick={onClick} className={sectionHeaderClassNames} tabIndex="0">
         <Arrange
           fitStart={onClick && accordionIcon}
-          fill={<Element className={cx('title')}>{title}</Element>}
+          fill={<span aria-hidden={(onClick !== undefined)} className={cx('title')}>{headerText}</span>}
           className={cx('title-arrange')}
         />
-      </div>
+      </Element>
     );
     /* eslint-enable jsx-a11y/no-static-element-interactions */
   }

--- a/packages/terra-section-header/tests/jest/SectionHeader.test.jsx
+++ b/packages/terra-section-header/tests/jest/SectionHeader.test.jsx
@@ -4,7 +4,7 @@ import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 import SectionHeader from '../../src/SectionHeader';
 
 describe('SectionHeader', () => {
-  const defaultRender = <SectionHeader title="foo" />;
+  const defaultRender = <SectionHeader text="foo" />;
 
   // Snapshot Tests
   it('should render a default component', () => {
@@ -13,19 +13,19 @@ describe('SectionHeader', () => {
   });
 
   it("should render without an accordion icon when no 'onClick()' is passed", () => {
-    const sectionHeader = <SectionHeader title="foo" />;
+    const sectionHeader = <SectionHeader text="foo" />;
     const wrapper = render(sectionHeader);
     expect(wrapper).toMatchSnapshot();
   });
 
   it("should render with an accordion icon when an 'onClick()' callback is passed", () => {
-    const sectionHeader = <SectionHeader title="foo" onClick={() => {}} />;
+    const sectionHeader = <SectionHeader text="foo" onClick={() => {}} />;
     const wrapper = render(sectionHeader);
     expect(wrapper).toMatchSnapshot();
   });
 
   it("should render with an accordion icon in the open position when an 'onClick()' callback and 'isOpen' is passed", () => {
-    const sectionHeader = <SectionHeader title="foo" onClick={() => {}} isOpen />;
+    const sectionHeader = <SectionHeader text="foo" onClick={() => {}} isOpen />;
     const wrapper = render(sectionHeader);
     expect(wrapper).toMatchSnapshot();
   });
@@ -33,7 +33,7 @@ describe('SectionHeader', () => {
   it('correctly applies the theme context className', () => {
     const wrapper = mount(
       <ThemeContextProvider theme={{ className: 'orion-fusion-theme' }}>
-        <SectionHeader title="foo" />
+        <SectionHeader text="foo" />
       </ThemeContextProvider>,
     );
     expect(wrapper).toMatchSnapshot();

--- a/packages/terra-section-header/tests/jest/__snapshots__/SectionHeader.test.jsx.snap
+++ b/packages/terra-section-header/tests/jest/__snapshots__/SectionHeader.test.jsx.snap
@@ -12,19 +12,21 @@ exports[`SectionHeader correctly applies the theme context className 1`] = `
     isOpen={false}
     isTransparent={false}
     level={2}
-    title="foo"
+    text="foo"
   >
-    <div
+    <h2
       className="section-header orion-fusion-theme"
+      tabIndex="0"
     >
       <Arrange
         className="title-arrange"
         fill={
-          <h2
+          <span
+            aria-hidden={false}
             className="title"
           >
             foo
-          </h2>
+          </span>
         }
       >
         <div
@@ -36,43 +38,45 @@ exports[`SectionHeader correctly applies the theme context className 1`] = `
           <div
             className="fill"
           >
-            <h2
+            <span
+              aria-hidden={false}
               className="title"
             >
               foo
-            </h2>
+            </span>
           </div>
           <div
             className="fit"
           />
         </div>
       </Arrange>
-    </div>
+    </h2>
   </SectionHeader>
 </ThemeContextProvider>
 `;
 
 exports[`SectionHeader should render a default component 1`] = `
-<div
+<h2
   className="section-header"
+  tabIndex="0"
 >
   <Arrange
     className="title-arrange"
     fill={
-      <h2
+      <span
+        aria-hidden={false}
         className="title"
       >
         foo
-      </h2>
+      </span>
     }
   />
-</div>
+</h2>
 `;
 
 exports[`SectionHeader should render with an accordion icon in the open position when an 'onClick()' callback and 'isOpen' is passed 1`] = `
-<div
+<h2
   class="section-header is-interactable"
-  role="button"
   tabindex="0"
 >
   <div
@@ -82,7 +86,11 @@ exports[`SectionHeader should render with an accordion icon in the open position
       class="fit"
     >
       <div
+        aria-expanded="true"
+        aria-label="foo"
         class="accordion-icon-wrapper"
+        role="button"
+        tabindex="-1"
       >
         <span
           class="accordion-icon is-open"
@@ -92,23 +100,23 @@ exports[`SectionHeader should render with an accordion icon in the open position
     <div
       class="fill"
     >
-      <h2
+      <span
+        aria-hidden="true"
         class="title"
       >
         foo
-      </h2>
+      </span>
     </div>
     <div
       class="fit"
     />
   </div>
-</div>
+</h2>
 `;
 
 exports[`SectionHeader should render with an accordion icon when an 'onClick()' callback is passed 1`] = `
-<div
+<h2
   class="section-header is-interactable"
-  role="button"
   tabindex="0"
 >
   <div
@@ -118,7 +126,11 @@ exports[`SectionHeader should render with an accordion icon when an 'onClick()' 
       class="fit"
     >
       <div
+        aria-expanded="false"
+        aria-label="foo"
         class="accordion-icon-wrapper"
+        role="button"
+        tabindex="-1"
       >
         <span
           class="accordion-icon"
@@ -128,22 +140,24 @@ exports[`SectionHeader should render with an accordion icon when an 'onClick()' 
     <div
       class="fill"
     >
-      <h2
+      <span
+        aria-hidden="true"
         class="title"
       >
         foo
-      </h2>
+      </span>
     </div>
     <div
       class="fit"
     />
   </div>
-</div>
+</h2>
 `;
 
 exports[`SectionHeader should render without an accordion icon when no 'onClick()' is passed 1`] = `
-<div
+<h2
   class="section-header"
+  tabindex="0"
 >
   <div
     class="arrange title-arrange"
@@ -154,15 +168,16 @@ exports[`SectionHeader should render without an accordion icon when no 'onClick(
     <div
       class="fill"
     >
-      <h2
+      <span
+        aria-hidden="false"
         class="title"
       >
         foo
-      </h2>
+      </span>
     </div>
     <div
       class="fit"
     />
   </div>
-</div>
+</h2>
 `;

--- a/packages/terra-toggle-section-header/CHANGELOG.md
+++ b/packages/terra-toggle-section-header/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Changed
+  * Renamed `terra-section-header` title prop to text
+  * Updated snapshots from changes made to terra-section-header
+  * Updated WDIO Screenshots from changes made to terra-section-header
+
 ## 2.58.4 - (July 14, 2022)
 
 * Changed

--- a/packages/terra-toggle-section-header/src/ToggleSectionHeader.jsx
+++ b/packages/terra-toggle-section-header/src/ToggleSectionHeader.jsx
@@ -128,7 +128,7 @@ class ToggleSectionHeader extends React.Component {
           aria-expanded={this.state.isOpen}
           isOpen={this.state.isOpen}
           level={level}
-          title={title}
+          text={title}
           isTransparent={isTransparent}
         />
         <Toggle isAnimated={isAnimated} isOpen={this.state.isOpen}>

--- a/packages/terra-toggle-section-header/tests/jest/__snapshots__/ToggleSectionHeader.test.jsx.snap
+++ b/packages/terra-toggle-section-header/tests/jest/__snapshots__/ToggleSectionHeader.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`ToggleSectionHeader should call any custom onCLose that is provided by 
     isTransparent={false}
     level={2}
     onClick={[Function]}
-    title="custom title"
+    text="custom title"
   />
   <Toggle
     isAnimated={false}
@@ -27,7 +27,7 @@ exports[`ToggleSectionHeader should call any custom onOpen that is provided by t
     isTransparent={false}
     level={2}
     onClick={[Function]}
-    title="custom title"
+    text="custom title"
   />
   <Toggle
     isAnimated={false}
@@ -40,10 +40,9 @@ exports[`ToggleSectionHeader should call any custom onOpen that is provided by t
 
 exports[`ToggleSectionHeader should render a default toggle section header 1`] = `
 <div>
-  <div
+  <h2
     aria-expanded="false"
     class="section-header is-interactable"
-    role="button"
     tabindex="0"
   >
     <div
@@ -53,7 +52,11 @@ exports[`ToggleSectionHeader should render a default toggle section header 1`] =
         class="fit"
       >
         <div
+          aria-expanded="false"
+          aria-label="default title"
           class="accordion-icon-wrapper"
+          role="button"
+          tabindex="-1"
         >
           <span
             class="accordion-icon"
@@ -63,17 +66,18 @@ exports[`ToggleSectionHeader should render a default toggle section header 1`] =
       <div
         class="fill"
       >
-        <h2
+        <span
+          aria-hidden="true"
           class="title"
         >
           default title
-        </h2>
+        </span>
       </div>
       <div
         class="fit"
       />
     </div>
-  </div>
+  </h2>
   <div
     aria-hidden="true"
     class="toggle"
@@ -83,10 +87,9 @@ exports[`ToggleSectionHeader should render a default toggle section header 1`] =
 
 exports[`ToggleSectionHeader should render an animated toggle section header 1`] = `
 <div>
-  <div
+  <h2
     aria-expanded="false"
     class="section-header is-interactable"
-    role="button"
     tabindex="0"
   >
     <div
@@ -96,7 +99,11 @@ exports[`ToggleSectionHeader should render an animated toggle section header 1`]
         class="fit"
       >
         <div
+          aria-expanded="false"
+          aria-label="animated title"
           class="accordion-icon-wrapper"
+          role="button"
+          tabindex="-1"
         >
           <span
             class="accordion-icon"
@@ -106,17 +113,18 @@ exports[`ToggleSectionHeader should render an animated toggle section header 1`]
       <div
         class="fill"
       >
-        <h2
+        <span
+          aria-hidden="true"
           class="title"
         >
           animated title
-        </h2>
+        </span>
       </div>
       <div
         class="fit"
       />
     </div>
-  </div>
+  </h2>
   <div
     aria-hidden="true"
     class="toggle"
@@ -136,10 +144,9 @@ exports[`ToggleSectionHeader should render an animated toggle section header 1`]
 
 exports[`ToggleSectionHeader should render an initially open toggle section header 1`] = `
 <div>
-  <div
+  <h2
     aria-expanded="true"
     class="section-header is-interactable"
-    role="button"
     tabindex="0"
   >
     <div
@@ -149,7 +156,11 @@ exports[`ToggleSectionHeader should render an initially open toggle section head
         class="fit"
       >
         <div
+          aria-expanded="true"
+          aria-label="initially open title"
           class="accordion-icon-wrapper"
+          role="button"
+          tabindex="-1"
         >
           <span
             class="accordion-icon is-open"
@@ -159,17 +170,18 @@ exports[`ToggleSectionHeader should render an initially open toggle section head
       <div
         class="fill"
       >
-        <h2
+        <span
+          aria-hidden="true"
           class="title"
         >
           initially open title
-        </h2>
+        </span>
       </div>
       <div
         class="fit"
       />
     </div>
-  </div>
+  </h2>
   <div
     aria-hidden="false"
     class="toggle"
@@ -195,29 +207,33 @@ exports[`ToggleSectionHeader should render an open toggle section header when cl
       isTransparent={false}
       level={2}
       onClick={[Function]}
-      title="opens on click title"
+      text="opens on click title"
     >
-      <div
+      <h2
         aria-expanded={true}
         className="section-header is-interactable"
         onClick={[Function]}
         onKeyDown={[Function]}
         onKeyUp={[Function]}
-        role="button"
         tabIndex="0"
       >
         <Arrange
           className="title-arrange"
           fill={
-            <h2
+            <span
+              aria-hidden={true}
               className="title"
             >
               opens on click title
-            </h2>
+            </span>
           }
           fitStart={
             <div
+              aria-expanded={true}
+              aria-label="opens on click title"
               className="accordion-icon-wrapper"
+              role="button"
+              tabIndex="-1"
             >
               <span
                 className="accordion-icon is-open"
@@ -232,7 +248,11 @@ exports[`ToggleSectionHeader should render an open toggle section header when cl
               className="fit"
             >
               <div
+                aria-expanded={true}
+                aria-label="opens on click title"
                 className="accordion-icon-wrapper"
+                role="button"
+                tabIndex="-1"
               >
                 <span
                   className="accordion-icon is-open"
@@ -242,18 +262,19 @@ exports[`ToggleSectionHeader should render an open toggle section header when cl
             <div
               className="fill"
             >
-              <h2
+              <span
+                aria-hidden={true}
                 className="title"
               >
                 opens on click title
-              </h2>
+              </span>
             </div>
             <div
               className="fit"
             />
           </div>
         </Arrange>
-      </div>
+      </h2>
     </SectionHeader>
     <Toggle
       isAnimated={false}
@@ -279,7 +300,7 @@ exports[`ToggleSectionHeader should set sectionHeaderAttrs prop correctly 1`] = 
     isTransparent={false}
     level={2}
     onClick={[Function]}
-    title="sectionHeaderAttrs props test"
+    text="sectionHeaderAttrs props test"
   />
   <Toggle
     isAnimated={false}
@@ -298,7 +319,7 @@ exports[`ToggleSectionHeader should set the children prop correctly 1`] = `
     isTransparent={false}
     level={2}
     onClick={[Function]}
-    title="sectionHeaderAttrs props test"
+    text="sectionHeaderAttrs props test"
   />
   <Toggle
     isAnimated={false}
@@ -317,7 +338,7 @@ exports[`ToggleSectionHeader should set the level prop correctly 1`] = `
     isTransparent={false}
     level={1}
     onClick={[Function]}
-    title="sectionHeaderAttrs props test"
+    text="sectionHeaderAttrs props test"
   />
   <Toggle
     isAnimated={false}


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

Renamed `title` prop to `text`. `text` prop is optional.
Assigned `role=button` to actionable section of component, in order to accessibly separate the heading landmark and the open/close toggle button.
Added `aria-expanded` to toggle button to expose expanded/collapsed state of  (accordion) terra-section-header. 

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

Jest Tests were updated to validate terra-section-header for the prop changes.

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
