### PR TITLE
Clicking parent row in a table will collapse/expand its child rows

### DIFF
--- a/packages/terra-core-docs/src/terra-dev-site/doc/table/example/SectionExample.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/table/example/SectionExample.jsx
@@ -10,7 +10,7 @@ const TableSectionExample = () => (
     bodyData={[
       {
         sectionHeader: {
-          title: 'Default Section',
+          title: 'Default Amyyy1 Section',
           id: 'default-id',
           key: 'default',
         },

--- a/packages/terra-core-docs/src/terra-dev-site/test/table/Section.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/table/Section.test.jsx
@@ -8,8 +8,21 @@ const SectionTest = () => (
     numberOfColumns={1}
     bodyData={[
       {
+        rows: [
+          {
+            key: 'row-1',
+            cells: [
+              {
+                key: 'cell-1',
+                children: [
+                  <div key="cell-1">Amy3EditedInVsCode olor</div>,
+                ],
+              },
+            ],
+          },
+        ],
         sectionHeader: {
-          title: 'Default Section',
+          title: 'Default Amy3TestEditedInVsCode Section',
           id: 'default-id',
           key: 'default',
         },

--- a/packages/terra-core-docs/src/terra-dev-site/test/table/SectionOfParentChildRows.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/table/SectionOfParentChildRows.test.jsx
@@ -1,13 +1,28 @@
 import React from 'react';
 import Table from 'terra-table';
 
-const SectionTest = () => (
+const SectionOfParentChildRowsTest = () => (
   <Table
     summaryId="section-table"
     summary="This table displays section grouping."
     dividerStyle="both"
     cellPaddingStyle="standard"
     numberOfColumns={1}
+    hasParentChildRows={true}
+    headerData={{
+      cells: [
+        {
+          id: 'amy-header-column1',
+          key: 'amy-column0',
+          children: 'Amy Column 1',
+        },
+        {
+          id: 'amy-header-column2',
+          key: 'amy-column1',
+          children: 'Amy Column 2',
+        },
+      ],
+    }}
     bodyData={[
       {
         sectionHeader: {
@@ -181,4 +196,4 @@ const SectionTest = () => (
   />
 );
 
-export default SectionTest;
+export default SectionOfParentChildRowsTest;

--- a/packages/terra-core-docs/src/terra-dev-site/test/table/SectionOfParentChildRows.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/table/SectionOfParentChildRows.test.jsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import Table from 'terra-table';
+
+const SectionTest = () => (
+  <Table
+    summaryId="section-table"
+    summary="This table displays section grouping."
+    dividerStyle="both"
+    cellPaddingStyle="standard"
+    numberOfColumns={1}
+    bodyData={[
+      {
+        sectionHeader: {
+          title: 'Amy section1 default sectionHeader',
+          id: 'amy-section1-default-id',
+          key: 'amy-section1-default',
+        },
+        parentRow: {
+          key: 'Amy section1 parent row',
+          cells: [
+            {
+              key: 'cell-1',
+              children: [
+                <div key="cell-1">Amy1 parentRow cell in section with sectionHeader and parentRow</div>,
+              ],
+            },
+            {
+              key: 'cell-1.1',
+              children: [
+                <div key="cell-1.1">Amy1.1 parentRow cell in section with sectionHeader and parentRow</div>,
+              ],
+            },
+          ],
+        },
+        rows: [
+          {
+            key: 'row-2',
+            cells: [
+              {
+                key: 'cell-2',
+                children: [
+                  <div key="cell-2">Amy2 cell in section with sectionHeader and parentRow</div>,
+                ],
+              },
+              {
+                key: 'cell-2.2',
+                children: [
+                  <div key="cell-2.2">Amy2.2 cell in section with sectionHeader and parentRow</div>,
+                ],
+              },
+            ],
+          },
+          {
+            key: 'row-3',
+            cells: [
+              {
+                key: 'cell-3',
+                children: [
+                  <div key="cell-3">Amy3 cell in section with sectionHeader and parentRow</div>,
+                ],
+              },
+              {
+                key: 'cell-3.3',
+                children: [
+                  <div key="cell-3.3">Amy3.3 cell in section with sectionHeader and parentRow</div>,
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        parentRow: {
+          key: 'amy-section2-parent-key',
+          id: 'amy-section2-parent-id',
+          //onToggle: handleSectionToggle,
+          //metaData: { key: `parent-key-${timelineRecordItem.recordId}` },
+          isCollapsible: true,
+          areItsChildRowsCollapsed: false,
+          row: {
+            key: 'row-4',
+            cells: [
+              {
+                key: 'cell-4',
+                children: [
+                  <div key="cell-4">Amy4 parentRow cell in section with parentRow</div>,
+                ],
+              },
+              {
+                key: 'cell-4.4',
+                children: [
+                  <div key="cell-4.4">Amy4.4 parentRow cell in section with parentRow</div>,
+                ],
+              },
+            ],
+          },
+        },
+        rows: [
+          {
+            key: 'row-5',
+            cells: [
+              {
+                key: 'cell-5',
+                children: [
+                  <div key="cell-5">Amy5 cell in section with parentRow</div>,
+                ],
+              },
+              {
+                key: 'cell-5.5',
+                children: [
+                  <div key="cell-5.5">Amy5.5 cell in section with parentRow</div>,
+                ],
+              },
+            ],
+          },
+          {
+            key: 'row-6',
+            cells: [
+              {
+                key: 'cell-6',
+                children: [
+                  <div key="cell-6">Amy6 cell in section with parentRow</div>,
+                ],
+              },
+              {
+                key: 'cell-6.6',
+                children: [
+                  <div key="cell-6.6">Amy6.6 cell in section with parentRow</div>,
+                ],
+              },
+            ],
+          },
+          {
+            key: 'row-7',
+            cells: [
+              {
+                key: 'cell-7',
+                children: [
+                  <div key="cell-7">Amy7 cell in section with parentRow</div>,
+                ],
+              },
+              {
+                key: 'cell-7.7',
+                children: [
+                  <div key="cell-7.7">Amy7.7 cell in section with parentRow</div>,
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        sectionHeader: {
+          title: 'Amy section3 Collapsed sectionHeader',
+          id: 'amy-section3-collapsed-id',
+          key: 'amy-section3-collapsed',
+          onToggle: () => {},
+          isCollapsed: true,
+        },
+        rows: [
+          {
+            key: 'row-8',
+            cells: [
+              {
+                key: 'cell-8',
+                children: [
+                  <div key="cell-8">Amy8 cell in section without sectionHeader or parentRow</div>,
+                ],
+              },
+              {
+                key: 'cell-8.9',
+                children: [
+                  <div key="cell-8.8">Amy8.8 cell in section without sectionHeader or parentRow</div>,
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]}
+  />
+);
+
+export default SectionTest;

--- a/packages/terra-table/src/Table.jsx
+++ b/packages/terra-table/src/Table.jsx
@@ -13,7 +13,6 @@ import widthShape from './proptypes/widthShape';
 import Row from './subcomponents/_Row';
 import Cell from './subcomponents/_Cell';
 import Section from './subcomponents/_Section';
-import SectionOfParentChildRows from './subcomponents/_SectionOfParentChildRows';
 import HeaderRow from './subcomponents/_HeaderRow';
 import HeaderCell from './subcomponents/_HeaderCell';
 import ChevronCell from './subcomponents/_ChevronCell';
@@ -21,6 +20,7 @@ import AccordionIconCell from './subcomponents/_AccordionIconCell';
 import CheckMarkCell from './subcomponents/_CheckMarkCell';
 import HeaderChevronCell from './subcomponents/_HeaderChevronCell';
 import HeaderCheckMarkCell from './subcomponents/_HeaderCheckMarkCell';
+import HeaderAccordionIconCell from './subcomponents/_HeaderAccordionIconCell';
 
 const cx = classNamesBind.bind(styles);
 
@@ -109,6 +109,10 @@ const propTypes = {
    * The element id to associate to the descriptive text.
    */
   summaryId: PropTypes.string.isRequired,
+  /**
+   * Whether or not the table contains any rows that have parent & child relationship.
+   */
+   hasParentChildRows: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -183,13 +187,19 @@ const createChevronCell = (rowStyle, hasChevrons) => {
   return undefined;
 };
 
-const createAccordionIconCell = (isParentRow, areItsChildRowsCollapsed) => {
-  if (isParentRow) {
-    return (
-      <AccordionIconCell 
-       isCollapsed={areItsChildRowsCollapsed}/>
-    );
+const createAccordionIconCell = (hasParentChildRows, isParentRow, areItsChildRowsCollapsed) => {
+  if (hasParentChildRows) {
+    if (isParentRow) {
+      return (
+        <AccordionIconCell 
+          isCollapsed={areItsChildRowsCollapsed}
+        />
+      );
+    } else {
+      return <HeaderAccordionIconCell />;
+    }
   }
+
   return undefined;
 };
 
@@ -245,6 +255,13 @@ const createHeaderChevronCell = (rowStyle, hasChevrons) => {
   return undefined;
 };
 
+const createHeaderAccordionIconCell = (hasParentChildRows) => {
+  if (hasParentChildRows) {
+    return <HeaderAccordionIconCell />;
+  }
+  return undefined;
+};
+
 const createRow = (tableData, rowData, rowIndex, sectionId, isParentRow, areItsChildRowsCollapsed) => {
   let rowMetaData;
   let rowOnAction;
@@ -284,7 +301,7 @@ const createRow = (tableData, rowData, rowIndex, sectionId, isParentRow, areItsC
       refCallback={rowData.refCallback}
     >
       
-      {createAccordionIconCell(isParentRow, areItsChildRowsCollapsed)}
+      {createAccordionIconCell(tableData.hasParentChildRows, isParentRow, areItsChildRowsCollapsed)}
       {createCheckCell(rowData, tableData.rowStyle, tableData.checkStyle)}
       {rowData.cells.map((cell, colIndex) => {
         const columnId = tableData.headerData && tableData.headerData.cells ? tableData.headerData.cells[colIndex].id : undefined;
@@ -386,6 +403,7 @@ const createHeader = (tableData) => {
       <HeaderRow
         aria-rowindex={1} // Row count begins with the header.
       >
+        {createHeaderAccordionIconCell(tableData.hasParentChildRows)}
         {createHeaderCheckCell(tableData.headerData.selectAllColumn, tableData.rowStyle, tableData.checkStyle)}
         {tableData.headerData.cells.map((cellData, colIndex) => (
           <HeaderCell
@@ -434,6 +452,7 @@ const Table = ({
   showSimpleFooter,
   summary,
   summaryId,
+  hasParentChildRows,
   ...customProps
 }) => {
   const theme = React.useContext(ThemeContext);
@@ -453,6 +472,8 @@ const Table = ({
     customProps.className,
   );
 
+  //const tempArray = bodyData.map(section => section.parentRow !== undefined);
+  //const hasParentChildRows = bodyData.map(section => section.parentRow != undefined).includes(true);
   const tableData = {
     headerData,
     bodyData,
@@ -462,6 +483,7 @@ const Table = ({
     hasChevrons,
     dividerStyle,
     numberOfColumns,
+    hasParentChildRows,
   };
   const { rowCount, header, sections } = unpackTableData(tableData);
 

--- a/packages/terra-table/src/Table.jsx
+++ b/packages/terra-table/src/Table.jsx
@@ -357,6 +357,7 @@ const createSections = (tableData, headerIndex) => {
           metaData={header.metaData}
           numberOfColumns={tableData.checkStyle !== 'toggle' && tableData.rowStyle === 'toggle' ? tableData.numberOfColumns + 1 : tableData.numberOfColumns}
           onSelect={header.onToggle}
+          isSectionHeaderVisible={header.isSectionHeaderVisible}
         >
           {section.rows ? section.rows.map(rowData => {
             rowIndex += 1;

--- a/packages/terra-table/src/clinical-lowlight-theme/Table.module.scss
+++ b/packages/terra-table/src/clinical-lowlight-theme/Table.module.scss
@@ -54,6 +54,12 @@
     --terra-table-chevron-cell-padding-left: 0.7142857143rem;
     --terra-table-chevron-cell-padding-right: 0.7142857143rem;
 
+    // AccordionIconCell
+    --terra-table-accordion-icon-cell-height: 0.7142857143rem;
+    --terra-table-accordion-icon-cell-width: 0.7142857143rem;
+    --terra-table-accordion-icon-cell-padding-left: 0.7142857143rem;
+    --terra-table-accordion-icon-cell-padding-right: 0.7142857143rem;
+
     // HeaderCell
     --terra-table-header-cell-border-right: 1px solid #909496;
     --terra-table-header-cell-color: #1c1f21;
@@ -114,6 +120,11 @@
     --terra-table-header-chevron-cell-width: 1rem;
     --terra-table-header-chevron-cell-padding-left: 0.7142857143rem;
     --terra-table-header-chevron-cell-padding-right: 0.7142857143rem;
+
+    // HeaderAccordionIconCell
+    --terra-table-header-accordion-icon-cell-width: 0.7142857143rem;
+    --terra-table-header-accordion-icon-cell-padding-left: 0.7142857143rem;
+    --terra-table-header-accordion-icon-cell-padding-right: 0.7142857143rem;
 
     // Row
     --terra-table-row-background-color: none;

--- a/packages/terra-table/src/orion-fusion-theme/Table.module.scss
+++ b/packages/terra-table/src/orion-fusion-theme/Table.module.scss
@@ -54,6 +54,12 @@
     --terra-table-chevron-cell-padding-left: 0.7142857143rem;
     --terra-table-chevron-cell-padding-right: 0.7142857143rem;
 
+    // AccordionIconCell
+    --terra-table-accordion-icon-cell-height: 0.7142857143rem;
+    --terra-table-accordion-icon-cell-width: 0.7142857143rem;
+    --terra-table-accordion-icon-cell-padding-left: 0.7142857143rem;
+    --terra-table-accordion-icon-cell-padding-right: 0.7142857143rem;
+
     // HeaderCell
     --terra-table-header-cell-border-right: 1px solid #c8cacb;
     --terra-table-header-cell-color: #64696c;
@@ -114,6 +120,11 @@
     --terra-table-header-chevron-cell-width: 1rem;
     --terra-table-header-chevron-cell-padding-left: 0.7142857143rem;
     --terra-table-header-chevron-cell-padding-right: 0.7142857143rem;
+
+    // HeaderAccordionIconCell
+    --terra-table-header-accordion-icon-cell-width: 0.7142857143rem;
+    --terra-table-header-accordion-icon-cell-padding-left: 0.7142857143rem;
+    --terra-table-header-accordion-icon-cell-padding-right: 0.7142857143rem;
 
     // Row
     --terra-table-row-background-color: transparent;

--- a/packages/terra-table/src/subcomponents/AccordionIconCell.module.scss
+++ b/packages/terra-table/src/subcomponents/AccordionIconCell.module.scss
@@ -1,0 +1,39 @@
+@import '~terra-mixins/lib/Mixins';
+
+:local {
+  .cell {
+    align-items: center;
+    border: 0;
+    display: flex;
+    flex: 0 0 auto;
+    word-break: break-word;
+  }
+
+  .accordion-icon {
+    background: var(--terra-table-section-header-accordion-icon-background, inline-svg('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><path id="caretRight" d="M12,0l24,24L12,48V0z"/></svg>'));
+    background-repeat: no-repeat;
+    background-size: contain;
+    display: block;
+    height: var(--terra-table-section-header-accordion-icon-height, 0.7142857143rem);
+    transform: rotate(0deg);
+    width: var(--terra-table-section-header-accordion-icon-width, 0.7142857143rem);
+
+    // flips the icon about its vertical axis, presenting it in its mirrored-image form
+    [dir=rtl] & {
+      transform: scaleX(-1);
+    }
+
+    // tells the rtl postcss plugin to not transform this by default
+    [dir] &.is-open {
+      transform: rotate(90deg);
+    }
+  }
+
+  .container {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    padding-left: var(--terra-table-chevron-cell-padding-left, 0.7142857143rem);
+    padding-right: var(--terra-table-chevron-cell-padding-right, 0.7142857143rem);
+  }
+}

--- a/packages/terra-table/src/subcomponents/AccordionIconCell.module.scss
+++ b/packages/terra-table/src/subcomponents/AccordionIconCell.module.scss
@@ -14,9 +14,9 @@
     background-repeat: no-repeat;
     background-size: contain;
     display: block;
-    height: var(--terra-table-section-header-accordion-icon-height, 0.7142857143rem);
+    height: var(--terra-table-accordion-icon-cell-height, 0.7142857143rem);
     transform: rotate(0deg);
-    width: var(--terra-table-section-header-accordion-icon-width, 0.7142857143rem);
+    width: var(--terra-table-accordion-icon-cell-width, 0.7142857143rem);
 
     // flips the icon about its vertical axis, presenting it in its mirrored-image form
     [dir=rtl] & {
@@ -33,7 +33,7 @@
     align-items: center;
     display: flex;
     flex-direction: column;
-    padding-left: var(--terra-table-chevron-cell-padding-left, 0.7142857143rem);
-    padding-right: var(--terra-table-chevron-cell-padding-right, 0.7142857143rem);
+    padding-left: var(--terra-table-accordion-icon-cell-padding-left, 0.7142857143rem);
+    padding-right: var(--terra-table-accordion-icon-cell-padding-right, 0.7142857143rem);
   }
 }

--- a/packages/terra-table/src/subcomponents/HeaderAccordionIconCell.module.scss
+++ b/packages/terra-table/src/subcomponents/HeaderAccordionIconCell.module.scss
@@ -1,0 +1,16 @@
+:local {
+  .cell {
+    border: 0;
+    flex: 0 0 auto;
+    word-break: break-word;
+  }
+
+  .accordion-icon {
+    width: var(--terra-table-section-header-accordion-icon-width, 0.7142857143rem);
+  }
+
+  .container {
+    padding-left: var(--terra-table-header-chevron-cell-padding-left, 0.7142857143rem);
+    padding-right: var(--terra-table-header-chevron-cell-padding-right, 0.7142857143rem);
+  }
+}

--- a/packages/terra-table/src/subcomponents/HeaderAccordionIconCell.module.scss
+++ b/packages/terra-table/src/subcomponents/HeaderAccordionIconCell.module.scss
@@ -6,11 +6,11 @@
   }
 
   .accordion-icon {
-    width: var(--terra-table-section-header-accordion-icon-width, 0.7142857143rem);
+    width: var(--terra-table-header-accordion-icon-cell-width, 0.7142857143rem);
   }
 
   .container {
-    padding-left: var(--terra-table-header-chevron-cell-padding-left, 0.7142857143rem);
-    padding-right: var(--terra-table-header-chevron-cell-padding-right, 0.7142857143rem);
+    padding-left: var(--terra-table-header-accordion-icon-cell-padding-left, 0.7142857143rem);
+    padding-right: var(--terra-table-header-accordion-icon-cell-padding-right, 0.7142857143rem);
   }
 }

--- a/packages/terra-table/src/subcomponents/_AccordionIconCell.jsx
+++ b/packages/terra-table/src/subcomponents/_AccordionIconCell.jsx
@@ -26,7 +26,11 @@ const AccordionIconCell = ({
     role="none"
   >
     <div className={cx('container')}>
-    <span className={cx(['accordion-icon', { 'is-open': !isCollapsed }])} />
+      <span 
+        className={cx(
+          ['accordion-icon', { 'is-open': !isCollapsed }]
+        )} 
+      />
     </div>
   </div>
 );

--- a/packages/terra-table/src/subcomponents/_AccordionIconCell.jsx
+++ b/packages/terra-table/src/subcomponents/_AccordionIconCell.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
+import styles from './AccordionIconCell.module.scss';
+
+const cx = classNames.bind(styles);
+
+const propTypes = {
+  /**
+   * @private Whether or not the section is collapsed.
+   */
+  isCollapsed: PropTypes.bool,
+}
+
+const defaultProps = {
+  isCollapsed: false,
+};
+
+const AccordionIconCell = ({
+  isCollapsed,
+  ...customProps
+}) => (
+  <div
+    {...customProps}
+    className={customProps.className ? `${cx('cell')} ${customProps.className}` : cx('cell')}
+    role="none"
+  >
+    <div className={cx('container')}>
+    <span className={cx(['accordion-icon', { 'is-open': !isCollapsed }])} />
+    </div>
+  </div>
+);
+
+export default AccordionIconCell;

--- a/packages/terra-table/src/subcomponents/_HeaderAccordionIconCell.jsx
+++ b/packages/terra-table/src/subcomponents/_HeaderAccordionIconCell.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import classNames from 'classnames/bind';
+import styles from './HeaderAccordionIconCell.module.scss';
+
+const cx = classNames.bind(styles);
+
+const HeaderAccordionIconCell = ({
+  ...customProps
+}) => (
+  <div
+    {...customProps}
+    className={customProps.className ? `${cx('cell')} ${customProps.className}` : cx('cell')}
+    role="none"
+  >
+    <div className={cx('container')}>
+      <div 
+        className={cx(
+          'accordion-icon',
+        )} 
+      />
+    </div>
+  </div>
+);
+
+export default HeaderAccordionIconCell;

--- a/packages/terra-table/src/subcomponents/_Section.jsx
+++ b/packages/terra-table/src/subcomponents/_Section.jsx
@@ -37,31 +37,45 @@ const propTypes = {
    * Title text to be placed within the section header.
    */
   title: PropTypes.string.isRequired,
+  /**
+   * Whether or not the section header should be visible.
+   */
+   isSectionHeaderVisible: PropTypes.bool,
 };
 
 const defaultProps = {
   children: [],
   isCollapsed: false,
   isCollapsible: false,
+  isSectionHeaderVisible: true,
 };
 
 const Section = ({
   children,
   isCollapsed,
   isCollapsible,
+  isSectionHeaderVisible,
   ...customProps
 }) => {
   let sectionItems;
   if (!isCollapsible || !isCollapsed) {
     sectionItems = children;
   }
-
-  return (
-    <React.Fragment>
-      <SectionHeader {...customProps} isCollapsible={isCollapsible} isCollapsed={isCollapsed} />
-      {sectionItems}
-    </React.Fragment>
-  );
+  if (isSectionHeaderVisible) {
+    return (
+      <React.Fragment>
+        <SectionHeader {...customProps} isCollapsible={isCollapsible} isCollapsed={isCollapsed} />
+        {sectionItems}
+      </React.Fragment>
+    );
+  } else {
+    return (
+      <React.Fragment>
+        {sectionItems}
+      </React.Fragment>
+    );
+  }
+  
 };
 
 Section.propTypes = propTypes;

--- a/packages/terra-table/src/subcomponents/_SectionHeader.jsx
+++ b/packages/terra-table/src/subcomponents/_SectionHeader.jsx
@@ -88,7 +88,7 @@ const SectionHeader = ({
   ...customProps
 }) => {
   const attrSpread = {};
-  let titleElement = <span className={cx('title')}>{title}</span>;
+  let titleElement = <span className={cx('title')}>{`Amy4EditInVsCode_${title}`}</span>;
   let accordionIcon;
   if (isCollapsible) {
     accordionIcon = (

--- a/packages/terra-table/src/subcomponents/_SectionOfParentChildRows.jsx
+++ b/packages/terra-table/src/subcomponents/_SectionOfParentChildRows.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  /**
+   * The children list items passed to the component.
+   */
+     children: PropTypes.node,
+  /**
+   * Whether or not the section is collapsed.
+   */
+  isCollapsed: PropTypes.bool,
+  /**
+   * Whether or not the section can be collapsed.
+   */
+  isCollapsible: PropTypes.bool,
+  /**
+   * The associated metaData to be provided in the onSelect callback.
+   */
+  // eslint-disable-next-line react/forbid-prop-types
+  metaData: PropTypes.object,
+  /**
+   * Function callback for when the appropriate click or key action is performed.
+   * Callback contains the javascript event and prop metadata, e.g. onSelect(event, metaData)
+   */
+  onSelect: PropTypes.func,
+  /**
+   * Function callback pass-through for the ref of the section header.
+   */
+  refCallback: PropTypes.func,
+  /**
+   * Title text to be placed within the section header.
+   */
+  title: PropTypes.string.isRequired,
+};
+
+const defaultProps = {
+  children: [],
+  isCollapsed: false,
+  isCollapsible: false,
+};
+
+const SectionOfParentChildRows = ({
+  children,
+  isCollapsed,
+  isCollapsible,
+  ...customProps
+}) => {
+  let sectionItems;
+  if (!isCollapsible || !isCollapsed) {
+    sectionItems = children;
+  }
+
+  return (
+    <React.Fragment>
+      {sectionItems}
+    </React.Fragment>
+  );
+};
+
+SectionOfParentChildRows.propTypes = propTypes;
+SectionOfParentChildRows.defaultProps = defaultProps;
+
+export default SectionOfParentChildRows;


### PR DESCRIPTION
### Summary
When we click a parent row in a table, it will expand or contract its child rows. This is for https://jira2.cerner.com/browse/RCBACM-20374. 

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
