### PR TITLE
[terra-form-field] Marking asterisk on hideRequired fields as aria-hidden

### DIFF
--- a/packages/terra-form-field/CHANGELOG.md
+++ b/packages/terra-form-field/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Changed
   * Set the hideRequired prop to be private
   * Set the isLabelHidden prop to be private
+  * Set an asterisk denoting required field to be aria-hidden
 
 ## 4.20.5 - (July 5, 2022)
 

--- a/packages/terra-form-field/src/Field.jsx
+++ b/packages/terra-form-field/src/Field.jsx
@@ -182,7 +182,7 @@ const Field = (props) => {
       <label htmlFor={htmlFor} {...labelAttrs} className={labelClassNames}>
         {required && (isInvalid || !hideRequired) && <div className={cx('required')} aria-hidden="true">*</div>}
         {label}
-        {required && !isInvalid && hideRequired && <div className={cx('required-hidden')}>*</div>}
+        {required && !isInvalid && hideRequired && <div className={cx('required-hidden')} aria-hidden="true">*</div>}
         {showOptional && !required
             && (
               <FormattedMessage id="Terra.form.field.optional">

--- a/packages/terra-form-field/tests/jest/__snapshots__/Field.test.jsx.snap
+++ b/packages/terra-form-field/tests/jest/__snapshots__/Field.test.jsx.snap
@@ -940,6 +940,7 @@ exports[`should render a required field label with required hidden 1`] = `
     >
       Field Label
       <div
+        aria-hidden="true"
         className="required-hidden"
       >
         *


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? --> Marking asterisk as aria-hidden to avoid having screen readers reading it as asterisk (or other things).

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #
UXPLATFORM-7826

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
