### PR TITLE
Fixing Terra List Section Header Illegible In Lowlight Theme

### DIFF
--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Changed
   * Added a `ariaSelectionStyle` prop that provides accessibility support for single and multi select lists
+  * Fix section and subsection header colors in the lowlight theme.
 
 ## 4.52.0 - (December 7, 2022)
 

--- a/packages/terra-list/src/ListSectionHeader.jsx
+++ b/packages/terra-list/src/ListSectionHeader.jsx
@@ -83,7 +83,6 @@ const ListSectionHeader = ({
     cx(
       'section-header',
       { 'is-collapsible': isCollapsible },
-      theme.className,
     ),
     customProps.className,
   );
@@ -110,7 +109,7 @@ const ListSectionHeader = ({
   }
 
   return (
-    <li>
+    <li className={cx(theme.className)}>
       <Element className={cx('title')}>
         <div {...customProps} {...attrSpread} className={sectionHeaderClassNames} ref={refCallback}>
           {accordionIcon}

--- a/packages/terra-list/src/ListSubsectionHeader.jsx
+++ b/packages/terra-list/src/ListSubsectionHeader.jsx
@@ -83,7 +83,6 @@ const ListSubsectionHeader = ({
     cx(
       'subsection-header',
       { 'is-collapsible': isCollapsible },
-      theme.className,
     ),
     customProps.className,
   );
@@ -110,7 +109,7 @@ const ListSubsectionHeader = ({
   }
 
   return (
-    <li>
+    <li className={cx(theme.className)}>
       <Element className={cx('title')}>
         <div {...customProps} {...attrSpread} className={sectionHeaderClassNames} ref={refCallback}>
           {accordionIcon}

--- a/packages/terra-list/tests/jest/__snapshots__/ListSection.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/ListSection.test.jsx.snap
@@ -20,12 +20,14 @@ exports[`correctly applies the theme context className 1`] = `
       level={1}
       title="test"
     >
-      <li>
+      <li
+        className="orion-fusion-theme"
+      >
         <h1
           className="title"
         >
           <div
-            className="section-header orion-fusion-theme"
+            className="section-header"
           >
             <div
               className="fill"

--- a/packages/terra-list/tests/jest/__snapshots__/ListSectionHeader.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/ListSectionHeader.test.jsx.snap
@@ -14,12 +14,14 @@ exports[`correctly applies the theme context className 1`] = `
     level={1}
     title="test"
   >
-    <li>
+    <li
+      className="orion-fusion-theme"
+    >
       <h1
         className="title"
       >
         <div
-          className="section-header orion-fusion-theme"
+          className="section-header"
         >
           <div
             className="fill"
@@ -34,7 +36,9 @@ exports[`correctly applies the theme context className 1`] = `
 `;
 
 exports[`should render default 1`] = `
-<li>
+<li
+  className=""
+>
   <h1
     className="title"
   >
@@ -52,7 +56,9 @@ exports[`should render default 1`] = `
 `;
 
 exports[`should render with callback functions 1`] = `
-<li>
+<li
+  className=""
+>
   <h1
     className="title"
   >
@@ -85,7 +91,9 @@ exports[`should render with callback functions 1`] = `
 `;
 
 exports[`should render with isCollapsed 1`] = `
-<li>
+<li
+  className=""
+>
   <h1
     className="title"
   >
@@ -103,7 +111,9 @@ exports[`should render with isCollapsed 1`] = `
 `;
 
 exports[`should render with isCollapsible 1`] = `
-<li>
+<li
+  className=""
+>
   <h1
     className="title"
   >
@@ -134,7 +144,9 @@ exports[`should render with isCollapsible 1`] = `
 `;
 
 exports[`should render with level 1`] = `
-<li>
+<li
+  className=""
+>
   <h3
     className="title"
   >

--- a/packages/terra-list/tests/jest/__snapshots__/ListSubsection.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/ListSubsection.test.jsx.snap
@@ -20,12 +20,14 @@ exports[`correctly applies the theme context className 1`] = `
       level={2}
       title="test"
     >
-      <li>
+      <li
+        className="orion-fusion-theme"
+      >
         <h2
           className="title"
         >
           <div
-            className="subsection-header orion-fusion-theme"
+            className="subsection-header"
           >
             <div
               className="fill"

--- a/packages/terra-list/tests/jest/__snapshots__/ListSubsectionHeader.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/ListSubsectionHeader.test.jsx.snap
@@ -14,12 +14,14 @@ exports[`correctly applies the theme context className 1`] = `
     level={2}
     title="test"
   >
-    <li>
+    <li
+      className="orion-fusion-theme"
+    >
       <h2
         className="title"
       >
         <div
-          className="subsection-header orion-fusion-theme"
+          className="subsection-header"
         >
           <div
             className="fill"
@@ -34,7 +36,9 @@ exports[`correctly applies the theme context className 1`] = `
 `;
 
 exports[`should render default 1`] = `
-<li>
+<li
+  className=""
+>
   <h2
     className="title"
   >
@@ -52,7 +56,9 @@ exports[`should render default 1`] = `
 `;
 
 exports[`should render with callback functions 1`] = `
-<li>
+<li
+  className=""
+>
   <h2
     className="title"
   >
@@ -85,7 +91,9 @@ exports[`should render with callback functions 1`] = `
 `;
 
 exports[`should render with isCollapsed 1`] = `
-<li>
+<li
+  className=""
+>
   <h2
     className="title"
   >
@@ -103,7 +111,9 @@ exports[`should render with isCollapsed 1`] = `
 `;
 
 exports[`should render with isCollapsible 1`] = `
-<li>
+<li
+  className=""
+>
   <h2
     className="title"
   >
@@ -134,7 +144,9 @@ exports[`should render with isCollapsible 1`] = `
 `;
 
 exports[`should render with level 1`] = `
-<li>
+<li
+  className=""
+>
   <h3
     className="title"
   >


### PR DESCRIPTION
[UXPLATFORM-8082](https://jira2.cerner.com/browse/UXPLATFORM-8082)
===

### Summary
The section and subsection header's font color was hard to read with the lowlight theme. Before https://github.com/cerner/terra-core/pull/3673, it was working as intended with a light font color and a black background. This PR reverts it back to the way it was.

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
