### PR TITLE
Fix react-intl import to peerDependency

### DIFF
--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed `react-intl` import to peerDependency and match other Terra components.  
+
 ## 4.53.0 - (January 3, 2023)
+
 * Changed
   * Added a `ariaSelectionStyle` prop that provides accessibility support for single and multi select lists
   * Fix section and subsection header colors in the lowlight theme.

--- a/packages/terra-list/package.json
+++ b/packages/terra-list/package.json
@@ -23,14 +23,14 @@
   "homepage": "https://github.com/cerner/terra-core#readme",
   "peerDependencies": {
     "react": "^16.8.5",
-    "react-dom": "^16.8.5"
+    "react-dom": "^16.8.5",
+    "react-intl": ">=2.8.0 <6.0.0"
   },
   "dependencies": {
     "@cerner/terra-docs": "^1.8.0",
     "classnames": "^2.2.5",
     "keycode-js": "^3.1.0",
     "prop-types": "^15.5.8",
-    "react-intl": "^2.9.0",
     "terra-icon": "^3.49.0",
     "terra-mixins": "^1.40.0",
     "terra-theme-context": "^1.0.0"


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

Fixes react-intl import to peerDependency and versions `">-2.8.0 <6.0.0"` to match [other terra components](https://github.com/search?q=react-intl+repo%3Acerner%2Fterra-core+filename%3Apackage.json&type=Code&ref=advsearch&l=&l=). 

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes: UXPLATFORM-8138

<!-- ### Deployment Link -->
<!-- Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
<!-- https://terra-core-deployed-pr-#.herokuapp.com/ -->

<!--  ### Testing -->
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
