### PR TITLE
[terra-section-header] Fix default header defect

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added Accessibility Guide for `terra-section-header`
+
 ## 1.23.0 - (March 1, 2023)
 
 * Changed

--- a/packages/terra-core-docs/src/terra-dev-site/doc/section-header/AccessibilityGuide.4.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/section-header/AccessibilityGuide.4.doc.mdx
@@ -1,0 +1,168 @@
+import { Badge } from 'terra-section-header/package.json?dev-site-package';
+import { Notice } from '@cerner/terra-docs';
+import Whitespace from "../../common/layout-helpers/Whitespace";
+import AccordionSectionHeaderAccess from "./example/AccordionSectionHeaderAccess";
+
+
+<Badge />
+
+# Accessibility Guide for Terra Section Header
+
+## Why the accessibility of Terra Section Header?
+
+> The accessibility of Section Headers is important because headers are used on virtually every page and in every product. Section Headers convey the visual and programmatic structure and informational hierarchy of the page. The context headings provide also help users understand what to expect within the content. However, if section headers are not coded correctly or use words that accurately describe the content they represent, they can cause confusion, prevent users from understanding, and create accessibility barriers.
+> 
+> The code behind the headings provides context to the structure of the page and allows additional navigational methods for some assistive technology users. Improperly coded headings create accessibility barriers to these users.
+
+## Accessibility Considerations.
+
+### Content Considerations
+
+- Ensure each Section Header has a meaningful label that describe the purpose of the heading.
+  - Section Headers must accurately describe the content they represent.
+  - Provide engineers the meaningful label that matches for each heading.
+- Work with engineers to convey the structure of the page.
+  - For each heading on the page, provide the engineers with an appropriate heading level to use to match the placement of the heading on the page.
+- When implementing section header, do not override default theme colors of section header to ensure the Section Header be easily perceived against its background color. If changing the default colors, the text color must meet a minimum contrast ratio against the background color. See [WCAG 1.4.3 Contrast Minimum](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) and [1.4.11 Non-text Content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html) for more information.
+- Do not cause any unexpected events to occur on focus or on input of any actionable controls.
+
+### Code Considerations
+
+> - Section Headers must programmatically have a heading level that is set to match the structure of its placement on the page. Work with the Content creators to understand what level to assign each Section Header used.
+>   - Developers must apply the appropriate heading levels (1 to 6) prop to the heading. The heading level should match the hierarchical structure of the page. 
+<div aria-label="Example Demo">
+  <AccordionSectionHeaderAccess />
+</div>
+> ```jsx
+> const AccordionSectionHeader = () => {
+>   const [isOpen, setIsOpen] = useState(false);
+> 
+>   const handleClick = () => {
+>     setIsOpen(!isOpen);
+>   };
+> 
+>   const sectionHeaderProps = {
+>     isOpen,
+>     level: 3,
+>     onClick: handleClick,
+>   };
+> 
+>   return (
+>     <div>
+>       <Card>
+>        <Card.Body>
+>           <AccoordianExampleTemplate title="Patient is Allergic to:" heading="Documented Allergies" sectionHeaderAttrs={sectionHeaderProps}>
+>             <p>Cats</p>
+>             <p>Dogs</p>
+>             <p>Dust</p>
+>             <p>Mold</p>
+>             <p>Latex</p>
+>           </AccoordianExampleTemplate>
+>        </Card.Body>
+>       </Card>
+>     </div>
+>   );
+> };
+> ```
+>   - Terra Section Headers must always follow the correct heading level order and arrangement for where it is placed within other content on the page.
+>   - **IMPORTANT**: If a value to the `level` prop is not provided, default heading level will be rendered with heading `text` which would not be appropriate if level is not provided as per its placement in an application.
+> - For accessibility best practices, it is recommended that consumers should always use `only one` `<h1>` per page or view. The one `<h1>` should be the page title.
+>   - A section header should never be a heading level 1.
+> - Do not implement any action to activate on the down event. All actions must be initiated on the up event.
+
+## Usability Expectations:
+
+- User expects headings to describe the content they represent.
+- User does not expect to navigate to or interact with a Section Header unless it is expandable or collapsible.
+
+## Interaction Details
+
+- Terra Section Header, when expandable or collapsible, must be able to be accessed, interacted with, and acted upon using only the keyboard. Engineers must also ensure actional elements inside a Section Header can:
+- Receive focus in the logical reading order of the user.
+- Display a visible keyboard focus when the control is in focus.
+- Setting a Tabindex should not be required. However, if any elements are assigned a Tabindex, it is critical that a Tabindex higher than 0 is never used.
+
+### Keyboard Navigation
+
+The basic keyboard navigation expectations: 
+
+| Key/Sequence | Description |
+|---|---|
+|*Tab*| Moves focus on to and off an expandable/collapsible Section Header. User expects to navigate from element to interactable element User expects elements to receive focus in the logical reading order of the page. |
+|*Space & Enter*| When focus is on the Section Header of a collapsed section, expands the section and vice-versa.    |
+
+<Whitespace newline={4} />
+
+## Support Compliance:
+
+### Primary criteria related to Terra Section Header
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html) — Supports 
+  - Terra provides the ability for information, structure, and relationships to be programmatically determined. 
+  - Engineers must ensure any visual relationship with a section header and other content that conveys meaning must programmatically set associations to the content for visual relationships can be understood by screen reader users.
+  - Content creators should provide engineering with Section Header level to match structure within the page. Must also express to the engineer any visual relationships of a Section Header to other content for them to ensure engineers can programmatically convey the visual relationships.
+- [2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html) — Supports
+  - Terra provides the ability to create labels that are descriptive of their purpose. 
+  - Engineers must implement meaningful text for labels to accurately describe their purpose. 
+  - Content creators must ensure Section Headers and labels accurately describe the purpose of the content they represent.  
+### Other accessibility criteria consuming teams are responsible for 
+- [1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html) — Supports
+  - Terra provides the ability to use icons inside a Section Header.
+  - Engineers must ensure appropriate alternate content is added to graphics, icons, or images that convey meaning.  
+  - Content creators must provide engineers with alternate content that conveys meaning to the user. 
+- [1.3.2 Meaningful Sequence](https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence.html) - Supports
+  - Terra Section Header provides the ability for components to be presented in the order in which they are coded.
+  - Engineers must ensure content is meaningful and logical. If there is a visual presentation of content that is important for the user to understand, that must be available programmatically.
+  - Content creator must ensure content is read in a meaningful and logical order so as to not lose context. Must also convey to the engineers any visual presentation of the use of Section Header which creates meaning in the order so that it can be programmatically understood.
+- [1.4.10 Reflow](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html) — Supports
+  - Terra provides the ability for components to reflow when the viewport is resized to 320x256 px without loss of information or function.
+  - Engineers must ensure content within Terra Section Header can reflow when the viewport is resized to 320 x 256 px without scrolling in two directions or loss of information or functionality.
+  - Content creators must consider the responsive nature of Terra Section Header and provide engineers guidance on how it should content should reflow when the viewport is resized to 320 x 256 px
+- [1.4.11 Non-Text Contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html) — Supports
+  - Terra provides components that, by default, meet color contrast requirements. 
+  - Content creators must ensure any graphical elements used within Section Header that convey information meets a 3:1 color contrast ratio.
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) — Supports
+  - Terra Section Header provides components that, by default, meet color contrast requirements.
+  - Engineers must work with content creators to implement Section Header so that Section Header text color and the background color meet appropriate color contrast ratios.
+  - Content creators must ensure that the Section Header text color meets the appropriate contrast ratio against background color(s) based on text size of the visual structure text. Contrast ratios should be above 4.5:1 for normal text and 3:1 for bold and large text.
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html) — Supports
+  - Terra provides the ability for all interactable elements to receive focus, be interacted with, and be acted upon via keyboard.
+  - Engineers must ensure that all interactable elements can receive focus, be interacted with, and are able to be acted upon using the keyboard.
+  - Content creators must ensure that all interactable elements can receive focus, be interacted with, and are able to be acted upon using the keyboard.
+- [2.4.3 Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html) — Supports
+  - Terra provides the ability for actionable components to receive focus in the order they are coded.
+  - Engineers must ensure that the focus order is expected and preserves page meaning. Code order should follow the logical reading order of the user. Though a TABINDEX attribute should not be required to ensure keyboard use, if used, never use a TABINDEX value higher than 0.   
+  - Content creators should convey to the engineers the logical reading order of the page.
+- [2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html) — Supports
+  - Terra provides the ability for actionable elements to receive visual focus.
+  - Engineers must ensure a visible keyboard focus is maintained on all interactive elements. 
+  - Content creators must inform engineers that whenever Section Header receives focus, the focus must be visible and maintain existing Terra Keyboard Focus styles.
+- [2.5.2 Pointer Cancellation](https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation.html) — Supports
+  - Terra components use the up event to perform actions.
+  - Engineers must ensure actionable controls always take on the up event (never the down event).
+- [3.2.1 On Focus](https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html) — Supports 
+  - Terra components do not cause a change of context on focus by default.
+  - Engineers must ensure that no unexpected change of context happens when interactive elements receive focus.
+  - Content creators must inform engineers that Section Header should not cause any change when an interactable control receives focus. 
+- [3.2.4 Consistent Identification](https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification.html) — Supports 
+  - Terra provides the ability for elements to be consistently identified. 
+  - Engineers must ensure that elements used for the same function are identified consistently.
+  -	Content creators must ensure any icons used are used to represent the same function consistently. Additionally, the alternate content used to describe icons must be consistent for users to understand their function predictably.
+- [4.1.1 Parsing](https://www.w3.org/WAI/WCAG21/Understanding/parsing.html) — Supports 
+  -	Terra components are tested and validated before release to ensure proper code parsing. 
+  - Engineers must ensure their code is valid HTML.
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html) — Supports 
+  - Terra provides the ability for `Name` `Role`, and `Value` attributes to be programmatically determined so as to be read by screen readers. 
+  - Engineers must ensure child elements added into Section Header have an accessible name, proper role, and value for the intended use.  
+  - Content creators must provide engineers with names to appropriately identify controls added within Section Header.
+### Supported Features and Technology.
+- Keyboard Interactions
+- JAWS Support with Chrome (PC).
+- Voice Over Support with Chrome, Safari (MAC).
+- Speech Input Interactions with assistive technology.
+- Mobile Touch Interactions with Screen Reader assistive technology.
+### Partial Support & Requiring Further Enhancement.
+- [Report a problem with this component on GitHub](https://github.com/cerner/terra-core/issues/new/choose)
+## References:
+- [Web Content Accessibility Guidelines (WCAG) ](https://www.w3.org/WAI/WCAG21/Understanding/)
+- [WebAim.org: Semantic Structure: Regions, Headings, and Lists](https://webaim.org/techniques/semanticstructure/#headings)
+- [WebAim.org: Keyboard Accessibility](https://webaim.org/techniques/keyboard/)

--- a/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/AccordionExampleTemplate.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/AccordionExampleTemplate.jsx
@@ -15,7 +15,7 @@ const propTypes = {
   /**
    * Text to be displayed in the section header.
    */
-  text: PropTypes.string.isRequired,
+  text: PropTypes.string,
   /**
    * Used to set props and HTML attributes on the underlying section-header.
    */

--- a/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/AccordionSectionHeaderAccess.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/AccordionSectionHeaderAccess.jsx
@@ -19,7 +19,7 @@ const AccordionSectionHeaderAccess = () => {
     <div>
       <Card>
         <Card.Body>
-          <AccoordianExampleTemplate title="Patient is Allergic to:" heading="Documented Allergies" sectionHeaderAttrs={sectionHeaderProps}>
+          <AccoordianExampleTemplate text="Patient is Allergic to:" heading="Documented Allergies" sectionHeaderAttrs={sectionHeaderProps}>
             <p>Cats</p>
             <p>Dogs</p>
             <p>Dust</p>

--- a/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/AccordionSectionHeaderAccess.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/section-header/example/AccordionSectionHeaderAccess.jsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import Card from 'terra-card';
+import AccoordianExampleTemplate from './AccordionExampleTemplate';
+
+const AccordionSectionHeaderAccess = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const sectionHeaderProps = {
+    isOpen,
+    level: 3,
+    onClick: handleClick,
+  };
+
+  return (
+    <div>
+      <Card>
+        <Card.Body>
+          <AccoordianExampleTemplate title="Patient is Allergic to:" heading="Documented Allergies" sectionHeaderAttrs={sectionHeaderProps}>
+            <p>Cats</p>
+            <p>Dogs</p>
+            <p>Dust</p>
+            <p>Mold</p>
+            <p>Latex</p>
+          </AccoordianExampleTemplate>
+        </Card.Body>
+      </Card>
+    </div>
+  );
+};
+
+export default AccordionSectionHeaderAccess;

--- a/packages/terra-section-header/CHANGELOG.md
+++ b/packages/terra-section-header/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Added
   * Added console warnings for section-header.
+  
+* Changed
+  * Removed button role for non-interactive section header.
+  * Added aria-label for non-interactive section header.
+  * Updated jest snapshots due to removal of button role
 
 ## 2.58.0 - (February 15, 2023)
 

--- a/packages/terra-section-header/CHANGELOG.md
+++ b/packages/terra-section-header/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Removed required for `text` and `title` prop
+
 ## 2.59.0 - (March 1, 2023)
 
 * Added

--- a/packages/terra-section-header/CHANGELOG.md
+++ b/packages/terra-section-header/CHANGELOG.md
@@ -4,16 +4,16 @@
 
 * Changed
   * Removed required for `text` and `title` prop
+  * Removed button role for non-interactive section header.
+  * Updated jest snapshots due to removal of button role
+
+* Added
+  * Added aria-label for non-interactive section header.
 
 ## 2.59.0 - (March 1, 2023)
 
 * Added
   * Added console warnings for section-header.
-  
-* Changed
-  * Removed button role for non-interactive section header.
-  * Added aria-label for non-interactive section header.
-  * Updated jest snapshots due to removal of button role
 
 ## 2.58.0 - (February 15, 2023)
 

--- a/packages/terra-section-header/src/SectionHeader.jsx
+++ b/packages/terra-section-header/src/SectionHeader.jsx
@@ -14,12 +14,12 @@ const propTypes = {
    * ![IMPORTANT](https://badgen.net/badge/UX/Accessibility/blue)
    * Text to be displayed on the SectionHeader.
    */
-  text: PropTypes.string.isRequired,
+  text: PropTypes.string,
   /**
    * ![IMPORTANT](https://badgen.net/badge/prop/deprecated/red)
    * title prop has been deperecated and will be removed on next major version relase. Replace the `title` prop with `text` prop.
    */
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   /**
    * Callback function triggered when the accordion icon is clicked.
    */

--- a/packages/terra-section-header/src/SectionHeader.jsx
+++ b/packages/terra-section-header/src/SectionHeader.jsx
@@ -125,11 +125,11 @@ class SectionHeader extends React.Component {
     );
 
     const arrangeComp = (
-        <Arrange
-            fitStart={onClick && accordionIcon}
-            fill={<span aria-hidden={(onClick !== undefined)} className={cx('title')}>{headerText}</span>}
-            className={cx('title-arrange')}
-        />
+      <Arrange
+        fitStart={onClick && accordionIcon}
+        fill={<span aria-hidden={(onClick !== undefined)} className={cx('title')}>{headerText}</span>}
+        className={cx('title-arrange')}
+      />
     );
 
     const sectionHeaderClassNames = classNames(
@@ -163,20 +163,20 @@ class SectionHeader extends React.Component {
 
     if (onClick) {
       return (
-          <Element {...attributes} className={sectionHeaderClassNames}>
-            <div role="button" aria-expanded={isOpen} tabIndex="-1" aria-label={headerText} className={cx('arrange-wrapper')}>
-              {arrangeComp}
-            </div>
-          </Element>
-      );
-    }
-    else {
-      return (
-          <Element {...attributes} className={sectionHeaderClassNames} aria-label={headerText}>
+        <Element {...attributes} className={sectionHeaderClassNames}>
+          <div role="button" aria-expanded={isOpen} tabIndex="-1" aria-label={headerText} className={cx('arrange-wrapper')}>
             {arrangeComp}
-          </Element>
+          </div>
+        </Element>
       );
     }
+
+    return (
+      <Element {...attributes} className={sectionHeaderClassNames} aria-label={headerText}>
+        {arrangeComp}
+      </Element>
+    );
+
     /* eslint-enable jsx-a11y/no-static-element-interactions */
   }
 }

--- a/packages/terra-section-header/src/SectionHeader.jsx
+++ b/packages/terra-section-header/src/SectionHeader.jsx
@@ -107,8 +107,10 @@ class SectionHeader extends React.Component {
     const attributes = { ...customProps };
 
     if (onClick) {
+      attributes.tabIndex = '0';
       attributes.onKeyDown = this.wrapOnKeyDown(attributes.onKeyDown);
       attributes.onKeyUp = this.wrapOnKeyUp(attributes.onKeyUp);
+      attributes.onClick = onClick;
     }
 
     const iconClassNames = cx([
@@ -120,6 +122,14 @@ class SectionHeader extends React.Component {
       <div className={cx('accordion-icon-wrapper')}>
         <span className={iconClassNames} />
       </div>
+    );
+
+    const arrangeComp = (
+        <Arrange
+            fitStart={onClick && accordionIcon}
+            fill={<span aria-hidden={(onClick !== undefined)} className={cx('title')}>{headerText}</span>}
+            className={cx('title-arrange')}
+        />
     );
 
     const sectionHeaderClassNames = classNames(
@@ -150,17 +160,23 @@ class SectionHeader extends React.Component {
     // eslint doesn't know about this and so it marks this as a lint error
     /* eslint-disable jsx-a11y/click-events-have-key-events */
     /* eslint-disable jsx-a11y/no-static-element-interactions */
-    return (
-      <Element {...attributes} onClick={onClick} className={sectionHeaderClassNames} tabIndex="0">
-        <div role="button" aria-expanded={isOpen} tabIndex="-1" aria-label={headerText} className={cx('arrange-wrapper')}>
-          <Arrange
-            fitStart={onClick && accordionIcon}
-            fill={<span aria-hidden={(onClick !== undefined)} className={cx('title')}>{headerText}</span>}
-            className={cx('title-arrange')}
-          />
-        </div>
-      </Element>
-    );
+
+    if (onClick) {
+      return (
+          <Element {...attributes} className={sectionHeaderClassNames}>
+            <div role="button" aria-expanded={isOpen} tabIndex="-1" aria-label={headerText} className={cx('arrange-wrapper')}>
+              {arrangeComp}
+            </div>
+          </Element>
+      );
+    }
+    else {
+      return (
+          <Element {...attributes} className={sectionHeaderClassNames} aria-label={headerText}>
+            {arrangeComp}
+          </Element>
+      );
+    }
     /* eslint-enable jsx-a11y/no-static-element-interactions */
   }
 }

--- a/packages/terra-section-header/src/SectionHeader.jsx
+++ b/packages/terra-section-header/src/SectionHeader.jsx
@@ -124,14 +124,6 @@ class SectionHeader extends React.Component {
       </div>
     );
 
-    const arrangeComp = (
-      <Arrange
-        fitStart={onClick && accordionIcon}
-        fill={<span aria-hidden={(onClick !== undefined)} className={cx('title')}>{headerText}</span>}
-        className={cx('title-arrange')}
-      />
-    );
-
     const sectionHeaderClassNames = classNames(
       cx(
         'section-header',
@@ -166,7 +158,11 @@ class SectionHeader extends React.Component {
     return (
       <Element {...attributes} className={sectionHeaderClassNames} aria-label={!onClick ? headerText : undefined}>
         <div {...buttonAttributes} tabIndex="-1" className={cx('arrange-wrapper')}>
-          {arrangeComp}
+          <Arrange
+            fitStart={onClick && accordionIcon}
+            fill={<span aria-hidden={(onClick !== undefined)} className={cx('title')}>{headerText}</span>}
+            className={cx('title-arrange')}
+          />
         </div>
       </Element>
     );

--- a/packages/terra-section-header/src/SectionHeader.jsx
+++ b/packages/terra-section-header/src/SectionHeader.jsx
@@ -161,19 +161,13 @@ class SectionHeader extends React.Component {
     /* eslint-disable jsx-a11y/click-events-have-key-events */
     /* eslint-disable jsx-a11y/no-static-element-interactions */
 
-    if (onClick) {
-      return (
-        <Element {...attributes} className={sectionHeaderClassNames}>
-          <div role="button" aria-expanded={isOpen} tabIndex="-1" aria-label={headerText} className={cx('arrange-wrapper')}>
-            {arrangeComp}
-          </div>
-        </Element>
-      );
-    }
+    const buttonAttributes = (onClick) ? { role: 'button', 'aria-expanded': isOpen, 'aria-label': headerText } : undefined;
 
     return (
-      <Element {...attributes} className={sectionHeaderClassNames} aria-label={headerText}>
-        {arrangeComp}
+      <Element {...attributes} className={sectionHeaderClassNames} aria-label={!onClick ? headerText : undefined}>
+        <div {...buttonAttributes} tabIndex="-1" className={cx('arrange-wrapper')}>
+          {arrangeComp}
+        </div>
       </Element>
     );
 

--- a/packages/terra-section-header/tests/jest/__snapshots__/SectionHeader.test.jsx.snap
+++ b/packages/terra-section-header/tests/jest/__snapshots__/SectionHeader.test.jsx.snap
@@ -17,38 +17,43 @@ exports[`SectionHeader correctly applies the theme context className 1`] = `
       aria-label="foo"
       className="section-header orion-fusion-theme"
     >
-      <Arrange
-        className="title-arrange"
-        fill={
-          <span
-            aria-hidden={false}
-            className="title"
-          >
-            foo
-          </span>
-        }
+      <div
+        className="arrange-wrapper"
+        tabIndex="-1"
       >
-        <div
-          className="arrange title-arrange"
-        >
-          <div
-            className="fit"
-          />
-          <div
-            className="fill"
-          >
+        <Arrange
+          className="title-arrange"
+          fill={
             <span
               aria-hidden={false}
               className="title"
             >
               foo
             </span>
-          </div>
+          }
+        >
           <div
-            className="fit"
-          />
-        </div>
-      </Arrange>
+            className="arrange title-arrange"
+          >
+            <div
+              className="fit"
+            />
+            <div
+              className="fill"
+            >
+              <span
+                aria-hidden={false}
+                className="title"
+              >
+                foo
+              </span>
+            </div>
+            <div
+              className="fit"
+            />
+          </div>
+        </Arrange>
+      </div>
     </h2>
   </SectionHeader>
 </ThemeContextProvider>
@@ -59,17 +64,22 @@ exports[`SectionHeader should render a default component 1`] = `
   aria-label="foo"
   className="section-header"
 >
-  <Arrange
-    className="title-arrange"
-    fill={
-      <span
-        aria-hidden={false}
-        className="title"
-      >
-        foo
-      </span>
-    }
-  />
+  <div
+    className="arrange-wrapper"
+    tabIndex="-1"
+  >
+    <Arrange
+      className="title-arrange"
+      fill={
+        <span
+          aria-hidden={false}
+          className="title"
+        >
+          foo
+        </span>
+      }
+    />
+  </div>
 </h2>
 `;
 
@@ -167,24 +177,29 @@ exports[`SectionHeader should render without an accordion icon when no 'onClick(
   class="section-header"
 >
   <div
-    class="arrange title-arrange"
+    class="arrange-wrapper"
+    tabindex="-1"
   >
     <div
-      class="fit"
-    />
-    <div
-      class="fill"
+      class="arrange title-arrange"
     >
-      <span
-        aria-hidden="false"
-        class="title"
+      <div
+        class="fit"
+      />
+      <div
+        class="fill"
       >
-        foo
-      </span>
+        <span
+          aria-hidden="false"
+          class="title"
+        >
+          foo
+        </span>
+      </div>
+      <div
+        class="fit"
+      />
     </div>
-    <div
-      class="fit"
-    />
   </div>
 </h2>
 `;

--- a/packages/terra-section-header/tests/jest/__snapshots__/SectionHeader.test.jsx.snap
+++ b/packages/terra-section-header/tests/jest/__snapshots__/SectionHeader.test.jsx.snap
@@ -14,49 +14,41 @@ exports[`SectionHeader correctly applies the theme context className 1`] = `
     text="foo"
   >
     <h2
+      aria-label="foo"
       className="section-header orion-fusion-theme"
-      tabIndex="0"
     >
-      <div
-        aria-expanded={false}
-        aria-label="foo"
-        className="arrange-wrapper"
-        role="button"
-        tabIndex="-1"
+      <Arrange
+        className="title-arrange"
+        fill={
+          <span
+            aria-hidden={false}
+            className="title"
+          >
+            foo
+          </span>
+        }
       >
-        <Arrange
-          className="title-arrange"
-          fill={
+        <div
+          className="arrange title-arrange"
+        >
+          <div
+            className="fit"
+          />
+          <div
+            className="fill"
+          >
             <span
               aria-hidden={false}
               className="title"
             >
               foo
             </span>
-          }
-        >
-          <div
-            className="arrange title-arrange"
-          >
-            <div
-              className="fit"
-            />
-            <div
-              className="fill"
-            >
-              <span
-                aria-hidden={false}
-                className="title"
-              >
-                foo
-              </span>
-            </div>
-            <div
-              className="fit"
-            />
           </div>
-        </Arrange>
-      </div>
+          <div
+            className="fit"
+          />
+        </div>
+      </Arrange>
     </h2>
   </SectionHeader>
 </ThemeContextProvider>
@@ -64,28 +56,20 @@ exports[`SectionHeader correctly applies the theme context className 1`] = `
 
 exports[`SectionHeader should render a default component 1`] = `
 <h2
+  aria-label="foo"
   className="section-header"
-  tabIndex="0"
 >
-  <div
-    aria-expanded={false}
-    aria-label="foo"
-    className="arrange-wrapper"
-    role="button"
-    tabIndex="-1"
-  >
-    <Arrange
-      className="title-arrange"
-      fill={
-        <span
-          aria-hidden={false}
-          className="title"
-        >
-          foo
-        </span>
-      }
-    />
-  </div>
+  <Arrange
+    className="title-arrange"
+    fill={
+      <span
+        aria-hidden={false}
+        className="title"
+      >
+        foo
+      </span>
+    }
+  />
 </h2>
 `;
 
@@ -179,36 +163,28 @@ exports[`SectionHeader should render with an accordion icon when an 'onClick()' 
 
 exports[`SectionHeader should render without an accordion icon when no 'onClick()' is passed 1`] = `
 <h2
+  aria-label="foo"
   class="section-header"
-  tabindex="0"
 >
   <div
-    aria-expanded="false"
-    aria-label="foo"
-    class="arrange-wrapper"
-    role="button"
-    tabindex="-1"
+    class="arrange title-arrange"
   >
     <div
-      class="arrange title-arrange"
+      class="fit"
+    />
+    <div
+      class="fill"
     >
-      <div
-        class="fit"
-      />
-      <div
-        class="fill"
+      <span
+        aria-hidden="false"
+        class="title"
       >
-        <span
-          aria-hidden="false"
-          class="title"
-        >
-          foo
-        </span>
-      </div>
-      <div
-        class="fit"
-      />
+        foo
+      </span>
     </div>
+    <div
+      class="fit"
+    />
   </div>
 </h2>
 `;


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

- Fixes defect in default section header (non-interactive) by removing div with role=button
- Added a11y guide for section-header

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

Updated Jest snapshots

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
