### PR TITLE
[terra-core-docs] Fix paginator example

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Fix second example on default Paginator doc page
+
 ## 1.23.0 - (March 1, 2023)
 
 * Changed

--- a/packages/terra-core-docs/src/terra-dev-site/doc/paginator/example/PaginatorNoPagesExample.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/paginator/example/PaginatorNoPagesExample.jsx
@@ -43,7 +43,7 @@ class PaginatorNoPagesExample extends React.Component {
   }
 
   changePages(direction) {
-    const index = direction === 'next' ? this.state.currentPage + 1 : this.state.currentPage - 1;
+    const index = direction === 'Next' ? this.state.currentPage + 1 : this.state.currentPage - 1;
 
     if (index >= maxPages) {
       this.setState({ content: <h2>No more pages...</h2>, currentPage: maxPages });


### PR DESCRIPTION
### Summary
Second example on Paginator About page wasn't working because it checked for 'next' while the callback gets 'Next'. There's a deeper problem here with terra-paginator using an internationalized string for this purpose, but this fix allows for easy demonstration of that problem.
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
<!--- Closes # --->

<!--- ### Deployment Link --->
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
<!--- https://terra-core-deployed-pr-#.herokuapp.com/ -->

