### PR TITLE
Fixes cloning of RadioField children

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -104,6 +104,7 @@ Community
 - Cory McDonald [@corymcdonald]
 - Noah Benham [@noahbenham]
 - Payal Sawant [@PayalSawant]
+- Volodymyr Kondratenko [@vohaha]
 
 [@ryanthemanuel]: https://github.com/ryanthemanuel
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -205,3 +206,4 @@ Community
 [@JacksonJN]: https://github.com/JacksonJN
 [@manjusr]: https://github.com/manjusr
 [@saurabhkhare86]: https://github.com/SaurabhKhare86
+[@vohaha]: https://github.com/vohaha

--- a/packages/terra-form-checkbox/CHANGELOG.md
+++ b/packages/terra-form-checkbox/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed cloning of CheckboxField child to extend property instead of overriding it.
+
 ## 4.18.0 - (February 15, 2023)
 
 * Changed

--- a/packages/terra-form-checkbox/src/CheckboxField.jsx
+++ b/packages/terra-form-checkbox/src/CheckboxField.jsx
@@ -138,7 +138,7 @@ const CheckboxField = (props) => {
   const content = React.Children.map(children, (child) => {
     if (child && child.type.isCheckbox) {
       return React.cloneElement(child, {
-        inputAttrs: { 'aria-describedby': ariaDescriptionIds },
+        inputAttrs: { ...child.props.inputAttrs, 'aria-describedby': ariaDescriptionIds },
       });
     }
 

--- a/packages/terra-form-checkbox/tests/jest/CheckboxField.test.jsx
+++ b/packages/terra-form-checkbox/tests/jest/CheckboxField.test.jsx
@@ -4,6 +4,7 @@ import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import { shallowWithIntl, mountWithIntl } from 'terra-enzyme-intl';
 import CheckboxField from '../../src/CheckboxField';
+import Checkbox from '../../src/Checkbox';
 
 window.matchMedia = () => ({ matches: true });
 
@@ -74,5 +75,23 @@ it('correctly applies the theme context className', () => {
       <CheckboxField legend="Hidden Legend legend" />
     </ThemeContextProvider>,
   );
+  expect(wrapper).toMatchSnapshot();
+});
+
+it('correctly applies "inputAttrs" property to the Checkbox component', () => {
+  const attrKey = 'data-custom-attr';
+  const attrValue = 'attr data';
+  const checkboxField = (
+    <CheckboxField legend="Default CheckboxField">
+      <Checkbox
+        labelText="Default label"
+        inputAttrs={{
+          [attrKey]: attrValue,
+        }}
+      />
+    </CheckboxField>
+  );
+  const wrapper = mountWithIntl(checkboxField);
+  expect(wrapper.find('input').prop(attrKey)).toBe(attrValue);
   expect(wrapper).toMatchSnapshot();
 });

--- a/packages/terra-form-checkbox/tests/jest/__snapshots__/CheckboxField.test.jsx.snap
+++ b/packages/terra-form-checkbox/tests/jest/__snapshots__/CheckboxField.test.jsx.snap
@@ -1,5 +1,133 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`correctly applies "inputAttrs" property to the Checkbox component 1`] = `
+<InjectIntl(CheckboxField)
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": null,
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": null,
+    }
+  }
+  legend="Default CheckboxField"
+>
+  <CheckboxField
+    error={null}
+    help={null}
+    hideRequired={false}
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {},
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": null,
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": "span",
+        "timeZone": null,
+      }
+    }
+    isInline={false}
+    isInvalid={false}
+    isLegendHidden={false}
+    legend="Default CheckboxField"
+    legendAttrs={Object {}}
+    required={false}
+    showOptional={false}
+  >
+    <fieldset
+      className="checkbox-field"
+    >
+      <legend
+        className="legend-group"
+        id="terra-checkbox-field-description-2"
+      >
+        <div
+          className="legend"
+        >
+          Default CheckboxField
+          <span
+            className="error-icon-hidden"
+          />
+        </div>
+      </legend>
+      <Checkbox
+        disabled={false}
+        inputAttrs={
+          Object {
+            "aria-describedby": "terra-checkbox-field-description-2  ",
+            "data-custom-attr": "attr data",
+          }
+        }
+        isInline={false}
+        isLabelHidden={false}
+        key=".0"
+        labelText="Default label"
+        labelTextAttrs={Object {}}
+        name={null}
+      >
+        <div
+          className="checkbox"
+        >
+          <label
+            className="label"
+          >
+            <input
+              aria-describedby="terra-checkbox-field-description-2  "
+              className="native-input"
+              data-custom-attr="attr data"
+              disabled={false}
+              name={null}
+              type="checkbox"
+            />
+            <span
+              className="label-text"
+            >
+              Default label
+            </span>
+          </label>
+        </div>
+      </Checkbox>
+    </fieldset>
+  </CheckboxField>
+</InjectIntl(CheckboxField)>
+`;
+
 exports[`correctly applies the theme context className 1`] = `
 <ThemeContextProvider
   intl={

--- a/packages/terra-form-radio/CHANGELOG.md
+++ b/packages/terra-form-radio/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Fix cloning of RadioField child to extend property instead of overriding it.
+
 ## 4.34.0 - (March 1, 2023)
 
 * Changed

--- a/packages/terra-form-radio/CHANGELOG.md
+++ b/packages/terra-form-radio/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Changed
-  * Fix cloning of RadioField child to extend property instead of overriding it.
+* Fixed
+  * Fixed cloning of RadioField child to extend property instead of overriding it.
 
 ## 4.34.0 - (March 1, 2023)
 

--- a/packages/terra-form-radio/src/RadioField.jsx
+++ b/packages/terra-form-radio/src/RadioField.jsx
@@ -138,7 +138,7 @@ const RadioField = (props) => {
   const content = React.Children.map(children, (child) => {
     if (child && child.type.isRadio) {
       return React.cloneElement(child, {
-        inputAttrs: { 'aria-describedby': ariaDescriptionIds, ...child.props.inputAttrs },
+        inputAttrs: { ...child.props.inputAttrs, 'aria-describedby': ariaDescriptionIds },
       });
     }
 

--- a/packages/terra-form-radio/src/RadioField.jsx
+++ b/packages/terra-form-radio/src/RadioField.jsx
@@ -138,7 +138,7 @@ const RadioField = (props) => {
   const content = React.Children.map(children, (child) => {
     if (child && child.type.isRadio) {
       return React.cloneElement(child, {
-        inputAttrs: { 'aria-describedby': ariaDescriptionIds },
+        inputAttrs: { 'aria-describedby': ariaDescriptionIds, ...child.props.inputAttrs },
       });
     }
 

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -93,4 +93,5 @@ it('correctly applies "inputAttrs" property to the Radio component', () => {
   );
   const wrapper = mountWithIntl(radioField);
   expect(wrapper.find('input').prop(attrKey)).toBe(attrValue);
+  expect(wrapper).toMatchSnapshot();
 });

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -4,6 +4,7 @@ import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import { shallowWithIntl, mountWithIntl } from 'terra-enzyme-intl';
 import RadioField from '../../src/RadioField';
+import Radio from '../../src/Radio';
 
 window.matchMedia = () => ({ matches: true });
 
@@ -75,4 +76,21 @@ it('correctly applies the theme context className', () => {
     </ThemeContextProvider>,
   );
   expect(wrapper).toMatchSnapshot();
+});
+
+it('correctly applies "inputAttrs" property to the Radio component', () => {
+  const attrKey = 'data-custom-attr';
+  const attrValue = 'attr data';
+  const radioField = (
+    <RadioField legend="Default RadioField">
+      <Radio
+        labelText="Default label"
+        inputAttrs={{
+          [attrKey]: attrValue,
+        }}
+      />
+    </RadioField>
+  );
+  const wrapper = mountWithIntl(radioField);
+  expect(wrapper.find('input').prop(attrKey)).toBe(attrValue);
 });

--- a/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
+++ b/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
@@ -1,5 +1,141 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
+<InjectIntl(RadioField)
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": null,
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": null,
+    }
+  }
+  legend="Default RadioField"
+>
+  <RadioField
+    error={null}
+    help={null}
+    hideRequired={false}
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {},
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": null,
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": "span",
+        "timeZone": null,
+      }
+    }
+    isInline={false}
+    isInvalid={false}
+    isLegendHidden={false}
+    legend="Default RadioField"
+    legendAttrs={Object {}}
+    required={false}
+    showOptional={false}
+  >
+    <fieldset
+      className="radio-field"
+      required={false}
+    >
+      <legend
+        className="legend-group"
+        id="terra-radio-field-description-2"
+      >
+        <div
+          className="legend"
+        >
+          Default RadioField
+          <span
+            className="error-icon-hidden"
+          />
+        </div>
+      </legend>
+      <Radio
+        disabled={false}
+        inputAttrs={
+          Object {
+            "aria-describedby": "terra-radio-field-description-2  ",
+            "data-custom-attr": "attr data",
+          }
+        }
+        isInline={false}
+        isLabelHidden={false}
+        key=".0"
+        labelText="Default label"
+        labelTextAttrs={Object {}}
+        name={null}
+      >
+        <div
+          className="radio"
+        >
+          <label
+            className="label"
+          >
+            <input
+              aria-describedby="terra-radio-field-description-2  "
+              className="native-input"
+              data-custom-attr="attr data"
+              disabled={false}
+              name={null}
+              type="radio"
+            />
+            <span
+              className="outer-ring"
+            >
+              <span
+                className="inner-ring"
+              />
+            </span>
+            <span
+              className="label-text"
+            >
+              Default label
+            </span>
+          </label>
+        </div>
+      </Radio>
+    </fieldset>
+  </RadioField>
+</InjectIntl(RadioField)>
+`;
+
 exports[`correctly applies the theme context className 1`] = `
 <ThemeContextProvider
   intl={


### PR DESCRIPTION
### Summary
When RadioField wraps Radio components, it clones children and overrides the `inputAttrs` property of Radio components. 
This PR suggests replacing overriding with extending to keep the `inputAttrs` property of the Radio component working.

### Testing
Tested with Jest.

### Additional Details
I cannot run the wdio tests (even on the main branch) due to some tech issues that I'm still investigating. But I suppose that changes in the current PR don't affect the wdio tests, otherwise, let me know about it, please.

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
