### PR TITLE
[terra-core-docs] Update Terra Alert examples for a11y

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -12,7 +12,8 @@
   * Added Accessibility Guide for `terra-section-header`
   * Added accessibility guide for `terra-progress-bar`
   * Added accessibility guide for `terra-avatar`
-  
+  * Added examples for for `terra-alert`
+
 * Changed
   * Added tests for `terra-list`.
   * Fix second example on default Paginator doc page

--- a/packages/terra-core-docs/src/terra-dev-site/test/alert/AlertDismissible.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/alert/AlertDismissible.test.jsx
@@ -15,9 +15,7 @@ const AlertDismissible = () => {
     SUCCESS: 'success',
   };
   const [isOpen, setIsOpen] = useState(true);
-  const [selectedAlertType, setSelectedAlertType] = useState(
-    AlertTypes.SUCCESS
-  );
+  const [selectedAlertType, setSelectedAlertType] = useState(AlertTypes.SUCCESS);
 
   return (
     <>
@@ -27,7 +25,7 @@ const AlertDismissible = () => {
           type={selectedAlertType}
           onDismiss={() => setIsOpen(false)}
         >
-          This is a dismissable Alert.
+          This is a dismissible Alert.
         </Alert>
       )}
       <br />

--- a/packages/terra-core-docs/src/terra-dev-site/test/alert/AlertDismissible.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/alert/AlertDismissible.test.jsx
@@ -1,28 +1,56 @@
 import React, { useState } from 'react';
 import Button from 'terra-button';
 import Alert from 'terra-alert';
+import NativeSelect from 'terra-form-select/lib/native-select/NativeSelect';
 
 const AlertDismissible = () => {
+  const AlertTypes = {
+    ALERT: 'alert',
+    ERROR: 'error',
+    WARNING: 'warning',
+    UNSATISFIED: 'unsatisfied',
+    UNVERIFIED: 'unverified',
+    ADVISORY: 'advisory',
+    INFO: 'info',
+    SUCCESS: 'success',
+  };
   const [isOpen, setIsOpen] = useState(true);
-
-  if (!isOpen) {
-    return (
-      <>
-        <div id="dismissed">Alert was dismissed</div>
-        <Button
-          text="Trigger Alert"
-          onClick={() => {
-            setIsOpen(true);
-          }}
-        />
-      </>
-    );
-  }
+  const [selectedAlertType, setSelectedAlertType] = useState(
+    AlertTypes.SUCCESS
+  );
 
   return (
-    <Alert id="dismissibleAlert" type="success" onDismiss={() => setIsOpen(false)}>
-      This is a dismissable Alert.
-    </Alert>
+    <>
+      {isOpen && (
+        <Alert
+          id="dismissibleAlert"
+          type={selectedAlertType}
+          onDismiss={() => setIsOpen(false)}
+        >
+          This is a dismissable Alert.
+        </Alert>
+      )}
+      <br />
+      <div id="dismissed">Select alert type:</div>
+      <NativeSelect
+        ariaLabel="Alert types"
+        isFilterStyle
+        onChange={(event) => setSelectedAlertType(event.currentTarget.value)}
+        options={Object.values(AlertTypes).map((alertType) => ({
+          value: alertType,
+          display: alertType,
+        }))}
+        value={selectedAlertType}
+      />
+      <br />
+      <Button
+        isDisabled={isOpen}
+        text="Trigger Alert"
+        onClick={() => {
+          setIsOpen(true);
+        }}
+      />
+    </>
   );
 };
 

--- a/packages/terra-core-docs/src/terra-dev-site/test/alert/AlertDismissible.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/alert/AlertDismissible.test.jsx
@@ -1,54 +1,28 @@
 import React, { useState } from 'react';
 import Button from 'terra-button';
 import Alert from 'terra-alert';
-import NativeSelect from 'terra-form-select/lib/native-select/NativeSelect';
 
 const AlertDismissible = () => {
-  const AlertTypes = {
-    ALERT: 'alert',
-    ERROR: 'error',
-    WARNING: 'warning',
-    UNSATISFIED: 'unsatisfied',
-    UNVERIFIED: 'unverified',
-    ADVISORY: 'advisory',
-    INFO: 'info',
-    SUCCESS: 'success',
-  };
   const [isOpen, setIsOpen] = useState(true);
-  const [selectedAlertType, setSelectedAlertType] = useState(AlertTypes.SUCCESS);
+
+  if (!isOpen) {
+    return (
+      <>
+        <div id="dismissed">Alert was dismissed</div>
+        <Button
+          text="Trigger Alert"
+          onClick={() => {
+            setIsOpen(true);
+          }}
+        />
+      </>
+    );
+  }
 
   return (
-    <>
-      {isOpen && (
-        <Alert
-          id="dismissibleAlert"
-          type={selectedAlertType}
-          onDismiss={() => setIsOpen(false)}
-        >
-          This is a dismissible Alert.
-        </Alert>
-      )}
-      <br />
-      <div id="dismissed">Select alert type:</div>
-      <NativeSelect
-        ariaLabel="Alert types"
-        isFilterStyle
-        onChange={(event) => setSelectedAlertType(event.currentTarget.value)}
-        options={Object.values(AlertTypes).map((alertType) => ({
-          value: alertType,
-          display: alertType,
-        }))}
-        value={selectedAlertType}
-      />
-      <br />
-      <Button
-        isDisabled={isOpen}
-        text="Trigger Alert"
-        onClick={() => {
-          setIsOpen(true);
-        }}
-      />
-    </>
+    <Alert id="dismissibleAlert" type="success" onDismiss={() => setIsOpen(false)}>
+      This is a dismissable Alert.
+    </Alert>
   );
 };
 

--- a/packages/terra-core-docs/src/terra-dev-site/test/alert/CustomPropAlert.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/alert/CustomPropAlert.test.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Alert from 'terra-alert';
 import Button from 'terra-button';
 import IconHelp from 'terra-icon/lib/icon/IconHelp';
+import Input from 'terra-form-input';
 import MultiSelect from 'terra-form-select/lib/MultiSelect';
 import NativeSelect from 'terra-form-select/lib/native-select/NativeSelect';
 import classNames from 'classnames/bind';
@@ -34,19 +35,24 @@ const CustomPropExample = () => {
     custom: 'Welcome to Terra!',
   };
   const [actionButtonClickCount, setActionButtonClickCount] = useState(0);
+  const [alertDelay, setAlertDelay] = useState(3000);
   const [alerts, setAlerts] = useState([
     {
       type: AlertTypes.SUCCESS,
       onDismiss: true,
     },
   ]);
-  const [selectedAlertType, setSelectedAlertType] = useState(
-    AlertTypes.SUCCESS
-  );
+  const [selectedAlertType, setSelectedAlertType] = useState(AlertTypes.SUCCESS);
   const [selectedProps, setSelectedProps] = useState(['onDismiss']);
 
   const handleActionClick = () => {
     setActionButtonClickCount((prevCount) => prevCount + 1);
+  };
+
+  const handleAlertDismiss = (index) => {
+    const updatedAlerts = [...alerts];
+    updatedAlerts.splice(index, 1);
+    setAlerts(updatedAlerts);
   };
 
   const triggerNewAlert = () => {
@@ -63,6 +69,10 @@ const CustomPropExample = () => {
                   onClick={handleActionClick}
                 />
               ) : null,
+            customColorClass:
+              selectedProps.indexOf('customColorClass') >= 0
+                ? cx(['my-app-alert-help-example'])
+                : null,
             customIcon:
               selectedProps.indexOf('customIcon') >= 0 ? <IconHelp /> : null,
             title: selectedProps.indexOf('title') >= 0 ? 'Terra Message' : null,
@@ -71,7 +81,7 @@ const CustomPropExample = () => {
         });
         setAlerts([...alerts]);
       },
-      selectedProps.indexOf('alertDelay') >= 0 ? 3000 : 0
+      selectedProps.indexOf('alertDelay') >= 0 ? alertDelay : 0,
     );
   };
 
@@ -82,14 +92,11 @@ const CustomPropExample = () => {
           <Alert
             key={index}
             id="customAlert"
-            customColorClass={cx(['my-app-alert-help-example'])}
             type={alert.type}
             onDismiss={
               alert.onDismiss
                 ? () => {
-                    const updatedAlerts = [...alerts];
-                    updatedAlerts.splice(index, 1);
-                    setAlerts(updatedAlerts);
+                    handleAlertDismiss(index);
                   }
                 : null
             }
@@ -117,11 +124,27 @@ const CustomPropExample = () => {
         onChange={setSelectedProps}
       >
         <MultiSelect.Option value="action" display="action (prop)" />
+        <MultiSelect.Option
+          value="customColorClass"
+          display="customColorClass (prop)"
+        />
         <MultiSelect.Option value="customIcon" display="customIcon (prop)" />
         <MultiSelect.Option value="onDismiss" display="onDismiss (prop)" />
         <MultiSelect.Option value="title" display="title (prop)" />
         <MultiSelect.Option value="alertDelay" display="alertDelay" />
       </MultiSelect>
+      {selectedProps.indexOf('alertDelay') >= 0 && (
+        <>
+          <div id="alertDelay">Set alert delay (ms):</div>
+          <Input
+            ariaLabel="Numeric Input"
+            name="Set alert delay (ms)"
+            onChange={(event) => setAlertDelay(event.target.value)}
+            type="number"
+            value={alertDelay}
+          />
+        </>
+      )}
       <br />
       <Button text="Trigger Alert" onClick={triggerNewAlert} />
       <p>{`Action button has been clicked ${actionButtonClickCount} times.`}</p>

--- a/packages/terra-core-docs/src/terra-dev-site/test/alert/CustomPropAlert.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/alert/CustomPropAlert.test.jsx
@@ -10,6 +10,8 @@ import styles from '../../doc/alert/example/colors.module.scss';
 
 const cx = classNames.bind(styles);
 
+let alertIdx = 0;
+
 const CustomPropExample = () => {
   const AlertTypes = {
     ALERT: 'alert',
@@ -38,6 +40,7 @@ const CustomPropExample = () => {
   const [alertDelay, setAlertDelay] = useState(3000);
   const [alerts, setAlerts] = useState([
     {
+      id: alertIdx,
       type: AlertTypes.SUCCESS,
       onDismiss: true,
     },
@@ -58,7 +61,9 @@ const CustomPropExample = () => {
   const triggerNewAlert = () => {
     setTimeout(
       () => {
+        alertIdx += 1;
         alerts.push({
+          id: alertIdx,
           type: selectedAlertType,
           props: {
             action:
@@ -89,8 +94,7 @@ const CustomPropExample = () => {
     <>
       {alerts && alerts.map((alert, index) => (
         <Alert
-          // eslint-disable-next-line react/no-array-index-key
-          key={index}
+          key={alert.id}
           id="customAlert"
           type={alert.type}
           onDismiss={

--- a/packages/terra-core-docs/src/terra-dev-site/test/alert/CustomPropAlert.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/alert/CustomPropAlert.test.jsx
@@ -1,0 +1,155 @@
+import React, { useState } from 'react';
+import Alert from 'terra-alert';
+import Button from 'terra-button';
+import IconHelp from 'terra-icon/lib/icon/IconHelp';
+import MultiSelect from 'terra-form-select/lib/MultiSelect';
+import NativeSelect from 'terra-form-select/lib/native-select/NativeSelect';
+import classNames from 'classnames/bind';
+import styles from '../../doc/alert/example/colors.module.scss';
+
+const cx = classNames.bind(styles);
+
+const CustomPropExample = () => {
+  const AlertTypes = {
+    ALERT: 'alert',
+    ERROR: 'error',
+    WARNING: 'warning',
+    UNSATISFIED: 'unsatisfied',
+    UNVERIFIED: 'unverified',
+    ADVISORY: 'advisory',
+    INFO: 'info',
+    SUCCESS: 'success',
+    CUSTOM: 'custom',
+  };
+  const alertTypeMessages = {
+    alert: 'Site is down for maintenance.',
+    error: 'Unable to save at this time. Please try again later.',
+    warning: 'There are unsaved changes.',
+    unsatisfied:
+      'Only one package must be selected before the Activate Content button is clicked.',
+    unverified: 'This item is not verified.',
+    advisory: 'This item is typically not used.',
+    info: 'This receipt is for a bill-only purchase order.',
+    success: 'Changes successfully committed.',
+    custom: 'Welcome to Terra!',
+  };
+  const longText = () => (
+    <>
+      <p>
+        Four score and seven years ago our fathers brought forth on this
+        continent, a new nation, conceived in Liberty, and dedicated to the
+        proposition that all men are created equal.
+      </p>
+      <p>
+        Now we are engaged in a great civil war, testing whether that nation, or
+        any nation so conceived and so dedicated, can long endure. We are met on
+        a great battle-field of that war. We have come to dedicate a portion of
+        that field, as a final resting place for those who here gave their lives
+        that that nation might live. It is altogether fitting and proper that we
+        should do this.
+      </p>
+      <p>
+        But, in a larger sense, we can not dedicate -- we can not consecrate --
+        we can not hallow -- this ground. The brave men, living and dead, who
+        struggled here, have consecrated it, far above our poor power to add or
+        detract. The world will little note, nor long remember what we say here,
+        but it can never forget what they did here. It is for us the living,
+        rather, to be dedicated here to the unfinished work which they who
+        fought here have thus far so nobly advanced. It is rather for us to be
+        here dedicated to the great task remaining before us -- that from these
+        honored dead we take increased devotion to that cause for which they
+        gave the last full measure of devotion -- that we here highly resolve
+        that these dead shall not have died in vain -- that this nation, under
+        God, shall have a new birth of freedom -- and that government of the
+        people, by the people, for the people, shall not perish from the earth.
+      </p>
+    </>
+  );
+  const [actionButtonClickCount, setActionButtonClickCount] = useState(0);
+  const [alerts, setAlerts] = useState([]);
+  const [selectedAlertType, setSelectedAlertType] = useState(
+    AlertTypes.SUCCESS
+  );
+  const [selectedProps, setSelectedProps] = useState(['onDismiss']);
+
+  const handleActionClick = () => {
+    setActionButtonClickCount((prevCount) => prevCount + 1);
+  };
+
+  const triggerNewAlert = () => {
+    alerts.push({
+      type: selectedAlertType,
+      props: {
+        action:
+          selectedProps.indexOf('action') >= 0 ? (
+            <Button
+              text="Action"
+              variant="emphasis"
+              onClick={handleActionClick}
+            />
+          ) : null,
+        customIcon:
+          selectedProps.indexOf('customIcon') >= 0 ? <IconHelp /> : null,
+        title: selectedProps.indexOf('title') >= 0 ? 'Terra Message' : null,
+      },
+      onDismiss: selectedProps.indexOf('onDismiss') >= 0,
+      useLongerText: selectedProps.indexOf('useLongerText') >= 0,
+    });
+    setAlerts([...alerts]);
+  };
+
+  return (
+    <>
+      {alerts &&
+        alerts.map((alert, index) => (
+          <Alert
+            key={index}
+            id="customAlert"
+            customColorClass={cx(['my-app-alert-help-example'])}
+            type={alert.type}
+            onDismiss={
+              alert.onDismiss
+                ? () => {
+                    const updatedAlerts = [...alerts];
+                    updatedAlerts.splice(index, 1);
+                    setAlerts(updatedAlerts);
+                  }
+                : null
+            }
+            {...alert.props}
+          >
+            {alert.useLongerText ? longText() : alertTypeMessages[alert.type]}
+          </Alert>
+        ))}
+      <br />
+      <div id="alertType">Select alert type:</div>
+      <NativeSelect
+        ariaLabel="Alert types"
+        isFilterStyle
+        onChange={(event) => setSelectedAlertType(event.currentTarget.value)}
+        options={Object.values(AlertTypes).map((alertType) => ({
+          value: alertType,
+          display: alertType,
+        }))}
+        value={selectedAlertType}
+      />
+      <div id="alertProps">Select alert props/options:</div>
+      <MultiSelect
+        placeholder="Select alert props"
+        value={selectedProps}
+        onChange={setSelectedProps}
+      >
+        <MultiSelect.Option value="action" display="action" />
+        <MultiSelect.Option value="customIcon" display="customIcon" />
+        <MultiSelect.Option value="onDismiss" display="onDismiss" />
+        <MultiSelect.Option value="title" display="title" />
+        <MultiSelect.Option value="useLongerText" display="Use Long Text" />
+      </MultiSelect>
+      <br />
+      <Button text="Trigger Alert" onClick={triggerNewAlert} />
+      <p>{`Action button has been clicked ${actionButtonClickCount} times.`}</p>
+    </>
+  );
+};
+
+export default CustomPropExample;

--- a/packages/terra-core-docs/src/terra-dev-site/test/alert/CustomPropAlert.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/alert/CustomPropAlert.test.jsx
@@ -160,7 +160,7 @@ const CustomPropExample = () => {
         </>
       )}
       <br />
-      <Button text="Trigger Custom Alert" onClick={triggerNewAlert} />
+      <Button text="Trigger Alert" onClick={triggerNewAlert} />
       <Button
         isDisabled={isOpen}
         text="Trigger Replaceable Alert"

--- a/packages/terra-core-docs/src/terra-dev-site/test/alert/CustomPropAlert.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/alert/CustomPropAlert.test.jsx
@@ -33,40 +33,13 @@ const CustomPropExample = () => {
     success: 'Changes successfully committed.',
     custom: 'Welcome to Terra!',
   };
-  const longText = () => (
-    <>
-      <p>
-        Four score and seven years ago our fathers brought forth on this
-        continent, a new nation, conceived in Liberty, and dedicated to the
-        proposition that all men are created equal.
-      </p>
-      <p>
-        Now we are engaged in a great civil war, testing whether that nation, or
-        any nation so conceived and so dedicated, can long endure. We are met on
-        a great battle-field of that war. We have come to dedicate a portion of
-        that field, as a final resting place for those who here gave their lives
-        that that nation might live. It is altogether fitting and proper that we
-        should do this.
-      </p>
-      <p>
-        But, in a larger sense, we can not dedicate -- we can not consecrate --
-        we can not hallow -- this ground. The brave men, living and dead, who
-        struggled here, have consecrated it, far above our poor power to add or
-        detract. The world will little note, nor long remember what we say here,
-        but it can never forget what they did here. It is for us the living,
-        rather, to be dedicated here to the unfinished work which they who
-        fought here have thus far so nobly advanced. It is rather for us to be
-        here dedicated to the great task remaining before us -- that from these
-        honored dead we take increased devotion to that cause for which they
-        gave the last full measure of devotion -- that we here highly resolve
-        that these dead shall not have died in vain -- that this nation, under
-        God, shall have a new birth of freedom -- and that government of the
-        people, by the people, for the people, shall not perish from the earth.
-      </p>
-    </>
-  );
   const [actionButtonClickCount, setActionButtonClickCount] = useState(0);
-  const [alerts, setAlerts] = useState([]);
+  const [alerts, setAlerts] = useState([
+    {
+      type: AlertTypes.SUCCESS,
+      onDismiss: true,
+    },
+  ]);
   const [selectedAlertType, setSelectedAlertType] = useState(
     AlertTypes.SUCCESS
   );
@@ -77,25 +50,29 @@ const CustomPropExample = () => {
   };
 
   const triggerNewAlert = () => {
-    alerts.push({
-      type: selectedAlertType,
-      props: {
-        action:
-          selectedProps.indexOf('action') >= 0 ? (
-            <Button
-              text="Action"
-              variant="emphasis"
-              onClick={handleActionClick}
-            />
-          ) : null,
-        customIcon:
-          selectedProps.indexOf('customIcon') >= 0 ? <IconHelp /> : null,
-        title: selectedProps.indexOf('title') >= 0 ? 'Terra Message' : null,
+    setTimeout(
+      () => {
+        alerts.push({
+          type: selectedAlertType,
+          props: {
+            action:
+              selectedProps.indexOf('action') >= 0 ? (
+                <Button
+                  text="Action"
+                  variant="emphasis"
+                  onClick={handleActionClick}
+                />
+              ) : null,
+            customIcon:
+              selectedProps.indexOf('customIcon') >= 0 ? <IconHelp /> : null,
+            title: selectedProps.indexOf('title') >= 0 ? 'Terra Message' : null,
+          },
+          onDismiss: selectedProps.indexOf('onDismiss') >= 0,
+        });
+        setAlerts([...alerts]);
       },
-      onDismiss: selectedProps.indexOf('onDismiss') >= 0,
-      useLongerText: selectedProps.indexOf('useLongerText') >= 0,
-    });
-    setAlerts([...alerts]);
+      selectedProps.indexOf('alertDelay') >= 0 ? 3000 : 0
+    );
   };
 
   return (
@@ -118,7 +95,7 @@ const CustomPropExample = () => {
             }
             {...alert.props}
           >
-            {alert.useLongerText ? longText() : alertTypeMessages[alert.type]}
+            {alertTypeMessages[alert.type]}
           </Alert>
         ))}
       <br />
@@ -139,11 +116,11 @@ const CustomPropExample = () => {
         value={selectedProps}
         onChange={setSelectedProps}
       >
-        <MultiSelect.Option value="action" display="action" />
-        <MultiSelect.Option value="customIcon" display="customIcon" />
-        <MultiSelect.Option value="onDismiss" display="onDismiss" />
-        <MultiSelect.Option value="title" display="title" />
-        <MultiSelect.Option value="useLongerText" display="Use Long Text" />
+        <MultiSelect.Option value="action" display="action (prop)" />
+        <MultiSelect.Option value="customIcon" display="customIcon (prop)" />
+        <MultiSelect.Option value="onDismiss" display="onDismiss (prop)" />
+        <MultiSelect.Option value="title" display="title (prop)" />
+        <MultiSelect.Option value="alertDelay" display="alertDelay" />
       </MultiSelect>
       <br />
       <Button text="Trigger Alert" onClick={triggerNewAlert} />

--- a/packages/terra-core-docs/src/terra-dev-site/test/alert/CustomPropAlert.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/alert/CustomPropAlert.test.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Alert from 'terra-alert';
 import Button from 'terra-button';
 import IconHelp from 'terra-icon/lib/icon/IconHelp';
@@ -45,24 +45,25 @@ const CustomPropExample = () => {
       onDismiss: true,
     },
   ]);
+  const [isOpen, setIsOpen] = useState(false);
   const [selectedAlertType, setSelectedAlertType] = useState(AlertTypes.SUCCESS);
   const [selectedProps, setSelectedProps] = useState(['onDismiss']);
+  const alertsRef = useRef(alerts);
 
   const handleActionClick = () => {
     setActionButtonClickCount((prevCount) => prevCount + 1);
   };
 
   const handleAlertDismiss = (index) => {
-    const updatedAlerts = [...alerts];
-    updatedAlerts.splice(index, 1);
-    setAlerts(updatedAlerts);
+    alertsRef.current.splice(index, 1);
+    setAlerts([...alertsRef.current]);
   };
 
   const triggerNewAlert = () => {
     setTimeout(
       () => {
         alertIdx += 1;
-        alerts.push({
+        alertsRef.current.push({
           id: alertIdx,
           type: selectedAlertType,
           props: {
@@ -84,7 +85,7 @@ const CustomPropExample = () => {
           },
           onDismiss: selectedProps.indexOf('onDismiss') >= 0,
         });
-        setAlerts([...alerts]);
+        setAlerts([...alertsRef.current]);
       },
       selectedProps.indexOf('alertDelay') >= 0 ? alertDelay : 0,
     );
@@ -92,6 +93,15 @@ const CustomPropExample = () => {
 
   return (
     <>
+      {isOpen && (
+        <Alert
+          id="replaceableAlert"
+          type={selectedAlertType}
+          onDismiss={() => setIsOpen(false)}
+        >
+          {`${alertTypeMessages[selectedAlertType]} Replaceable alert.`}
+        </Alert>
+      )}
       {alerts && alerts.map((alert, index) => (
         <Alert
           key={alert.id}
@@ -150,7 +160,14 @@ const CustomPropExample = () => {
         </>
       )}
       <br />
-      <Button text="Trigger Alert" onClick={triggerNewAlert} />
+      <Button text="Trigger Custom Alert" onClick={triggerNewAlert} />
+      <Button
+        isDisabled={isOpen}
+        text="Trigger Replaceable Alert"
+        onClick={() => {
+          setIsOpen(true);
+        }}
+      />
       <p>{`Action button has been clicked ${actionButtonClickCount} times.`}</p>
     </>
   );

--- a/packages/terra-core-docs/src/terra-dev-site/test/alert/CustomPropAlert.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/alert/CustomPropAlert.test.jsx
@@ -87,24 +87,24 @@ const CustomPropExample = () => {
 
   return (
     <>
-      {alerts &&
-        alerts.map((alert, index) => (
-          <Alert
-            key={index}
-            id="customAlert"
-            type={alert.type}
-            onDismiss={
-              alert.onDismiss
-                ? () => {
-                    handleAlertDismiss(index);
-                  }
-                : null
-            }
-            {...alert.props}
-          >
-            {alertTypeMessages[alert.type]}
-          </Alert>
-        ))}
+      {alerts && alerts.map((alert, index) => (
+        <Alert
+          // eslint-disable-next-line react/no-array-index-key
+          key={index}
+          id="customAlert"
+          type={alert.type}
+          onDismiss={
+            alert.onDismiss
+              ? () => {
+                handleAlertDismiss(index);
+              }
+              : null
+          }
+          {...alert.props}
+        >
+          {alertTypeMessages[alert.type]}
+        </Alert>
+      ))}
       <br />
       <div id="alertType">Select alert type:</div>
       <NativeSelect

--- a/packages/terra-core-docs/src/terra-dev-site/test/alert/LongTextAlert.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/alert/LongTextAlert.test.jsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import Alert from 'terra-alert';
+import Button from 'terra-button';
+import ShowHide from 'terra-show-hide';
+import classNames from 'classnames/bind';
+
+import styles from './LongTextExample.module.scss';
+
+const cx = classNames.bind(styles);
+
+const LongTextAlert = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  const [isTextOpen, setIsTextOpen] = useState(false);
+  const previewText =
+    'Four score and seven years ago our fathers brought forth on this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men are created equal.';
+
+  return (
+    <>
+      {isOpen && (
+        <Alert
+          type="info"
+          title="Gettysburg Address:"
+          onDismiss={() => {
+            setIsOpen(false);
+          }}
+        >
+          <ShowHide
+            preview={previewText}
+            isOpen={isTextOpen}
+            onChange={() => {
+              setIsTextOpen(!isTextOpen);
+            }}
+            className={cx('long-text-example')}
+          >
+            <p>{previewText}</p>
+            <p>
+              Now we are engaged in a great civil war, testing whether that
+              nation, or any nation so conceived and so dedicated, can long
+              endure. We are met on a great battle-field of that war. We have
+              come to dedicate a portion of that field, as a final resting place
+              for those who here gave their lives that that nation might live.
+              It is altogether fitting and proper that we should do this.
+            </p>
+            <p>
+              But, in a larger sense, we can not dedicate -- we can not
+              consecrate -- we can not hallow -- this ground. The brave men,
+              living and dead, who struggled here, have consecrated it, far
+              above our poor power to add or detract. The world will little
+              note, nor long remember what we say here, but it can never forget
+              what they did here. It is for us the living, rather, to be
+              dedicated here to the unfinished work which they who fought here
+              have thus far so nobly advanced. It is rather for us to be here
+              dedicated to the great task remaining before us -- that from these
+              honored dead we take increased devotion to that cause for which
+              they gave the last full measure of devotion -- that we here highly
+              resolve that these dead shall not have died in vain -- that this
+              nation, under God, shall have a new birth of freedom -- and that
+              government of the people, by the people, for the people, shall not
+              perish from the earth.
+            </p>
+          </ShowHide>
+        </Alert>
+      )}
+      <br />
+      <Button
+        isDisabled={isOpen}
+        text="Trigger Alert"
+        onClick={() => {
+          setIsOpen(true);
+        }}
+      />
+    </>
+  );
+};
+
+export default LongTextAlert;

--- a/packages/terra-core-docs/src/terra-dev-site/test/alert/LongTextAlert.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/alert/LongTextAlert.test.jsx
@@ -11,8 +11,7 @@ const cx = classNames.bind(styles);
 const LongTextAlert = () => {
   const [isOpen, setIsOpen] = useState(true);
   const [isTextOpen, setIsTextOpen] = useState(false);
-  const previewText =
-    'Four score and seven years ago our fathers brought forth on this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men are created equal.';
+  const previewText = 'Four score and seven years ago our fathers brought forth on this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men are created equal.';
 
   return (
     <>

--- a/packages/terra-core-docs/src/terra-dev-site/test/alert/LongTextExample.module.scss
+++ b/packages/terra-core-docs/src/terra-dev-site/test/alert/LongTextExample.module.scss
@@ -1,0 +1,15 @@
+:local {
+  .long-text-example {
+    p {
+      margin: 0.71428rem 0;
+
+      &:first-child {
+        margin-top: 0;
+      }
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
https://jira2.cerner.com/browse/UXPLATFORM-8490

Added a few examples to the terra-core test page for a11y testing and auditing. A few key notes
- trigger button and existing UI should persist when an alert is triggered to simulate the user's context within the page
- the different alerts types should be able to be tested for how they get announced when triggered (are they assertive or polite)
- allow stacking alerts
- separated long text example that is dismissible
- updated dismissible example with different alert types that changes existing alert in place

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-core-deployed-pr-45.herokuapp.com/ -->
https://terra-core-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
Please see Jira for some additional notes and screenshots https://jira2.cerner.com/browse/UXPLATFORM-8629

Keyboard/Jaws

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
