### PR TITLE
Fix danger failures

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -4,7 +4,7 @@ import { danger, fail } from 'danger';
 const CHANGELOG_PATTERN = /^packages\/terra-([a-z-0-9])*\/CHANGELOG\.md/i;
 
 const changedFiles = danger.git.created_files.concat(danger.git.modified_files);
-const allowedFilepaths = ['package.json', 'src', 'translations'];
+const allowedFilepaths = ['package.json', 'CHANGELOG.md', 'src', 'translations', 'terra-core-docs'];
 
 const changedChangelogs = new Set();
 const changedPackages = new Set();


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This PR fixes danger failures by including CHANGELOGs in the allowed file paths. `terra-core-docs` was also included as the CHANGELOG entries for that package might be useful to have.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
