### PR TITLE
[terra-button] Enable visible focus when button is active

### DIFF
--- a/packages/terra-button/CHANGELOG.md
+++ b/packages/terra-button/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Enabled visible focus when button is the active element
+
 ## 3.65.0 - (March 1, 2023)
 
 * Removed

--- a/packages/terra-button/src/Button.jsx
+++ b/packages/terra-button/src/Button.jsx
@@ -173,7 +173,7 @@ class Button extends React.Component {
     }
 
     // Add focus styles for keyboard navigation
-    if (event.nativeEvent.keyCode === KeyCode.KEY_SPACE || event.nativeEvent.keyCode === KeyCode.KEY_RETURN) {
+    if (event.nativeEvent.keyCode === KeyCode.KEY_SPACE || event.nativeEvent.keyCode === KeyCode.KEY_RETURN || document.activeElement === event.currentTarget) {
       this.setState({ focused: true });
     }
 
@@ -189,7 +189,7 @@ class Button extends React.Component {
     }
 
     // Apply focus styles for keyboard navigation
-    if (event.nativeEvent.keyCode === KeyCode.KEY_TAB) {
+    if (event.nativeEvent.keyCode === KeyCode.KEY_TAB || document.activeElement === event.currentTarget) {
       this.setState({ focused: true });
     }
 


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

- Added visible focus to button when the active dom element is button
- This change was made to allow focus on button when `terra-menu` is closed

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!-- Please add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License. -->

Thank you for contributing to Terra.
@cerner/terra
