### PR TITLE
checkbox issue resolved

### DIFF
--- a/packages/terra-form-checkbox/CHANGELOG.md
+++ b/packages/terra-form-checkbox/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## Unreleased
+
 * Fixed
-  *   * Fixed issue where click area of a checked checkbox is too large in Fusion theme.
+  * Fixed issue where click area of a checked checkbox is too large in Fusion theme.
 
 ## 4.19.0 - (April 7, 2023)
 

--- a/packages/terra-form-checkbox/CHANGELOG.md
+++ b/packages/terra-form-checkbox/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* Fixed
+  * Fixed the click area is too large in Fusion theme.
 
 ## 4.19.0 - (April 7, 2023)
 

--- a/packages/terra-form-checkbox/CHANGELOG.md
+++ b/packages/terra-form-checkbox/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 * Fixed
-  * Fixed the click area is too large in Fusion theme.
+  *   * Fixed issue where click area of a checked checkbox is too large in Fusion theme.
 
 ## 4.19.0 - (April 7, 2023)
 

--- a/packages/terra-form-checkbox/src/orion-fusion-theme/Checkbox.module.scss
+++ b/packages/terra-form-checkbox/src/orion-fusion-theme/Checkbox.module.scss
@@ -73,6 +73,6 @@
 
     // Inline SVG
     @include terra-inline-svg-var('--terra-form-checkbox-checked-disabled-before-content', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
-    @include terra-inline-svg-var('--terra-form-checkbox-checked-before-content', '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><path fill="#002b42" d="M12.2,44.5L0,32.3v-4.9V22l18.4,18.4L48,10.8l0,5.4l0,4.9l-24,24C20.9,48,16,48.6,12.2,44.5z"/><path fill="#b2b5b6" d="M18.4,40.4L0,22l4.2-4.2L18.4,32L43.8,6.6l4.2,4.2L18.4,40.4z"/></svg>');
+    @include terra-inline-svg-var('--terra-form-checkbox-checked-before-content', none);
   }
 }

--- a/packages/terra-form-checkbox/src/orion-fusion-theme/Checkbox.module.scss
+++ b/packages/terra-form-checkbox/src/orion-fusion-theme/Checkbox.module.scss
@@ -73,6 +73,6 @@
 
     // Inline SVG
     @include terra-inline-svg-var('--terra-form-checkbox-checked-disabled-before-content', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
-    // @include terra-inline-svg-var('--terra-form-checkbox-checked-before-content', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    @include terra-inline-svg-var('--terra-form-checkbox-checked-before-content', '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><path fill="#002b42" d="M12.2,44.5L0,32.3v-4.9V22l18.4,18.4L48,10.8l0,5.4l0,4.9l-24,24C20.9,48,16,48.6,12.2,44.5z"/><path fill="#b2b5b6" d="M18.4,40.4L0,22l4.2-4.2L18.4,32L43.8,6.6l4.2,4.2L18.4,40.4z"/></svg>');
   }
 }

--- a/packages/terra-form-checkbox/src/orion-fusion-theme/Checkbox.module.scss
+++ b/packages/terra-form-checkbox/src/orion-fusion-theme/Checkbox.module.scss
@@ -73,6 +73,6 @@
 
     // Inline SVG
     @include terra-inline-svg-var('--terra-form-checkbox-checked-disabled-before-content', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
-    @include terra-inline-svg-var('--terra-form-checkbox-checked-before-content', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    // @include terra-inline-svg-var('--terra-form-checkbox-checked-before-content', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
   }
 }


### PR DESCRIPTION
### Summary
The Terra Form Checkbox click area is too large in Fusion theme is fixed.

 Solution
 I have update the svg to none in **orion-fusion-theme/Checkbox.module.scss** ,  now it is working fine.


### Testing
I have tested  with Chrome, Safari,Edge.









https://user-images.githubusercontent.com/126649018/233294561-c9cf415b-2df9-4d40-8837-213ce892c35c.mov

