### PR TITLE
[terra-toggle] Fixed terra-toggle attribute from examples page

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,6 +90,7 @@ Cerner Corporation
 - Manjuraghavendra Sathrasala [@manjusr]
 - Saurabh Khare [@saurabhkhare86]
 - Chetan Sharma [@cschetan77]
+- Razvan Luca [@razvanluca]
 
 Community
 
@@ -207,3 +208,4 @@ Community
 [@manjusr]: https://github.com/manjusr
 [@saurabhkhare86]: https://github.com/SaurabhKhare86
 [@vohaha]: https://github.com/vohaha
+[@razvanluca] https://github.com/razvanluca

--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -3,10 +3,6 @@
 ## Unreleased
 
 * Changed
-
-  * Updated focusable attribute value from boolean to string to fix some console log warnings.
-
-* Changed
   * Updated icon documentation to incorporate `one-cerner-style-icons` v1.5.0.
   * Updated non-meaningful content with meaningful content for `action-header`, `arrange`, `content-container`, `divider`, `checkbox`, `radio`, `paginator`, `scroll`, `section-header`, `show-hide`, `toggle`, `toggle-button` and `toggle-section-header`
 

--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 * Changed
+
+  * Updated focusable attribute value from boolean to string to fix some console log warnings.
+
+* Changed
   * Updated icon documentation to incorporate `one-cerner-style-icons` v1.5.0.
   * Updated non-meaningful content with meaningful content for `action-header`, `arrange`, `content-container`, `divider`, `checkbox`, `radio`, `paginator`, `scroll`, `section-header`, `show-hide`, `toggle`, `toggle-button` and `toggle-section-header`
 

--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## Unreleased
 
 * Changed
+
   * Updated icon documentation to incorporate `one-cerner-style-icons` v1.5.0.
   * Updated non-meaningful content with meaningful content for `action-header`, `arrange`, `content-container`, `divider`, `checkbox`, `radio`, `paginator`, `scroll`, `section-header`, `show-hide`, `toggle`, `toggle-button` and `toggle-section-header`
+  * Updated terra-toggle component focusable attribute value from boolean to string to fix some console log warnings.
 
 * Added
   * Updated Usage Guide to include information on decorative, supportive and meaningful text attributes.

--- a/packages/terra-core-docs/src/terra-dev-site/doc/toggle/example/AnimatedToggle.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/toggle/example/AnimatedToggle.jsx
@@ -22,7 +22,7 @@ const AnimatedToggle = () => {
 
   return (
     <div>
-      <IconInformation data-show-focus-styles={focused} focusable a11yLabel="information Icon" tabIndex="0" role="button" onKeyDown={handleOnKeyDown} onMouseDown={() => { setFocus(false); }} onClick={handleOnClick} aria-expanded={isOpen} aria-controls="toggle" />
+      <IconInformation data-show-focus-styles={focused} focusable="true" a11yLabel="information Icon" tabIndex="0" role="button" onKeyDown={handleOnKeyDown} onMouseDown={() => { setFocus(false); }} onClick={handleOnClick} aria-expanded={isOpen} aria-controls="toggle" />
       {/**
       * The aria-expanded state is used on the triggering component to indicate the contents are collapsible, and whether a region is currently expanded or collapsed
       */}

--- a/packages/terra-core-docs/src/terra-dev-site/doc/toggle/example/DefaultToggle.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/toggle/example/DefaultToggle.jsx
@@ -21,7 +21,7 @@ const ToggleDefault = () => {
   };
   return (
     <div>
-      <IconInformation data-show-focus-styles={focused} focusable a11yLabel="information Icon" tabIndex="0" role="button" onKeyDown={handleOnKeyDown} onMouseDown={() => { setFocus(false); }} onClick={handleOnClick} aria-expanded={isOpen} aria-controls="toggle" />
+      <IconInformation data-show-focus-styles={focused} focusable="true" a11yLabel="information Icon" tabIndex="0" role="button" onKeyDown={handleOnKeyDown} onMouseDown={() => { setFocus(false); }} onClick={handleOnClick} aria-expanded={isOpen} aria-controls="toggle" />
       {/**
       * The aria-expanded state is used on the triggering component to indicate the contents are collapsible, and whether a region is currently expanded or collapsed
       */}

--- a/packages/terra-core-docs/src/terra-dev-site/doc/toggle/example/ToggleLabResults.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/toggle/example/ToggleLabResults.jsx
@@ -24,7 +24,7 @@ const ToggleLabResults = () => {
   return (
     <div>
       <label htmlFor="Icon-label">
-        <IconInformation data-show-focus-styles={focused} focusable onKeyDown={handleOnKeyDown} onMouseDown={() => { setFocus(false); }} onClick={handleOnClick} a11yLabel="Lab Results, Information Icon" tabIndex="0" role="button" aria-expanded={isOpen} aria-controls="toggle" id="Icon-label" />
+        <IconInformation data-show-focus-styles={focused} focusable="true" onKeyDown={handleOnKeyDown} onMouseDown={() => { setFocus(false); }} onClick={handleOnClick} a11yLabel="Lab Results, Information Icon" tabIndex="0" role="button" aria-expanded={isOpen} aria-controls="toggle" id="Icon-label" />
         <span> Lab Results</span>
       </label>
       <Toggle isOpen={isOpen} isAnimated>

--- a/packages/terra-core-docs/src/terra-dev-site/doc/toggle/example/TogglePatient.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/toggle/example/TogglePatient.jsx
@@ -24,7 +24,7 @@ const TogglePatient = () => {
   return (
     <div>
       <label htmlFor="Info-Icon">
-        <IconInformation data-show-focus-styles={focused} focusable onKeyDown={handleOnKeyDown} onMouseDown={() => { setFocus(false); }} onClick={handleOnClick} a11yLabel="Allergies, Information Icon" tabIndex="0" role="button" aria-expanded={isOpen} aria-controls="toggle" id="Info-Icon" />
+        <IconInformation data-show-focus-styles={focused} focusable="true" onKeyDown={handleOnKeyDown} onMouseDown={() => { setFocus(false); }} onClick={handleOnClick} a11yLabel="Allergies, Information Icon" tabIndex="0" role="button" aria-expanded={isOpen} aria-controls="toggle" id="Info-Icon" />
         <span> Allergies</span>
       </label>
       <Toggle isOpen={isOpen} isAnimated>

--- a/packages/terra-core-docs/src/terra-dev-site/doc/toggle/example/ToggleWithLabel.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/toggle/example/ToggleWithLabel.jsx
@@ -23,7 +23,7 @@ const ToggleWithLabel = () => {
   return (
     <div>
       <label htmlFor="Icon-label">
-        <IconInformation data-show-focus-styles={focused} focusable onKeyDown={handleOnKeyDown} onMouseDown={() => { setFocus(false); }} onClick={handleOnClick} a11yLabel="Cerner’s Physician Solutions" tabIndex="0" role="button" aria-expanded={isOpen} aria-controls="toggle" id="Icon-label" />
+        <IconInformation data-show-focus-styles={focused} focusable="true" onKeyDown={handleOnKeyDown} onMouseDown={() => { setFocus(false); }} onClick={handleOnClick} a11yLabel="Cerner’s Physician Solutions" tabIndex="0" role="button" aria-expanded={isOpen} aria-controls="toggle" id="Icon-label" />
         <span id="Icon-label"> Cerner’s Physician Solutions</span>
       </label>
       <Toggle isOpen={isOpen} isAnimated>

--- a/packages/terra-toggle/CHANGELOG.md
+++ b/packages/terra-toggle/CHANGELOG.md
@@ -1,13 +1,6 @@
 # Changelog
 
 ## Unreleased
-* Changed
-  * Updated focusable attribute value from boolean to string.
-
-## 3.54.0 - (February 15, 2023)
-
-* Changed
-  * Updated wdio screenshots due to functional-testing upgrade.
 
 ## 3.54.0 - (February 15, 2023)
 

--- a/packages/terra-toggle/CHANGELOG.md
+++ b/packages/terra-toggle/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## Unreleased
+* Changed
+  * Updated focusable attribute value from boolean to string.
+
+## 3.54.0 - (February 15, 2023)
+
+* Changed
+  * Updated wdio screenshots due to functional-testing upgrade.
 
 ## 3.54.0 - (February 15, 2023)
 

--- a/packages/terra-toggle/CHANGELOG.md
+++ b/packages/terra-toggle/CHANGELOG.md
@@ -9,6 +9,11 @@
 * Changed
   * Updated wdio screenshots due to functional-testing upgrade.
 
+## 3.54.0 - (February 15, 2023)
+
+* Changed
+  * Updated wdio screenshots due to functional-testing upgrade.
+
 ## 3.53.0 - (February 7, 2023)
 
 * Changed

--- a/packages/terra-toggle/CHANGELOG.md
+++ b/packages/terra-toggle/CHANGELOG.md
@@ -9,11 +9,6 @@
 * Changed
   * Updated wdio screenshots due to functional-testing upgrade.
 
-## 3.54.0 - (February 15, 2023)
-
-* Changed
-  * Updated wdio screenshots due to functional-testing upgrade.
-
 ## 3.53.0 - (February 7, 2023)
 
 * Changed


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->
Fix console log error for terra-toggle example saying that "Fix Chrome Console log warning: Failed prop type: Invalid prop `focusable` of type `boolean` supplied to `IconBase`, expected `string`"

**What was changed:**
The focusable attribute was boolean and was changed to a string

**Why it was changed:**
To fix a console log warning

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-8871<!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra

![default toggle](https://user-images.githubusercontent.com/13691565/233660653-7574d25c-5e30-4553-90d1-bb198d788d46.png)
