### PR TITLE
[terra-alert] Programmatically associate alert text to dismiss button

### DIFF
--- a/packages/terra-alert/CHANGELOG.md
+++ b/packages/terra-alert/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Added screen reader support to programmatically associate an alert's text to its dismiss button.
+
 ## 4.67.0 - (April 27, 2023)
 
 * Changed

--- a/packages/terra-alert/package.json
+++ b/packages/terra-alert/package.json
@@ -32,7 +32,8 @@
     "terra-button": "^3.65.0",
     "terra-icon": "^3.54.0",
     "terra-responsive-element": "^5.37.0",
-    "terra-theme-context": "^1.0.0"
+    "terra-theme-context": "^1.0.0",
+    "uuid": "^9.0.0"
   },
   "scripts": {
     "compile": "babel --root-mode upward src --out-dir lib --copy-files",

--- a/packages/terra-alert/src/Alert.jsx
+++ b/packages/terra-alert/src/Alert.jsx
@@ -13,6 +13,7 @@ import IconSuccess from 'terra-icon/lib/icon/IconSuccess';
 import classNames from 'classnames';
 import classNamesBind from 'classnames/bind';
 import ThemeContext from 'terra-theme-context';
+import { v4 as uuidv4 } from 'uuid';
 
 import styles from './Alert.module.scss';
 
@@ -144,9 +145,21 @@ const Alert = ({
     { 'body-narrow': isNarrow && (onDismiss || action) },
   );
 
+  const alertId = uuidv4();
+  const alertTitleId = `alert-title-${alertId}`;
+  const alertMessageId = `alert-message-${alertId}`;
+
+  const dismissButtonAriaDescribedBy = title || defaultTitle ? alertTitleId : alertMessageId;
+
   let dismissButton;
   if (onDismiss) {
-    dismissButton = <Button text={intl.formatMessage({ id: 'Terra.alert.dismiss' })} onClick={onDismiss} />;
+    dismissButton = (
+      <Button
+        aria-describedby={dismissButtonAriaDescribedBy}
+        text={intl.formatMessage({ id: 'Terra.alert.dismiss' })}
+        onClick={onDismiss}
+      />
+    );
   }
 
   let actionsSection;
@@ -162,8 +175,8 @@ const Alert = ({
 
   const alertSectionClassName = cx('section', { 'section-custom': type === AlertTypes.CUSTOM });
   const alertMessageContent = (
-    <div className={alertSectionClassName}>
-      {(title || defaultTitle) && <strong className={cx('title')}>{title || defaultTitle}</strong>}
+    <div id={alertMessageId} className={alertSectionClassName}>
+      {(title || defaultTitle) && <strong id={alertTitleId} className={cx('title')}>{title || defaultTitle}</strong>}
       {children}
     </div>
   );

--- a/packages/terra-alert/src/Alert.jsx
+++ b/packages/terra-alert/src/Alert.jsx
@@ -149,7 +149,7 @@ const Alert = ({
   const alertTitleId = `alert-title-${alertId}`;
   const alertMessageId = `alert-message-${alertId}`;
 
-  const dismissButtonAriaDescribedBy = title || defaultTitle ? alertTitleId : alertMessageId;
+  const dismissButtonAriaDescribedBy = (title || defaultTitle) ? alertTitleId : alertMessageId;
 
   let dismissButton;
   if (onDismiss) {

--- a/packages/terra-alert/tests/jest/Alert.test.jsx
+++ b/packages/terra-alert/tests/jest/Alert.test.jsx
@@ -121,7 +121,7 @@ describe('Dismissable Alert of type custom with action button, custom title and 
 describe('Dismissible Alert', () => {
   let wrapper;
 
-  describe('of type custom with no title', () => {
+  describe('Custom Alert with no title', () => {
     beforeEach(() => {
       wrapper = shallowWithIntl(
         <Alert
@@ -144,7 +144,7 @@ describe('Dismissible Alert', () => {
     });
   });
 
-  describe('of type custom with custom title', () => {
+  describe('Custom Alert with custom title', () => {
     beforeEach(() => {
       wrapper = shallowWithIntl(
         <Alert
@@ -174,7 +174,7 @@ describe('Dismissible Alert', () => {
     });
   });
 
-  describe('of type success with no title', () => {
+  describe('Success Alert with no title', () => {
     beforeEach(() => {
       wrapper = shallowWithIntl(
         <Alert
@@ -202,7 +202,7 @@ describe('Dismissible Alert', () => {
     });
   });
 
-  describe('of type success with blank title', () => {
+  describe('Success Alert with blank title', () => {
     beforeEach(() => {
       wrapper = shallowWithIntl(
         <Alert

--- a/packages/terra-alert/tests/jest/Alert.test.jsx
+++ b/packages/terra-alert/tests/jest/Alert.test.jsx
@@ -121,7 +121,7 @@ describe('Dismissable Alert of type custom with action button, custom title and 
 describe('Dismissible Alert', () => {
   let wrapper;
 
-  describe('Custom Alert with no title', () => {
+  describe('Custom Alert with no title prop', () => {
     beforeEach(() => {
       wrapper = shallowWithIntl(
         <Alert
@@ -174,7 +174,7 @@ describe('Dismissible Alert', () => {
     });
   });
 
-  describe('Success Alert with no title', () => {
+  describe('Success Alert with no title prop', () => {
     beforeEach(() => {
       wrapper = shallowWithIntl(
         <Alert

--- a/packages/terra-alert/tests/jest/Alert.test.jsx
+++ b/packages/terra-alert/tests/jest/Alert.test.jsx
@@ -5,6 +5,9 @@ import IconHelp from 'terra-icon/lib/icon/IconHelp';
 import Button from 'terra-button';
 import Alert from '../../src/Alert';
 
+const mockUUID = '00000000-0000-0000-0000-000000000000';
+jest.mock('uuid', () => ({ v4: () => mockUUID }));
+
 describe('Alert with no props', () => {
   // Snapshot Tests
   it('should render a default component', () => {
@@ -112,6 +115,125 @@ describe('Dismissable Alert of type custom with action button, custom title and 
   it('should render an Alert component of type custom with an action button', () => {
     const wrapper = mountWithIntl(<Alert type={Alert.Opts.Types.CUSTOM} onDismiss={() => { }} title="Help!" customIcon={<IconHelp />} customColorClass="terra-alert-custom-orange-color" action={<Button text="Action" variant={Button.Opts.Variants.EMPHASIS} onClick={() => { }} />}>This is a custom alert.</Alert>);
     expect(wrapper).toMatchSnapshot();
+  });
+});
+
+describe('Dismissible Alert', () => {
+  let wrapper;
+
+  describe('of type custom with no title', () => {
+    beforeEach(() => {
+      wrapper = shallowWithIntl(
+        <Alert
+          type={Alert.Opts.Types.CUSTOM}
+          onDismiss={() => { }}
+          customIcon={<IconHelp />}
+        >
+          This is a custom alert.
+        </Alert>,
+      ).dive();
+    });
+    it('should set the alert message ID', () => {
+      const alertContent = wrapper.find('.section');
+      expect(alertContent.prop('id')).toEqual(`alert-message-${mockUUID}`);
+    });
+
+    it('should set the dismiss button aria-describedby to the alert description', () => {
+      const dismissButton = wrapper.find('Button');
+      expect(dismissButton.prop('aria-describedby')).toEqual(`alert-message-${mockUUID}`);
+    });
+  });
+
+  describe('of type custom with custom title', () => {
+    beforeEach(() => {
+      wrapper = shallowWithIntl(
+        <Alert
+          type={Alert.Opts.Types.CUSTOM}
+          title="Help!"
+          onDismiss={() => { }}
+          customIcon={<IconHelp />}
+        >
+          This is a custom alert.
+        </Alert>,
+      ).dive();
+    });
+
+    it('should set the alert message ID', () => {
+      const alertContent = wrapper.find('.section');
+      expect(alertContent.prop('id')).toEqual(`alert-message-${mockUUID}`);
+    });
+
+    it('should set the alert title ID', () => {
+      const alertTitle = wrapper.find('.title');
+      expect(alertTitle.prop('id')).toEqual(`alert-title-${mockUUID}`);
+    });
+
+    it('should set the dismiss button aria-describedby to the alert title', () => {
+      const dismissButton = wrapper.find('Button');
+      expect(dismissButton.prop('aria-describedby')).toEqual(`alert-title-${mockUUID}`);
+    });
+  });
+
+  describe('of type success with no title', () => {
+    beforeEach(() => {
+      wrapper = shallowWithIntl(
+        <Alert
+          type={Alert.Opts.Types.SUCCESS}
+          onDismiss={() => { }}
+        >
+          This is a success alert.
+        </Alert>,
+      ).dive();
+    });
+
+    it('should set the alert message ID', () => {
+      const alertContent = wrapper.find('.section');
+      expect(alertContent.prop('id')).toEqual(`alert-message-${mockUUID}`);
+    });
+
+    it('should set the alert title ID', () => {
+      const alertTitle = wrapper.find('.title');
+      expect(alertTitle.prop('id')).toEqual(`alert-title-${mockUUID}`);
+    });
+
+    it('should set the dismiss button aria-describedby to the alert title', () => {
+      const dismissButton = wrapper.find('Button');
+      expect(dismissButton.prop('aria-describedby')).toEqual(`alert-title-${mockUUID}`);
+    });
+  });
+
+  describe('of type success with blank title', () => {
+    beforeEach(() => {
+      wrapper = shallowWithIntl(
+        <Alert
+          type={Alert.Opts.Types.SUCCESS}
+          title=""
+          onDismiss={() => { }}
+        >
+          This is a success alert.
+        </Alert>,
+      ).dive();
+    });
+
+    it('should use the default title', () => {
+      const alertTitle = wrapper.find('.title');
+      expect(alertTitle.prop('children')).toEqual('Terra.alert.success');
+    });
+
+    it('should set the alert message ID', () => {
+      const alertContent = wrapper.find('.section');
+      expect(alertContent.prop('id')).toEqual(`alert-message-${mockUUID}`);
+    });
+
+    it('should set the alert title ID', () => {
+      const alertTitle = wrapper.find('.title');
+      expect(alertTitle.prop('id')).toEqual(`alert-title-${mockUUID}`);
+    });
+
+    it('should set the dismiss button aria-describedby to the alert title', () => {
+      const dismissButton = wrapper.find('Button');
+      expect(dismissButton.prop('aria-describedby')).toEqual(`alert-title-${mockUUID}`);
+    });
   });
 });
 

--- a/packages/terra-alert/tests/jest/__snapshots__/Alert.test.jsx.snap
+++ b/packages/terra-alert/tests/jest/__snapshots__/Alert.test.jsx.snap
@@ -75,9 +75,11 @@ exports[`Alert of type advisory with text content should render an Alert compone
         >
           <div
             className="section"
+            id="alert-message-00000000-0000-0000-0000-000000000000"
           >
             <strong
               className="title"
+              id="alert-title-00000000-0000-0000-0000-000000000000"
             >
               Terra.alert.advisory
             </strong>
@@ -203,9 +205,11 @@ exports[`Alert of type alert with text content should render an Alert component 
           </span>
           <div
             className="section"
+            id="alert-message-00000000-0000-0000-0000-000000000000"
           >
             <strong
               className="title"
+              id="alert-title-00000000-0000-0000-0000-000000000000"
             >
               Terra.alert.alert
             </strong>
@@ -346,9 +350,11 @@ exports[`Alert of type custom with custom title and text content should render a
           </span>
           <div
             className="section section-custom"
+            id="alert-message-00000000-0000-0000-0000-000000000000"
           >
             <strong
               className="title"
+              id="alert-title-00000000-0000-0000-0000-000000000000"
             >
               Help!
             </strong>
@@ -474,9 +480,11 @@ exports[`Alert of type error with text content should render an Alert component 
           </span>
           <div
             className="section"
+            id="alert-message-00000000-0000-0000-0000-000000000000"
           >
             <strong
               className="title"
+              id="alert-title-00000000-0000-0000-0000-000000000000"
             >
               Terra.alert.error
             </strong>
@@ -604,9 +612,11 @@ exports[`Alert of type info with custom title and HTML content should render an 
           </span>
           <div
             className="section"
+            id="alert-message-00000000-0000-0000-0000-000000000000"
           >
             <strong
               className="title"
+              id="alert-title-00000000-0000-0000-0000-000000000000"
             >
               Gettysburg Address
             </strong>
@@ -734,9 +744,11 @@ exports[`Alert of type info with text content should render an Alert component o
           </span>
           <div
             className="section"
+            id="alert-message-00000000-0000-0000-0000-000000000000"
           >
             <strong
               className="title"
+              id="alert-title-00000000-0000-0000-0000-000000000000"
             >
               Terra.alert.info
             </strong>
@@ -888,9 +900,11 @@ exports[`Alert of type success with an action button text content should render 
           </span>
           <div
             className="section"
+            id="alert-message-00000000-0000-0000-0000-000000000000"
           >
             <strong
               className="title"
+              id="alert-title-00000000-0000-0000-0000-000000000000"
             >
               Terra.alert.success
             </strong>
@@ -1054,9 +1068,11 @@ exports[`Alert of type success with text content should render an Alert componen
           </span>
           <div
             className="section"
+            id="alert-message-00000000-0000-0000-0000-000000000000"
           >
             <strong
               className="title"
+              id="alert-title-00000000-0000-0000-0000-000000000000"
             >
               Terra.alert.success
             </strong>
@@ -1176,9 +1192,11 @@ exports[`Alert of type unsatisfied should render an unsatisfied Alert 1`] = `
           </span>
           <div
             className="section"
+            id="alert-message-00000000-0000-0000-0000-000000000000"
           >
             <strong
               className="title"
+              id="alert-title-00000000-0000-0000-0000-000000000000"
             >
               Terra.alert.unsatisfied
             </strong>
@@ -1298,9 +1316,11 @@ exports[`Alert of type unverified should render an unverified Alert 1`] = `
           </span>
           <div
             className="section"
+            id="alert-message-00000000-0000-0000-0000-000000000000"
           >
             <strong
               className="title"
+              id="alert-title-00000000-0000-0000-0000-000000000000"
             >
               Terra.alert.unverified
             </strong>
@@ -1426,9 +1446,11 @@ exports[`Alert of type warning with text content should render an Alert componen
           </span>
           <div
             className="section"
+            id="alert-message-00000000-0000-0000-0000-000000000000"
           >
             <strong
               className="title"
+              id="alert-title-00000000-0000-0000-0000-000000000000"
             >
               Terra.alert.warning
             </strong>
@@ -1553,9 +1575,11 @@ exports[`Alert with no props should render a default component 1`] = `
           </span>
           <div
             className="section"
+            id="alert-message-00000000-0000-0000-0000-000000000000"
           >
             <strong
               className="title"
+              id="alert-title-00000000-0000-0000-0000-000000000000"
             >
               Terra.alert.alert
             </strong>
@@ -1723,9 +1747,11 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
           </span>
           <div
             className="section section-custom"
+            id="alert-message-00000000-0000-0000-0000-000000000000"
           >
             <strong
               className="title"
+              id="alert-title-00000000-0000-0000-0000-000000000000"
             >
               Help!
             </strong>
@@ -1770,6 +1796,7 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
             </button>
           </Button>
           <Button
+            aria-describedby="alert-title-00000000-0000-0000-0000-000000000000"
             isBlock={false}
             isCompact={false}
             isDisabled={false}
@@ -1781,6 +1808,7 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
             variant="neutral"
           >
             <button
+              aria-describedby="alert-title-00000000-0000-0000-0000-000000000000"
               aria-disabled={false}
               className="button neutral"
               disabled={false}
@@ -1924,9 +1952,11 @@ exports[`Dismissible Alert that includes actions section should render an alert 
           </span>
           <div
             className="section"
+            id="alert-message-00000000-0000-0000-0000-000000000000"
           >
             <strong
               className="title"
+              id="alert-title-00000000-0000-0000-0000-000000000000"
             >
               Terra.alert.alert
             </strong>
@@ -1937,6 +1967,7 @@ exports[`Dismissible Alert that includes actions section should render an alert 
           className="actions"
         >
           <Button
+            aria-describedby="alert-title-00000000-0000-0000-0000-000000000000"
             isBlock={false}
             isCompact={false}
             isDisabled={false}
@@ -1948,6 +1979,7 @@ exports[`Dismissible Alert that includes actions section should render an alert 
             variant="neutral"
           >
             <button
+              aria-describedby="alert-title-00000000-0000-0000-0000-000000000000"
               aria-disabled={false}
               className="button neutral"
               disabled={false}
@@ -1997,9 +2029,11 @@ exports[`correctly applies the theme context className 1`] = `
       </span>
       <div
         className="section"
+        id="alert-message-00000000-0000-0000-0000-000000000000"
       >
         <strong
           className="title"
+          id="alert-title-00000000-0000-0000-0000-000000000000"
         >
           Terra.alert.success
         </strong>

--- a/packages/terra-core-docs/src/terra-dev-site/doc/content-container/example/ContentContainerFill.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/content-container/example/ContentContainerFill.jsx
@@ -24,6 +24,7 @@ const Container = () => {
     setField(event.target.value);
   };
 
+  // eslint-disable-next-line no-alert
   const clickHandler = () => alert(
     `${
       field.trim().length !== 0

--- a/packages/terra-core-docs/src/terra-dev-site/doc/content-container/example/ContentContainerScrollRef.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/content-container/example/ContentContainerScrollRef.jsx
@@ -30,6 +30,7 @@ const Container = () => {
     setField(event.target.value);
   };
 
+  // eslint-disable-next-line no-alert
   const clickHandler = () => alert(
     `${
       field.trim().length !== 0

--- a/packages/terra-core-docs/src/terra-dev-site/doc/content-container/example/ContentContainerStandard.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/content-container/example/ContentContainerStandard.jsx
@@ -25,6 +25,7 @@ const Container = () => {
     setField(event.target.value);
   };
 
+  // eslint-disable-next-line no-alert
   const clickHandler = () => alert(
     `${
       field.trim().length !== 0

--- a/packages/terra-core-docs/src/terra-dev-site/doc/paginator/example/ControlledProgressivePaginatorWithoutTotalCountExample.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/paginator/example/ControlledProgressivePaginatorWithoutTotalCountExample.jsx
@@ -7,7 +7,6 @@ import styles from './PaginatorExampleCommon.module.scss';
 
 const cx = classNames.bind(styles);
 
-
 const buildPage = () => {
   const fullContent = [<p>This example used to  separating content into discrete pages.</p>,
     <p>selectedPage must be managed through the state of a parent component, and passed into this paginator through props.</p>];


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

This change adds screen reader support to programmatically associate the text of an alert to its dismiss button so that screen reader users will have context for what content is being dismissed. With these changes, the dismiss button of an alert is associated to the following:

- The title of the alert, if it exists.
- The description text of the alert, if no title exists.

This PR also includes minor fixes for unrelated eslint warnings.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [x] Other (please describe below)
   - Manually tested with JAWS in Edge and Voiceover in Chrome and Safari.
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [x] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-8898 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
