### PR TITLE
[Terra-dropdown] Added focus styles for dropdown list-items

### DIFF
--- a/packages/terra-dropdown-button/CHANGELOG.md
+++ b/packages/terra-dropdown-button/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+*Added 
+ * Added focus styles for dropdown list items.
+
+
 ## 1.34.0 - (May 9, 2023)
 
 * Added

--- a/packages/terra-dropdown-button/src/_DropdownList.jsx
+++ b/packages/terra-dropdown-button/src/_DropdownList.jsx
@@ -53,7 +53,7 @@ class DropdownList extends React.Component {
   handleKeyDown(event) {
     const { keyCode } = event;
     const { focused } = this.state;
-    const index = Util.findIndexByValue(this, event.target.innerText);
+    const index = Util.findIndexByValue(this, event.target.textContent);
     if (keyCode === KeyCode.KEY_RETURN || keyCode === KeyCode.KEY_SPACE) {
       /*
         Prevent the callback from being called repeatedly if key is held down.

--- a/packages/terra-dropdown-button/src/_DropdownList.module.scss
+++ b/packages/terra-dropdown-button/src/_DropdownList.module.scss
@@ -17,4 +17,8 @@
     padding-right: 0;
     padding-top: var(--terra-dropdown-button-list-padding-top, 0.42857rem);
   }
+  .dropdown-list li:focus {
+    outline: 2px dashed var(--terra-dev-site-example-template-keyboard-focus-outline, #000);
+    outline-offset: -2px;
+  }
 }


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
[Terra-dropdown] Added focus styles for dropdown list-items

**What was changed:**
Added outline for the dropdown list-items.


**Why it was changed:**
While navigating through keyboard mainly in safari browser not able to see the focus for the dropdown list-items




https://github.com/cerner/terra-core/assets/126655256/16a3ab72-3157-40f2-a03a-3bd77ded398a


https://github.com/cerner/terra-core/assets/126655256/4bd6c00c-485e-4924-97f3-667239a0450a


https://github.com/cerner/terra-core/assets/126655256/a1b9bbd3-c0ad-4bb9-9227-2c2a49363c0d





[**This](url) PR resolves:**

[UXPLATFORM-9029](https://jira2.cerner.com/browse/UXPLATFORM-9029)


---

Thank you for contributing to Terra.
@cerner/terra
