### PR TITLE
[terra-form-radio] Fix for RadioField title being read twice on Voice Over 

### DIFF
--- a/packages/terra-form-radio/CHANGELOG.md
+++ b/packages/terra-form-radio/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed issue with VO announcing group and legend multiple times.
+
 ## 4.35.0 - (April 7, 2023)
 
 * Fixed

--- a/packages/terra-form-radio/src/RadioField.jsx
+++ b/packages/terra-form-radio/src/RadioField.jsx
@@ -114,12 +114,12 @@ const RadioField = (props) => {
   const errorAriaDescriptionId = error ? `terra-radio-field-description-error-${uniqueid()}` : '';
   const ariaDescriptionIds = `${legendAriaDescriptionId} ${errorAriaDescriptionId} ${helpAriaDescriptionId}`;
 
-  let isSafariOrEdgBrowser = false;
-  if (navigator.userAgent.indexOf('Safari') !== -1 && (navigator.userAgent.indexOf('Chrome') === -1 || navigator.userAgent.indexOf('Edg') !== -1)) {
-    isSafariOrEdgBrowser = true;
+  let isSafariOREdge = false;
+  if ((navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1) || navigator.userAgent.indexOf('Edg') !== -1) {
+    isSafariOREdge = true;
   }
 
-  const Component = (isSafariOrEdgBrowser) ? 'div' : 'legend';
+  const Component = (isSafariOREdge) ? 'div' : 'legend';
   const legendGroup = (
     <Component id={legendAriaDescriptionId} className={cx(['legend-group', { 'legend-group-hidden': isLegendHidden }])}>
       <div {...legendAttrs} className={legendClassNames}>

--- a/packages/terra-form-radio/src/RadioField.jsx
+++ b/packages/terra-form-radio/src/RadioField.jsx
@@ -114,24 +114,38 @@ const RadioField = (props) => {
   const errorAriaDescriptionId = error ? `terra-radio-field-description-error-${uniqueid()}` : '';
   const ariaDescriptionIds = `${legendAriaDescriptionId} ${errorAriaDescriptionId} ${helpAriaDescriptionId}`;
 
-  const legendGroup = (
-    <legend id={legendAriaDescriptionId} className={cx(['legend-group', { 'legend-group-hidden': isLegendHidden }])}>
-      <div {...legendAttrs} className={legendClassNames}>
-        {isInvalid && <span className={cx('error-icon')} />}
-        {required && (isInvalid || !hideRequired) && (
-          <React.Fragment>
-            <div aria-hidden="true" className={cx('required')}>*</div>
-            <VisualyHiddenText text={intl.formatMessage({ id: 'Terra.form.field.required' })} />
-          </React.Fragment>
+  let isSafariOrEdgBrowser = false;
+
+  if (navigator.userAgent.indexOf('Safari') !== -1 && (navigator.userAgent.indexOf('Chrome') === -1 || navigator.userAgent.indexOf('Edg') !== -1)) {
+    isSafariOrEdgBrowser = true;
+  }
+
+  const legendCode = (
+    <div {...legendAttrs} className={legendClassNames}>
+      {isInvalid && <span className={cx('error-icon')} />}
+      {required && (isInvalid || !hideRequired) && (
+        <React.Fragment>
+          <div aria-hidden="true" className={cx('required')}>*</div>
+          <VisualyHiddenText text={intl.formatMessage({ id: 'Terra.form.field.required' })} />
+        </React.Fragment>
+      )}
+      {legend}
+      {required && !isInvalid && hideRequired && <span className={cx('required-hidden')}>*</span>}
+      {showOptional && !required
+        && (
+          <span className={cx('optional')}>{intl.formatMessage({ id: 'Terra.form.field.optional' })}</span>
         )}
-        {legend}
-        {required && !isInvalid && hideRequired && <span className={cx('required-hidden')}>*</span>}
-        {showOptional && !required
-          && (
-            <span className={cx('optional')}>{intl.formatMessage({ id: 'Terra.form.field.optional' })}</span>
-          )}
-        {!isInvalid && <span className={cx('error-icon-hidden')} />}
-      </div>
+      {!isInvalid && <span className={cx('error-icon-hidden')} />}
+    </div>
+  );
+
+  const legendGroup = isSafariOrEdgBrowser ? (
+    <div id={legendAriaDescriptionId} className={cx(['legend-group', { 'legend-group-hidden': isLegendHidden }])}>
+      {legendCode}
+    </div>
+  ) : (
+    <legend id={legendAriaDescriptionId} className={cx(['legend-group', { 'legend-group-hidden': isLegendHidden }])}>
+      {legendCode}
     </legend>
   );
 

--- a/packages/terra-form-radio/src/RadioField.jsx
+++ b/packages/terra-form-radio/src/RadioField.jsx
@@ -113,17 +113,16 @@ const RadioField = (props) => {
     legendAttrs.className,
   ]);
 
-  const feildSetId = `terra-radio-group-${uniqueid()}`;
+  const fieldSetId = `terra-radio-group-${uniqueid()}`;
   const legendAriaDescriptionId = `terra-radio-field-description-${uniqueid()}`;
   const helpAriaDescriptionId = help ? `terra-radio-field-description-help-${uniqueid()}` : '';
   const errorAriaDescriptionId = error ? `terra-radio-field-description-error-${uniqueid()}` : '';
   const ariaDescriptionIds = `${legendAriaDescriptionId} ${errorAriaDescriptionId} ${helpAriaDescriptionId}`;
 
   const isSafariOREdge = ((navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1) || navigator.userAgent.indexOf('Edg') !== -1);
-  const Component = (isSafariOREdge) ? 'div' : 'legend';
-
+  const LegendGroup = (isSafariOREdge) ? 'div' : 'legend';
   const legendGroup = (
-    <Component id={legendAriaDescriptionId} className={cx(['legend-group', { 'legend-group-hidden': isLegendHidden }])}>
+    <LegendGroup id={legendAriaDescriptionId} className={cx(['legend-group', { 'legend-group-hidden': isLegendHidden }])}>
       <div {...legendAttrs} className={legendClassNames}>
         {isInvalid && <span className={cx('error-icon')} />}
         {required && (isInvalid || !hideRequired) && (
@@ -140,11 +139,11 @@ const RadioField = (props) => {
           )}
         {!isInvalid && <span className={cx('error-icon-hidden')} />}
       </div>
-    </Component>
+    </LegendGroup>
   );
 
   const handleKeyDown = (event) => {
-    const radioGroup = document.getElementById(feildSetId);
+    const radioGroup = document.getElementById(fieldSetId);
     const radioItems = radioGroup.querySelectorAll('[type=radio]');
     const itemIndex = Array.from(radioItems).indexOf(event.currentTarget);
     if (event.key === VALUE_DOWN || event.key === VALUE_RIGHT) {
@@ -179,7 +178,7 @@ const RadioField = (props) => {
   });
 
   return (
-    <fieldset id={feildSetId} {...customProps} required={required} className={radioFieldClasses}>
+    <fieldset id={fieldSetId} {...customProps} required={required} className={radioFieldClasses}>
       {legendGroup}
       {content}
       {isInvalid && error && <div id={errorAriaDescriptionId} className={cx('error-text')}>{error}</div>}

--- a/packages/terra-form-radio/src/RadioField.jsx
+++ b/packages/terra-form-radio/src/RadioField.jsx
@@ -113,12 +113,7 @@ const RadioField = (props) => {
   const helpAriaDescriptionId = help ? `terra-radio-field-description-help-${uniqueid()}` : '';
   const errorAriaDescriptionId = error ? `terra-radio-field-description-error-${uniqueid()}` : '';
   const ariaDescriptionIds = `${legendAriaDescriptionId} ${errorAriaDescriptionId} ${helpAriaDescriptionId}`;
-
-  let isSafariOREdge = false;
-  if ((navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1) || navigator.userAgent.indexOf('Edg') !== -1) {
-    isSafariOREdge = true;
-  }
-
+  const isSafariOREdge = ((navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1) || navigator.userAgent.indexOf('Edg') !== -1);
   const Component = (isSafariOREdge) ? 'div' : 'legend';
   const legendGroup = (
     <Component id={legendAriaDescriptionId} className={cx(['legend-group', { 'legend-group-hidden': isLegendHidden }])}>

--- a/packages/terra-form-radio/src/RadioField.jsx
+++ b/packages/terra-form-radio/src/RadioField.jsx
@@ -115,38 +115,30 @@ const RadioField = (props) => {
   const ariaDescriptionIds = `${legendAriaDescriptionId} ${errorAriaDescriptionId} ${helpAriaDescriptionId}`;
 
   let isSafariOrEdgBrowser = false;
-
   if (navigator.userAgent.indexOf('Safari') !== -1 && (navigator.userAgent.indexOf('Chrome') === -1 || navigator.userAgent.indexOf('Edg') !== -1)) {
     isSafariOrEdgBrowser = true;
   }
 
-  const legendCode = (
-    <div {...legendAttrs} className={legendClassNames}>
-      {isInvalid && <span className={cx('error-icon')} />}
-      {required && (isInvalid || !hideRequired) && (
-        <React.Fragment>
-          <div aria-hidden="true" className={cx('required')}>*</div>
-          <VisualyHiddenText text={intl.formatMessage({ id: 'Terra.form.field.required' })} />
-        </React.Fragment>
-      )}
-      {legend}
-      {required && !isInvalid && hideRequired && <span className={cx('required-hidden')}>*</span>}
-      {showOptional && !required
-        && (
-          <span className={cx('optional')}>{intl.formatMessage({ id: 'Terra.form.field.optional' })}</span>
+  const Component = (isSafariOrEdgBrowser) ? 'div' : 'legend';
+  const legendGroup = (
+    <Component id={legendAriaDescriptionId} className={cx(['legend-group', { 'legend-group-hidden': isLegendHidden }])}>
+      <div {...legendAttrs} className={legendClassNames}>
+        {isInvalid && <span className={cx('error-icon')} />}
+        {required && (isInvalid || !hideRequired) && (
+          <React.Fragment>
+            <div aria-hidden="true" className={cx('required')}>*</div>
+            <VisualyHiddenText text={intl.formatMessage({ id: 'Terra.form.field.required' })} />
+          </React.Fragment>
         )}
-      {!isInvalid && <span className={cx('error-icon-hidden')} />}
-    </div>
-  );
-
-  const legendGroup = isSafariOrEdgBrowser ? (
-    <div id={legendAriaDescriptionId} className={cx(['legend-group', { 'legend-group-hidden': isLegendHidden }])}>
-      {legendCode}
-    </div>
-  ) : (
-    <legend id={legendAriaDescriptionId} className={cx(['legend-group', { 'legend-group-hidden': isLegendHidden }])}>
-      {legendCode}
-    </legend>
+        {legend}
+        {required && !isInvalid && hideRequired && <span className={cx('required-hidden')}>*</span>}
+        {showOptional && !required
+          && (
+            <span className={cx('optional')}>{intl.formatMessage({ id: 'Terra.form.field.optional' })}</span>
+          )}
+        {!isInvalid && <span className={cx('error-icon-hidden')} />}
+      </div>
+    </Component>
   );
 
   const content = React.Children.map(children, (child) => {

--- a/packages/terra-form-radio/src/RadioField.jsx
+++ b/packages/terra-form-radio/src/RadioField.jsx
@@ -119,8 +119,11 @@ const RadioField = (props) => {
   const errorAriaDescriptionId = error ? `terra-radio-field-description-error-${uniqueid()}` : '';
   const ariaDescriptionIds = `${legendAriaDescriptionId} ${errorAriaDescriptionId} ${helpAriaDescriptionId}`;
 
+  const isSafariOREdge = ((navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1) || navigator.userAgent.indexOf('Edg') !== -1);
+  const Component = (isSafariOREdge) ? 'div' : 'legend';
+
   const legendGroup = (
-    <legend id={legendAriaDescriptionId} className={cx(['legend-group', { 'legend-group-hidden': isLegendHidden }])}>
+    <Component id={legendAriaDescriptionId} className={cx(['legend-group', { 'legend-group-hidden': isLegendHidden }])}>
       <div {...legendAttrs} className={legendClassNames}>
         {isInvalid && <span className={cx('error-icon')} />}
         {required && (isInvalid || !hideRequired) && (
@@ -137,7 +140,7 @@ const RadioField = (props) => {
           )}
         {!isInvalid && <span className={cx('error-icon-hidden')} />}
       </div>
-    </legend>
+    </Component>
   );
 
   const handleKeyDown = (event) => {

--- a/packages/terra-form-radio/src/RadioField.jsx
+++ b/packages/terra-form-radio/src/RadioField.jsx
@@ -119,8 +119,10 @@ const RadioField = (props) => {
   const errorAriaDescriptionId = error ? `terra-radio-field-description-error-${uniqueid()}` : '';
   const ariaDescriptionIds = `${legendAriaDescriptionId} ${errorAriaDescriptionId} ${helpAriaDescriptionId}`;
 
-  const isSafariOREdge = ((navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1) || navigator.userAgent.indexOf('Edg') !== -1);
-  const LegendGroup = (isSafariOREdge) ? 'div' : 'legend';
+  const isSafari = navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1;
+  const isEdge = navigator.userAgent.indexOf('Edg') !== -1;
+  const LegendGroup = (isSafari || isEdge) ? 'div' : 'legend';
+
   const legendGroup = (
     <LegendGroup id={legendAriaDescriptionId} className={cx(['legend-group', { 'legend-group-hidden': isLegendHidden }])}>
       <div {...legendAttrs} className={legendClassNames}>

--- a/packages/terra-form-radio/src/RadioField.jsx
+++ b/packages/terra-form-radio/src/RadioField.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import classNames from 'classnames';
@@ -98,7 +98,6 @@ const RadioField = (props) => {
   } = props;
 
   const theme = React.useContext(ThemeContext);
-  const [radioItems, setRadioItems] = useState([]);
 
   const radioFieldClasses = classNames(
     cx(
@@ -119,12 +118,6 @@ const RadioField = (props) => {
   const helpAriaDescriptionId = help ? `terra-radio-field-description-help-${uniqueid()}` : '';
   const errorAriaDescriptionId = error ? `terra-radio-field-description-error-${uniqueid()}` : '';
   const ariaDescriptionIds = `${legendAriaDescriptionId} ${errorAriaDescriptionId} ${helpAriaDescriptionId}`;
-
-  useEffect(() => {
-    const radioGroup = document.getElementById(feildSetId);
-    setRadioItems(radioGroup.querySelectorAll('[type=radio]'));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const legendGroup = (
     <legend id={legendAriaDescriptionId} className={cx(['legend-group', { 'legend-group-hidden': isLegendHidden }])}>
@@ -148,6 +141,8 @@ const RadioField = (props) => {
   );
 
   const handleKeyDown = (event) => {
+    const radioGroup = document.getElementById(feildSetId);
+    const radioItems = radioGroup.querySelectorAll('[type=radio]');
     const itemIndex = Array.from(radioItems).indexOf(event.currentTarget);
     if (event.key === VALUE_DOWN || event.key === VALUE_RIGHT) {
       if (itemIndex === radioItems.length - 1) {

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -21,14 +21,14 @@ it('should render a default radio field', () => {
 
 it('should render radio field with div element for safari browser or Edg browser', () => {
   userAgentGetter.mockReturnValue('safari Edg');
-  const wrapper = shallowWithIntl(<RadioField legend="Coustom Message RadioField" />).dive();
-  expect(wrapper).toMatchSnapshot();
+  const wrapper = shallowWithIntl(<RadioField legend="Coustom Message RadioField" />);
+  expect(wrapper.dive()).toMatchSnapshot();
 });
 
 it('should render radio field with legend element for Chrome browser', () => {
   userAgentGetter.mockReturnValue('Chrome');
-  const wrapper = shallowWithIntl(<RadioField legend="Coustom Message RadioField" />).dive();
-  expect(wrapper).toMatchSnapshot();
+  const wrapper = shallowWithIntl(<RadioField legend="Coustom Message RadioField" />);
+  expect(wrapper.dive()).toMatchSnapshot();
 });
 
 it('should render a default radio field if it has an undefined child', () => {

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -25,53 +25,13 @@ it('should render a default radio field', () => {
 it('should render radio field with div element for Safari browser or Edg browser', () => {
   userAgentGetter.mockReturnValue('Safari Edg');
   const wrapper = shallowWithIntl(<RadioField legend="Custom Message RadioField" />);
-  expect(wrapper.dive()).toMatchInlineSnapshot(`
-    <fieldset
-      className="radio-field"
-      id="terra-radio-group-uuid123"
-      required={false}
-    >
-      <div
-        className="legend-group"
-        id="terra-radio-field-description-uuid123"
-      >
-        <div
-          className="legend"
-        >
-          Custom Message RadioField
-          <span
-            className="error-icon-hidden"
-          />
-        </div>
-      </div>
-    </fieldset>
-  `);
+  expect(wrapper.dive()).toMatchSnapshot();
 });
 
 it('should render radio field with legend element for Chrome browser', () => {
   userAgentGetter.mockReturnValue('Chrome');
   const wrapper = shallowWithIntl(<RadioField legend="Custom Message RadioField" />);
-  expect(wrapper.dive()).toMatchInlineSnapshot(`
-    <fieldset
-      className="radio-field"
-      id="terra-radio-group-uuid123"
-      required={false}
-    >
-      <legend
-        className="legend-group"
-        id="terra-radio-field-description-uuid123"
-      >
-        <div
-          className="legend"
-        >
-          Custom Message RadioField
-          <span
-            className="error-icon-hidden"
-          />
-        </div>
-      </legend>
-    </fieldset>
-  `);
+  expect(wrapper.dive()).toMatchSnapshot();
 });
 
 it('should render a default radio field if it has an undefined child', () => {

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -24,8 +24,8 @@ it('should render radio field with div element for Safari browser or Edg browser
   const wrapper = shallowWithIntl(<RadioField legend="Coustom Message RadioField" />);
   expect(wrapper.dive()).toMatchInlineSnapshot(`
     <fieldset
-    className="radio-field"
-    required={false}
+      className="radio-field"
+      required={false}
     >
       <div
         className="legend-group"
@@ -49,8 +49,8 @@ it('should render radio field with legend element for Chrome browser', () => {
   const wrapper = shallowWithIntl(<RadioField legend="Coustom Message RadioField" />);
   expect(wrapper.dive()).toMatchInlineSnapshot(`
     <fieldset
-    className="radio-field"
-    required={false}
+      className="radio-field"
+      required={false}
     >
       <legend
         className="legend-group"

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -33,7 +33,7 @@ it('should render radio field with div element for Safari browser or Edg browser
       id="terra-radio-group-uuid123"
       required={false}
     >
-      <legend
+      <div
         className="legend-group"
         id="terra-radio-field-description-uuid123"
       >
@@ -45,7 +45,7 @@ it('should render radio field with div element for Safari browser or Edg browser
             className="error-icon-hidden"
           />
         </div>
-      </legend>
+      </div>
     </fieldset>
   `);
 });

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -24,9 +24,7 @@ it('should render a default radio field', () => {
 
 it('should render radio field with div element for Safari browser or Edg browser', () => {
   userAgentGetter.mockReturnValue('Safari Edg');
-  const wrapper = shallowWithIntl(
-    <RadioField legend="Custom Message RadioField" />,
-  );
+  const wrapper = shallowWithIntl(<RadioField legend="Custom Message RadioField" />);
   expect(wrapper.dive()).toMatchInlineSnapshot(`
     <fieldset
       className="radio-field"
@@ -52,9 +50,7 @@ it('should render radio field with div element for Safari browser or Edg browser
 
 it('should render radio field with legend element for Chrome browser', () => {
   userAgentGetter.mockReturnValue('Chrome');
-  const wrapper = shallowWithIntl(
-    <RadioField legend="Custom Message RadioField" />,
-  );
+  const wrapper = shallowWithIntl(<RadioField legend="Custom Message RadioField" />);
   expect(wrapper.dive()).toMatchInlineSnapshot(`
     <fieldset
       className="radio-field"

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -21,7 +21,7 @@ it('should render a default radio field', () => {
 
 it('should render radio field with div element for Safari browser or Edg browser', () => {
   userAgentGetter.mockReturnValue('Safari Edg');
-  const wrapper = shallowWithIntl(<RadioField legend="Coustom Message RadioField" />);
+  const wrapper = shallowWithIntl(<RadioField legend="Custom Message RadioField" />);
   expect(wrapper.dive()).toMatchInlineSnapshot(`
     <fieldset
       className="radio-field"
@@ -34,7 +34,7 @@ it('should render radio field with div element for Safari browser or Edg browser
         <div
           className="legend"
         >
-          Coustom Message RadioField
+          Custom Message RadioField
           <span
             className="error-icon-hidden"
           />
@@ -46,7 +46,7 @@ it('should render radio field with div element for Safari browser or Edg browser
 
 it('should render radio field with legend element for Chrome browser', () => {
   userAgentGetter.mockReturnValue('Chrome');
-  const wrapper = shallowWithIntl(<RadioField legend="Coustom Message RadioField" />);
+  const wrapper = shallowWithIntl(<RadioField legend="Custom Message RadioField" />);
   expect(wrapper.dive()).toMatchInlineSnapshot(`
     <fieldset
       className="radio-field"
@@ -59,7 +59,7 @@ it('should render radio field with legend element for Chrome browser', () => {
         <div
           className="legend"
         >
-          Coustom Message RadioField
+          Custom Message RadioField
           <span
             className="error-icon-hidden"
           />

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -10,7 +10,7 @@ window.matchMedia = () => ({ matches: true });
 jest.mock('lodash.uniqueid');
 
 let userAgentGetter;
-beforeEach(() => {
+beforeAll(() => {
   userAgentGetter = jest.spyOn(window.navigator, 'userAgent', 'get');
   uniqueid.mockReturnValue('uuid123');
 });

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -6,13 +6,11 @@ import { shallowWithIntl, mountWithIntl } from 'terra-enzyme-intl';
 import RadioField from '../../src/RadioField';
 import Radio from '../../src/Radio';
 
-jest.mock('lodash.uniqueid');
 window.matchMedia = () => ({ matches: true });
 
 let userAgentGetter;
 beforeEach(() => {
   userAgentGetter = jest.spyOn(window.navigator, 'userAgent', 'get');
-  uniqueid.mockImplementation(() => 'uuid123');
 });
 
 it('should render a default radio field', () => {

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -19,8 +19,14 @@ it('should render a default radio field', () => {
   expect(wrapper).toMatchSnapshot();
 });
 
-it('should render radio field with div element or legend element', () => {
-  userAgentGetter.mockReturnValue('safari');
+it('should render radio field with div element for safari browser or Edg browser', () => {
+  userAgentGetter.mockReturnValue('safari Edg');
+  const wrapper = shallowWithIntl(<RadioField legend="Coustom Message RadioField" />).dive();
+  expect(wrapper).toMatchSnapshot();
+});
+
+it('should render radio field with legend element for Chrome browser', () => {
+  userAgentGetter.mockReturnValue('Chrome');
   const wrapper = shallowWithIntl(<RadioField legend="Coustom Message RadioField" />).dive();
   expect(wrapper).toMatchSnapshot();
 });

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -1,35 +1,41 @@
 import React from 'react';
 import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
+import uniqueid from 'lodash.uniqueid';
 
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import { shallowWithIntl, mountWithIntl } from 'terra-enzyme-intl';
 import RadioField from '../../src/RadioField';
 import Radio from '../../src/Radio';
 
+jest.mock('lodash.uniqueid');
 window.matchMedia = () => ({ matches: true });
 
 let userAgentGetter;
 beforeEach(() => {
   userAgentGetter = jest.spyOn(window.navigator, 'userAgent', 'get');
+  uniqueid.mockImplementation(() => 'uuid123');
 });
 
 it('should render a default radio field', () => {
-  const radioField = (<RadioField legend="Default RadioField" />);
+  const radioField = <RadioField legend="Default RadioField" />;
   const wrapper = shallowWithIntl(radioField);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render radio field with div element for Safari browser or Edg browser', () => {
   userAgentGetter.mockReturnValue('Safari Edg');
-  const wrapper = shallowWithIntl(<RadioField legend="Custom Message RadioField" />);
+  const wrapper = shallowWithIntl(
+    <RadioField legend="Custom Message RadioField" />,
+  );
   expect(wrapper.dive()).toMatchInlineSnapshot(`
     <fieldset
       className="radio-field"
+      id="terra-radio-group-uuid123"
       required={false}
     >
-      <div
+      <legend
         className="legend-group"
-        id="terra-radio-field-description-1"
+        id="terra-radio-field-description-uuid123"
       >
         <div
           className="legend"
@@ -39,22 +45,25 @@ it('should render radio field with div element for Safari browser or Edg browser
             className="error-icon-hidden"
           />
         </div>
-      </div>
+      </legend>
     </fieldset>
   `);
 });
 
 it('should render radio field with legend element for Chrome browser', () => {
   userAgentGetter.mockReturnValue('Chrome');
-  const wrapper = shallowWithIntl(<RadioField legend="Custom Message RadioField" />);
+  const wrapper = shallowWithIntl(
+    <RadioField legend="Custom Message RadioField" />,
+  );
   expect(wrapper.dive()).toMatchInlineSnapshot(`
     <fieldset
       className="radio-field"
+      id="terra-radio-group-uuid123"
       required={false}
     >
       <legend
         className="legend-group"
-        id="terra-radio-field-description-2"
+        id="terra-radio-field-description-uuid123"
       >
         <div
           className="legend"
@@ -71,55 +80,84 @@ it('should render radio field with legend element for Chrome browser', () => {
 
 it('should render a default radio field if it has an undefined child', () => {
   const undefinedChild = undefined;
-  const radioField = (<RadioField legend="Default RadioField">{ undefinedChild }</RadioField>);
+  const radioField = (
+    <RadioField legend="Default RadioField">{undefinedChild}</RadioField>
+  );
   const wrapper = shallowWithIntl(radioField);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render an invalid radio field', () => {
-  const radioField = (<RadioField legend="Invalid RadioField" isInvalid error="Test Error" />);
+  const radioField = (
+    <RadioField legend="Invalid RadioField" isInvalid error="Test Error" />
+  );
   const wrapper = shallowWithIntl(radioField);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a help message', () => {
-  const radioField = (<RadioField legend="Help RadioField" help="This will help up determine how many chairs to request" />);
+  const radioField = (
+    <RadioField
+      legend="Help RadioField"
+      help="This will help up determine how many chairs to request"
+    />
+  );
   const wrapper = shallowWithIntl(radioField);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render an optional part on the label', () => {
-  const radioField = (<RadioField legend="Optional RadioField" showOptional />);
+  const radioField = <RadioField legend="Optional RadioField" showOptional />;
   const wrapper = shallowWithIntl(radioField);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render required radio field', () => {
-  const radioField = (<RadioField legend="Required RadioField" required />);
+  const radioField = <RadioField legend="Required RadioField" required />;
   const wrapper = shallowWithIntl(radioField);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should hide the required indicator when requested', () => {
-  const radioField = (<RadioField legend="Hidden Required RadioField" required hideRequired />);
+  const radioField = (
+    <RadioField legend="Hidden Required RadioField" required hideRequired />
+  );
   const wrapper = shallowWithIntl(radioField);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render the legend with custom attributes properly', () => {
-  const radioField = (<RadioField legend="Custom Legend RadioField" legendAttrs={{ class: 'application-legend' }} />);
+  const radioField = (
+    <RadioField
+      legend="Custom Legend RadioField"
+      legendAttrs={{ class: 'application-legend' }}
+    />
+  );
   const wrapper = shallowWithIntl(radioField);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should display the required icon for fields with hideRequired, but have a state of invalid', () => {
-  const checkBox = (<RadioField legend="Hidden Required CheckboxField" required hideRequired isInvalid />);
+  const checkBox = (
+    <RadioField
+      legend="Hidden Required CheckboxField"
+      required
+      hideRequired
+      isInvalid
+    />
+  );
   const wrapper = shallowWithIntl(checkBox);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should hide the legend when requested', () => {
-  const radioField = (<RadioField legend="Hidden Legend legend" legendAttrs={{ class: 'application-legend' }} isLegendHidden />);
+  const radioField = (
+    <RadioField
+      legend="Hidden Legend legend"
+      legendAttrs={{ class: 'application-legend' }}
+      isLegendHidden
+    />
+  );
   const wrapper = shallowWithIntl(radioField);
   expect(wrapper).toMatchSnapshot();
 });

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -22,13 +22,51 @@ it('should render a default radio field', () => {
 it('should render radio field with div element for Safari browser or Edg browser', () => {
   userAgentGetter.mockReturnValue('Safari Edg');
   const wrapper = shallowWithIntl(<RadioField legend="Coustom Message RadioField" />);
-  expect(wrapper.dive()).toMatchSnapshot();
+  expect(wrapper.dive()).toMatchInlineSnapshot(`
+    <fieldset
+    className="radio-field"
+    required={false}
+    >
+      <div
+        className="legend-group"
+        id="terra-radio-field-description-1"
+      >
+        <div
+          className="legend"
+        >
+          Coustom Message RadioField
+          <span
+            className="error-icon-hidden"
+          />
+        </div>
+      </div>
+    </fieldset>
+  `);
 });
 
 it('should render radio field with legend element for Chrome browser', () => {
   userAgentGetter.mockReturnValue('Chrome');
   const wrapper = shallowWithIntl(<RadioField legend="Coustom Message RadioField" />);
-  expect(wrapper.dive()).toMatchSnapshot();
+  expect(wrapper.dive()).toMatchInlineSnapshot(`
+    <fieldset
+    className="radio-field"
+    required={false}
+    >
+      <legend
+        className="legend-group"
+        id="terra-radio-field-description-2"
+      >
+        <div
+          className="legend"
+        >
+          Coustom Message RadioField
+          <span
+            className="error-icon-hidden"
+          />
+        </div>
+      </legend>
+    </fieldset>
+  `);
 });
 
 it('should render a default radio field if it has an undefined child', () => {

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -19,8 +19,8 @@ it('should render a default radio field', () => {
   expect(wrapper).toMatchSnapshot();
 });
 
-it('should render radio field with div element for safari browser or Edg browser', () => {
-  userAgentGetter.mockReturnValue('safari Edg');
+it('should render radio field with div element for Safari browser or Edg browser', () => {
+  userAgentGetter.mockReturnValue('Safari Edg');
   const wrapper = shallowWithIntl(<RadioField legend="Coustom Message RadioField" />);
   expect(wrapper.dive()).toMatchSnapshot();
 });

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -8,9 +8,20 @@ import Radio from '../../src/Radio';
 
 window.matchMedia = () => ({ matches: true });
 
+let userAgentGetter;
+beforeEach(() => {
+  userAgentGetter = jest.spyOn(window.navigator, 'userAgent', 'get');
+});
+
 it('should render a default radio field', () => {
   const radioField = (<RadioField legend="Default RadioField" />);
   const wrapper = shallowWithIntl(radioField);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it('should render radio field with div element or legend element', () => {
+  userAgentGetter.mockReturnValue('safari');
+  const wrapper = shallowWithIntl(<RadioField legend="Coustom Message RadioField" />).dive();
   expect(wrapper).toMatchSnapshot();
 });
 

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
-import uniqueid from 'lodash.uniqueid';
 
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import { shallowWithIntl, mountWithIntl } from 'terra-enzyme-intl';

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
-
+import uniqueid from 'lodash.uniqueid';
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import { shallowWithIntl, mountWithIntl } from 'terra-enzyme-intl';
 import RadioField from '../../src/RadioField';
 import Radio from '../../src/Radio';
 
 window.matchMedia = () => ({ matches: true });
+jest.mock('lodash.uniqueid');
 
 let userAgentGetter;
 beforeEach(() => {
   userAgentGetter = jest.spyOn(window.navigator, 'userAgent', 'get');
+  uniqueid.mockReturnValue('uuid123');
 });
 
 it('should render a default radio field', () => {
@@ -21,14 +23,20 @@ it('should render a default radio field', () => {
 
 it('should render radio field with div element for Safari browser or Edg browser', () => {
   userAgentGetter.mockReturnValue('Safari Edg');
-  const wrapper = shallowWithIntl(<RadioField legend="Custom Message RadioField" />);
-  expect(wrapper.dive()).toMatchSnapshot();
+  const wrapper = shallowWithIntl(<RadioField legend="Custom Message RadioField" />).dive();
+  const radioDiv = wrapper.find('fieldset');
+  const divExist = radioDiv.find('div');
+  expect(divExist).toBeDefined();
+  expect(wrapper).toMatchSnapshot();
 });
 
 it('should render radio field with legend element for Chrome browser', () => {
   userAgentGetter.mockReturnValue('Chrome');
-  const wrapper = shallowWithIntl(<RadioField legend="Custom Message RadioField" />);
-  expect(wrapper.dive()).toMatchSnapshot();
+  const wrapper = shallowWithIntl(<RadioField legend="Custom Message RadioField" />).dive();
+  const radioDiv = wrapper.find('fieldset');
+  const legendExist = radioDiv.find('legend');
+  expect(legendExist).toBeDefined();
+  expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a default radio field if it has an undefined child', () => {

--- a/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
+++ b/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
@@ -72,12 +72,12 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
   >
     <fieldset
       className="radio-field"
-      id="terra-radio-group-7"
+      id="terra-radio-group-uuid123"
       required={false}
     >
       <legend
         className="legend-group"
-        id="terra-radio-field-description-8"
+        id="terra-radio-field-description-uuid123"
       >
         <div
           className="legend"
@@ -92,7 +92,7 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
         disabled={false}
         inputAttrs={
           Object {
-            "aria-describedby": "terra-radio-field-description-8  ",
+            "aria-describedby": "terra-radio-field-description-uuid123  ",
             "data-custom-attr": "attr data",
             "onKeyDown": [Function],
           }
@@ -111,7 +111,7 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
             className="label"
           >
             <input
-              aria-describedby="terra-radio-field-description-8  "
+              aria-describedby="terra-radio-field-description-uuid123  "
               className="native-input"
               data-custom-attr="attr data"
               disabled={false}
@@ -218,12 +218,12 @@ exports[`correctly applies the theme context className 1`] = `
     >
       <fieldset
         className="radio-field orion-fusion-theme"
-        id="terra-radio-group-5"
+        id="terra-radio-group-uuid123"
         required={false}
       >
         <legend
           className="legend-group"
-          id="terra-radio-field-description-6"
+          id="terra-radio-field-description-uuid123"
         >
           <div
             className="legend"

--- a/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
+++ b/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
@@ -576,48 +576,6 @@ exports[`should render an optional part on the label 1`] = `
 />
 `;
 
-exports[`should render radio field with div element for Safari browser or Edg browser 1`] = `
-<fieldset
-  className="radio-field"
-  required={false}
->
-  <div
-    className="legend-group"
-    id="terra-radio-field-description-1"
-  >
-    <div
-      className="legend"
-    >
-      Coustom Message RadioField
-      <span
-        className="error-icon-hidden"
-      />
-    </div>
-  </div>
-</fieldset>
-`;
-
-exports[`should render radio field with legend element for Chrome browser 1`] = `
-<fieldset
-  className="radio-field"
-  required={false}
->
-  <legend
-    className="legend-group"
-    id="terra-radio-field-description-2"
-  >
-    <div
-      className="legend"
-    >
-      Coustom Message RadioField
-      <span
-        className="error-icon-hidden"
-      />
-    </div>
-  </legend>
-</fieldset>
-`;
-
 exports[`should render required radio field 1`] = `
 <RadioField
   error={null}

--- a/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
+++ b/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
@@ -580,6 +580,50 @@ exports[`should render an optional part on the label 1`] = `
 />
 `;
 
+exports[`should render radio field with div element for Safari browser or Edg browser 1`] = `
+<fieldset
+  className="radio-field"
+  id="terra-radio-group-uuid123"
+  required={false}
+>
+  <div
+    className="legend-group"
+    id="terra-radio-field-description-uuid123"
+  >
+    <div
+      className="legend"
+    >
+      Custom Message RadioField
+      <span
+        className="error-icon-hidden"
+      />
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`should render radio field with legend element for Chrome browser 1`] = `
+<fieldset
+  className="radio-field"
+  id="terra-radio-group-uuid123"
+  required={false}
+>
+  <legend
+    className="legend-group"
+    id="terra-radio-field-description-uuid123"
+  >
+    <div
+      className="legend"
+    >
+      Custom Message RadioField
+      <span
+        className="error-icon-hidden"
+      />
+    </div>
+  </legend>
+</fieldset>
+`;
+
 exports[`should render required radio field 1`] = `
 <RadioField
   error={null}

--- a/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
+++ b/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
@@ -72,12 +72,12 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
   >
     <fieldset
       className="radio-field"
-      id="terra-radio-group-uuid123"
+      id="terra-radio-group-7"
       required={false}
     >
       <legend
         className="legend-group"
-        id="terra-radio-field-description-uuid123"
+        id="terra-radio-field-description-8"
       >
         <div
           className="legend"
@@ -92,7 +92,7 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
         disabled={false}
         inputAttrs={
           Object {
-            "aria-describedby": "terra-radio-field-description-uuid123  ",
+            "aria-describedby": "terra-radio-field-description-8  ",
             "data-custom-attr": "attr data",
             "onKeyDown": [Function],
           }
@@ -111,7 +111,7 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
             className="label"
           >
             <input
-              aria-describedby="terra-radio-field-description-uuid123  "
+              aria-describedby="terra-radio-field-description-8  "
               className="native-input"
               data-custom-attr="attr data"
               disabled={false}
@@ -218,12 +218,12 @@ exports[`correctly applies the theme context className 1`] = `
     >
       <fieldset
         className="radio-field orion-fusion-theme"
-        id="terra-radio-group-uuid123"
+        id="terra-radio-group-5"
         required={false}
       >
         <legend
           className="legend-group"
-          id="terra-radio-field-description-uuid123"
+          id="terra-radio-field-description-6"
         >
           <div
             className="legend"
@@ -583,12 +583,12 @@ exports[`should render an optional part on the label 1`] = `
 exports[`should render radio field with div element for Safari browser or Edg browser 1`] = `
 <fieldset
   className="radio-field"
-  id="terra-radio-group-uuid123"
+  id="terra-radio-group-1"
   required={false}
 >
   <div
     className="legend-group"
-    id="terra-radio-field-description-uuid123"
+    id="terra-radio-field-description-2"
   >
     <div
       className="legend"
@@ -605,12 +605,12 @@ exports[`should render radio field with div element for Safari browser or Edg br
 exports[`should render radio field with legend element for Chrome browser 1`] = `
 <fieldset
   className="radio-field"
-  id="terra-radio-group-uuid123"
+  id="terra-radio-group-3"
   required={false}
 >
   <legend
     className="legend-group"
-    id="terra-radio-field-description-uuid123"
+    id="terra-radio-field-description-4"
   >
     <div
       className="legend"

--- a/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
+++ b/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
@@ -72,12 +72,12 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
   >
     <fieldset
       className="radio-field"
-      id="terra-radio-group-7"
+      id="terra-radio-group-uuid123"
       required={false}
     >
       <legend
         className="legend-group"
-        id="terra-radio-field-description-8"
+        id="terra-radio-field-description-uuid123"
       >
         <div
           className="legend"
@@ -92,7 +92,7 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
         disabled={false}
         inputAttrs={
           Object {
-            "aria-describedby": "terra-radio-field-description-8  ",
+            "aria-describedby": "terra-radio-field-description-uuid123  ",
             "data-custom-attr": "attr data",
             "onKeyDown": [Function],
           }
@@ -111,7 +111,7 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
             className="label"
           >
             <input
-              aria-describedby="terra-radio-field-description-8  "
+              aria-describedby="terra-radio-field-description-uuid123  "
               className="native-input"
               data-custom-attr="attr data"
               disabled={false}
@@ -218,12 +218,12 @@ exports[`correctly applies the theme context className 1`] = `
     >
       <fieldset
         className="radio-field orion-fusion-theme"
-        id="terra-radio-group-5"
+        id="terra-radio-group-uuid123"
         required={false}
       >
         <legend
           className="legend-group"
-          id="terra-radio-field-description-6"
+          id="terra-radio-field-description-uuid123"
         >
           <div
             className="legend"
@@ -583,12 +583,12 @@ exports[`should render an optional part on the label 1`] = `
 exports[`should render radio field with div element for Safari browser or Edg browser 1`] = `
 <fieldset
   className="radio-field"
-  id="terra-radio-group-1"
+  id="terra-radio-group-uuid123"
   required={false}
 >
   <div
     className="legend-group"
-    id="terra-radio-field-description-2"
+    id="terra-radio-field-description-uuid123"
   >
     <div
       className="legend"
@@ -605,12 +605,12 @@ exports[`should render radio field with div element for Safari browser or Edg br
 exports[`should render radio field with legend element for Chrome browser 1`] = `
 <fieldset
   className="radio-field"
-  id="terra-radio-group-3"
+  id="terra-radio-group-uuid123"
   required={false}
 >
   <legend
     className="legend-group"
-    id="terra-radio-field-description-4"
+    id="terra-radio-field-description-uuid123"
   >
     <div
       className="legend"

--- a/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
+++ b/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
@@ -72,11 +72,12 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
   >
     <fieldset
       className="radio-field"
+      id="terra-radio-group-7"
       required={false}
     >
       <legend
         className="legend-group"
-        id="terra-radio-field-description-4"
+        id="terra-radio-field-description-8"
       >
         <div
           className="legend"
@@ -91,8 +92,9 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
         disabled={false}
         inputAttrs={
           Object {
-            "aria-describedby": "terra-radio-field-description-4  ",
+            "aria-describedby": "terra-radio-field-description-8  ",
             "data-custom-attr": "attr data",
+            "onKeyDown": [Function],
           }
         }
         isInline={false}
@@ -109,11 +111,12 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
             className="label"
           >
             <input
-              aria-describedby="terra-radio-field-description-4  "
+              aria-describedby="terra-radio-field-description-8  "
               className="native-input"
               data-custom-attr="attr data"
               disabled={false}
               name={null}
+              onKeyDown={[Function]}
               type="radio"
             />
             <span
@@ -215,11 +218,12 @@ exports[`correctly applies the theme context className 1`] = `
     >
       <fieldset
         className="radio-field orion-fusion-theme"
+        id="terra-radio-group-5"
         required={false}
       >
         <legend
           className="legend-group"
-          id="terra-radio-field-description-3"
+          id="terra-radio-field-description-6"
         >
           <div
             className="legend"

--- a/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
+++ b/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
@@ -576,7 +576,7 @@ exports[`should render an optional part on the label 1`] = `
 />
 `;
 
-exports[`should render radio field with div element for safari browser or Edg browser 1`] = `
+exports[`should render radio field with div element for Safari browser or Edg browser 1`] = `
 <fieldset
   className="radio-field"
   required={false}

--- a/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
+++ b/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
@@ -76,7 +76,7 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
     >
       <legend
         className="legend-group"
-        id="terra-radio-field-description-3"
+        id="terra-radio-field-description-4"
       >
         <div
           className="legend"
@@ -91,7 +91,7 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
         disabled={false}
         inputAttrs={
           Object {
-            "aria-describedby": "terra-radio-field-description-3  ",
+            "aria-describedby": "terra-radio-field-description-4  ",
             "data-custom-attr": "attr data",
           }
         }
@@ -109,7 +109,7 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
             className="label"
           >
             <input
-              aria-describedby="terra-radio-field-description-3  "
+              aria-describedby="terra-radio-field-description-4  "
               className="native-input"
               data-custom-attr="attr data"
               disabled={false}
@@ -219,7 +219,7 @@ exports[`correctly applies the theme context className 1`] = `
       >
         <legend
           className="legend-group"
-          id="terra-radio-field-description-2"
+          id="terra-radio-field-description-3"
         >
           <div
             className="legend"
@@ -576,12 +576,33 @@ exports[`should render an optional part on the label 1`] = `
 />
 `;
 
-exports[`should render radio field with div element or legend element 1`] = `
+exports[`should render radio field with div element for Chrome browser 1`] = `
 <fieldset
   className="radio-field"
   required={false}
 >
   <legend
+    className="legend-group"
+    id="terra-radio-field-description-2"
+  >
+    <div
+      className="legend"
+    >
+      Coustom Message RadioField
+      <span
+        className="error-icon-hidden"
+      />
+    </div>
+  </legend>
+</fieldset>
+`;
+
+exports[`should render radio field with div element for safari browser or Edg browser 1`] = `
+<fieldset
+  className="radio-field"
+  required={false}
+>
+  <div
     className="legend-group"
     id="terra-radio-field-description-1"
   >
@@ -593,7 +614,7 @@ exports[`should render radio field with div element or legend element 1`] = `
         className="error-icon-hidden"
       />
     </div>
-  </legend>
+  </div>
 </fieldset>
 `;
 

--- a/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
+++ b/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
@@ -576,27 +576,6 @@ exports[`should render an optional part on the label 1`] = `
 />
 `;
 
-exports[`should render radio field with div element for Chrome browser 1`] = `
-<fieldset
-  className="radio-field"
-  required={false}
->
-  <legend
-    className="legend-group"
-    id="terra-radio-field-description-2"
-  >
-    <div
-      className="legend"
-    >
-      Coustom Message RadioField
-      <span
-        className="error-icon-hidden"
-      />
-    </div>
-  </legend>
-</fieldset>
-`;
-
 exports[`should render radio field with div element for safari browser or Edg browser 1`] = `
 <fieldset
   className="radio-field"
@@ -615,6 +594,27 @@ exports[`should render radio field with div element for safari browser or Edg br
       />
     </div>
   </div>
+</fieldset>
+`;
+
+exports[`should render radio field with legend element for Chrome browser 1`] = `
+<fieldset
+  className="radio-field"
+  required={false}
+>
+  <legend
+    className="legend-group"
+    id="terra-radio-field-description-2"
+  >
+    <div
+      className="legend"
+    >
+      Coustom Message RadioField
+      <span
+        className="error-icon-hidden"
+      />
+    </div>
+  </legend>
 </fieldset>
 `;
 

--- a/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
+++ b/packages/terra-form-radio/tests/jest/__snapshots__/RadioField.test.jsx.snap
@@ -76,7 +76,7 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
     >
       <legend
         className="legend-group"
-        id="terra-radio-field-description-2"
+        id="terra-radio-field-description-3"
       >
         <div
           className="legend"
@@ -91,7 +91,7 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
         disabled={false}
         inputAttrs={
           Object {
-            "aria-describedby": "terra-radio-field-description-2  ",
+            "aria-describedby": "terra-radio-field-description-3  ",
             "data-custom-attr": "attr data",
           }
         }
@@ -109,7 +109,7 @@ exports[`correctly applies "inputAttrs" property to the Radio component 1`] = `
             className="label"
           >
             <input
-              aria-describedby="terra-radio-field-description-2  "
+              aria-describedby="terra-radio-field-description-3  "
               className="native-input"
               data-custom-attr="attr data"
               disabled={false}
@@ -219,7 +219,7 @@ exports[`correctly applies the theme context className 1`] = `
       >
         <legend
           className="legend-group"
-          id="terra-radio-field-description-1"
+          id="terra-radio-field-description-2"
         >
           <div
             className="legend"
@@ -574,6 +574,27 @@ exports[`should render an optional part on the label 1`] = `
   required={false}
   showOptional={true}
 />
+`;
+
+exports[`should render radio field with div element or legend element 1`] = `
+<fieldset
+  className="radio-field"
+  required={false}
+>
+  <legend
+    className="legend-group"
+    id="terra-radio-field-description-1"
+  >
+    <div
+      className="legend"
+    >
+      Coustom Message RadioField
+      <span
+        className="error-icon-hidden"
+      />
+    </div>
+  </legend>
+</fieldset>
 `;
 
 exports[`should render required radio field 1`] = `


### PR DESCRIPTION
Summary
Terra - Form Radio Field - VO announces group and legend multiple times

Solution
I have replaced legend Tag with div Tag in Safari & Edge.

Testing
I have tested with Chrome, Safari,Edge.