### PR TITLE
[Terra Form Single-Select] Announce Selected/Not Selected

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added
   * Added terra-scroll A11y tests.
   * Added an example in terra-content-container without interactive elements.
+  * Added documentation updates for `Single Select`.
 
 * Changed
   * Updated `terra-status-view - Change Variant` example component to use the `terra-form-select` component instead of HTML native `<select>`.
@@ -14,6 +15,8 @@
   * Updated `Custom Icon + message + buttons example` for `terra-status-view`.
   * Corrected typo in `terra-demographics-banner` example doc.
   * Updated documentation for a11y guidance on `alert` notification type, live regions, and titles.
+  * Removed aria-checked to make screen readers announce Selected in `terra-form-select`.
+  * Updated focus to shift back on select upon key press or mouse click event while using Safari browser in `terra-form-select`.
 
 ## 1.27.0 - (May 9, 2023)
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SingleSelect.03.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SingleSelect.03.doc.mdx
@@ -19,6 +19,14 @@ import OptGroupPropsTable from 'terra-form-select/src/shared/_OptGroup?dev-site-
 
 The Single Select component allows selecting a single option from a dropdown of selectable options.
 
+Consumers are encouraged to use the `SingleSelectField` component over the `SingleSelect` component wherever possible, as the latter does not provide the labels necessary to support accessibility.
+
+To create an accessible `SingleSelect` component:
+1. Ensure that `SelectField` can receive keyboard focus.
+2. Ensure that `SelectField` programmatically associates all related content (such as visible label, helper text & error messaging) to the field.
+3. Ensure any visible `SelectLabel` matches any artificially applied programmatic label.
+4. Error messaging should provide error suggestions when the system can programmatically understand what is wrong.
+
 ## Getting Started
 
 - Install with [npmjs](https://www.npmjs.com):

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+* Added
+  * Added documentation updates for `Single Select`.
+
+* Changed
+  * Removed aria-checked to make screen readers announce Selected in `terra-form-select`.
+  * Updated focus to shift back on select upon key press or mouse click event while using Safari browser in `terra-form-select`.
+
 ## 6.41.0 - (May 9, 2023)
 
 * Added

--- a/packages/terra-form-select/src/shared/_Option.jsx
+++ b/packages/terra-form-select/src/shared/_Option.jsx
@@ -131,8 +131,7 @@ const Option = ({
       {...customProps}
       disabled={disabled}
       className={optionClassNames}
-      aria-selected={isSelected} // Needed to allow VoiceOver on iOS to announce selected state
-      aria-checked={isSelected} // Needed to allow JAWS to announce "selected" state
+      aria-selected={isSelected} // Needed to allow screen reader to announce selected state
       aria-disabled={disabled}
       tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
       data-terra-select-option

--- a/packages/terra-form-select/src/single/Menu.jsx
+++ b/packages/terra-form-select/src/single/Menu.jsx
@@ -116,6 +116,7 @@ class Menu extends React.Component {
   static getDerivedStateFromProps(props, state) {
     const { clearOptionDisplay, noResultContent } = props;
 
+    const closedViaKeyEvent = true;
     let hasNoResults = false;
     const hasAddOption = false;
 
@@ -135,6 +136,7 @@ class Menu extends React.Component {
       children,
       hasNoResults,
       active: Menu.getActiveOptionFromProps(props, children, state),
+      closedViaKeyEvent,
     };
   }
 
@@ -161,8 +163,9 @@ class Menu extends React.Component {
     this.clearSearch();
     this.clearScrollTimeout();
     if (this.state.closedViaKeyEvent) {
-      this.props.select.focus();
-      if (SharedUtil.isSafari()) {
+      if (!SharedUtil.isSafari()) {
+        this.props.select.focus();
+      } else {
         /**
          * Shifting focus back to the select specifically
          * when VoiceOver is on will sometimes trigger VO to shift focus
@@ -260,7 +263,21 @@ class Menu extends React.Component {
     }
 
     if (select) {
-      select.focus();
+      if (!SharedUtil.isSafari()) {
+        select.focus();
+      } else {
+        /**
+         * Shifting focus back to the select specifically
+         * when VoiceOver is on will sometimes trigger VO to shift focus
+         * randomly to the root of document or the skip to main link
+         * instead of the select and then break VoiceOver usage when navigating the
+         * select options on subsequent opening of select
+         * Refocusing on select seems to seems to mitigate this VO bug.
+         */
+        setTimeout(() => {
+          select.focus();
+        }, 300);
+      }
     }
   }
 

--- a/packages/terra-form-select/tests/jest/Menu.test.jsx
+++ b/packages/terra-form-select/tests/jest/Menu.test.jsx
@@ -4,8 +4,11 @@ import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import { shallowWithIntl, mountWithIntl } from 'terra-enzyme-intl';
 import Option from '../../src/shared/_Option';
+import SharedUtil from '../../src/shared/_SharedUtil';
 import ComboboxMenu from '../../src/combobox/Menu';
 import SingleSelectMenu from '../../src/single/Menu';
+
+jest.mock('../../src/shared/_SharedUtil');
 
 describe('Menu', () => {
   it('should render a default Menu', () => {
@@ -106,5 +109,50 @@ describe('Menu', () => {
       </ThemeContextProvider>,
     );
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should call focus on select component when select is closed via key event while not using safari browser', () => {
+    SharedUtil.isSafari.mockReturnValueOnce(false);
+    const liveRegion = { current: document.createElement('div') };
+
+    const mockSelect = {
+      focus: jest.fn(),
+    };
+
+    const menu = (
+      <SingleSelectMenu onSelect={() => {}} visuallyHiddenComponent={liveRegion} value="value" searchValue="" select={mockSelect}>
+        <Option value="value" display="display" />
+      </SingleSelectMenu>
+    );
+
+    const wrapper = mountWithIntl(menu);
+    wrapper.setState({ closedViaKeyEvent: true });
+    wrapper.unmount();
+
+    expect(mockSelect.focus).toHaveBeenCalled();
+  });
+
+  it('should call focus on select component when select is closed via key event while using safari browser', () => {
+    SharedUtil.isSafari.mockReturnValueOnce(true);
+    const liveRegion = { current: document.createElement('div') };
+
+    const mockSelect = {
+      focus: jest.fn(),
+    };
+
+    jest.useFakeTimers();
+
+    const menu = (
+      <SingleSelectMenu onSelect={() => {}} visuallyHiddenComponent={liveRegion} value="value" searchValue="" select={mockSelect}>
+        <Option value="value" display="display" />
+      </SingleSelectMenu>
+    );
+
+    const wrapper = mountWithIntl(menu);
+    wrapper.setState({ closedViaKeyEvent: true });
+    wrapper.unmount();
+    jest.advanceTimersByTime(500);
+
+    expect(mockSelect.focus).toHaveBeenCalled();
   });
 });

--- a/packages/terra-form-select/tests/jest/__snapshots__/ClearOption.test.jsx.snap
+++ b/packages/terra-form-select/tests/jest/__snapshots__/ClearOption.test.jsx.snap
@@ -48,7 +48,6 @@ exports[`ClearOption correctly applies the theme context className 1`] = `
       value=""
     >
       <li
-        aria-checked={false}
         aria-disabled={false}
         aria-label="Clear"
         aria-selected={false}

--- a/packages/terra-form-select/tests/jest/__snapshots__/Menu.test.jsx.snap
+++ b/packages/terra-form-select/tests/jest/__snapshots__/Menu.test.jsx.snap
@@ -109,7 +109,6 @@ exports[`Menu correctly applies the theme context className 1`] = `
           variant="default"
         >
           <li
-            aria-checked={true}
             aria-disabled={false}
             aria-label="Terra.form.select.expanded display"
             aria-selected={true}


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:** 
- Removed aria-checked from `terra-form-select/src/shared/_Option.jsx`.
- Updated focus to shift on select based on browser.
- Updated documentation for encouraging consumers to use Single Select Field.


**Why it was changed:** For JAWS to announce `Selected` instead of checked.



### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [x] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9100 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
