### PR TITLE
Revert d231e27

### DIFF
--- a/packages/terra-alert/CHANGELOG.md
+++ b/packages/terra-alert/CHANGELOG.md
@@ -7,7 +7,6 @@
 
 * Changed
   * Locked `uuid` to `8.2.0` to maintain IE compatibility.
-  * Changed the Dutch translation for `Terra.alert.success`.
 
 ## 4.68.0 - (May 9, 2023)
 

--- a/packages/terra-alert/translations/nl-BE.json
+++ b/packages/terra-alert/translations/nl-BE.json
@@ -7,5 +7,5 @@
   "Terra.alert.advisory": "Advies.",
   "Terra.alert.unsatisfied": "Vereiste actie.",
   "Terra.alert.unverified": "Externe records.",
-  "Terra.alert.success": "Geslaagd."
+  "Terra.alert.success": "Succes."
 }

--- a/packages/terra-alert/translations/nl.json
+++ b/packages/terra-alert/translations/nl.json
@@ -7,5 +7,5 @@
   "Terra.alert.advisory": "Advies.",
   "Terra.alert.unsatisfied": "Vereiste actie.",
   "Terra.alert.unverified": "Externe records.",
-  "Terra.alert.success": "Geslaagd."
+  "Terra.alert.success": "Succes."
 }


### PR DESCRIPTION
### Summary
This PR reverts[ d231e27](https://github.com/cerner/terra-core/commit/d231e271349a6a1edc43eba8cd6a1e431ea7bb0b) that was accidentally committed to a main branch.
The build check is not passing due to linting issue in main that will be fixed in this [PR](https://github.com/cerner/terra-core/pull/3820)

### Testing
This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed