### PR TITLE
[terra-alert][terra-form-fieldset] Lock uuid to 7.0.3

### DIFF
--- a/packages/terra-alert/CHANGELOG.md
+++ b/packages/terra-alert/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
   * Changed
-    *  Locked `uuid` to `7.0.3`.
+    *  Locked `uuid` dependency to `7.0.3`.
 
 ## 4.69.0 - (June 14, 2023)
 
@@ -11,7 +11,7 @@
   * Added focus shift to the rendered notification banners content when notification is an alert and includes an action element
 
 * Changed
-  * Locked `uuid` to `8.2.0` to maintain IE compatibility.
+  * Locked `uuid` dependency to `8.2.0` to maintain IE compatibility.
   * Updated the Dutch translation for `Terra.alert.success`.
 
 ## 4.68.0 - (May 9, 2023)

--- a/packages/terra-alert/CHANGELOG.md
+++ b/packages/terra-alert/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+  * Changed
+    *  Locked `uuid` to `7.0.3`.
+
 ## 4.69.0 - (June 14, 2023)
 
 * Added

--- a/packages/terra-alert/CHANGELOG.md
+++ b/packages/terra-alert/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## 4.69.0 - (June 14, 2023)
 
 * Added
-  * Added focus shift to the rendered notification banners content when notification is an alert and includes an action element
+  * Added focus shift to the rendered notification banners content when notification is an alert and includes an action element.
 
 * Changed
   * Locked `uuid` dependency to `8.2.0` to maintain IE compatibility.

--- a/packages/terra-alert/package.json
+++ b/packages/terra-alert/package.json
@@ -33,7 +33,7 @@
     "terra-icon": "^3.54.0",
     "terra-responsive-element": "^5.37.0",
     "terra-theme-context": "^1.0.0",
-    "uuid": "8.2.0"
+    "uuid": "7.0.3"
   },
   "scripts": {
     "compile": "babel --root-mode upward src --out-dir lib --copy-files",

--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## Unreleased
 
+* Changed
+  * Minor formatting update in `terra-alert` & `terra-form-fieldset`.
+
 ## 1.30.0 - (July 11, 2023)
 
 * Added
   * Added test example for controlled form native select component.
-
-* Added
   * Added more realistic examples for terra-toggle-button.
 
 ## 1.29.0 - (June 28, 2023)

--- a/packages/terra-core-docs/src/terra-dev-site/doc/alert/About.1.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/alert/About.1.doc.mdx
@@ -137,7 +137,7 @@ For further guidance, please view the full [Accessibility Guide](./accessibility
 
 Terra Alert uses `uuid` which changes the component's description id dynamically. To mock it with the Jest testing library, `jest.mock` can be used.
 
-If Enzyme `shallow` is being used for the tests then the mock may not be required depending on the depth of the returned wrapper. However, if `mount` is used then uuid should be mocked as shown below.
+If Enzyme `shallow` is being used for the tests then the mock may not be required depending on the depth of the returned wrapper. However, if `mount` is used then `uuid` should be mocked as shown below:
 
 ```js
 // using a variable may result in failures. For best results, hardcode the mock return value.

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-fieldset/About.1.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-fieldset/About.1.doc.mdx
@@ -53,7 +53,7 @@ import Fieldset from 'terra-form-fieldset/lib/Fieldset';
 
 Terra Form Fieldset uses `uuid` which changes the component's description id dynamically. To mock it with the Jest testing library, `jest.mock` can be used.
 
-If Enzyme `shallow` is being used for the tests then the mock may not be required depending on the depth of the returned wrapper. However, if `mount` is used then uuid should be mocked as shown below.
+If Enzyme `shallow` is being used for the tests then the mock may not be required depending on the depth of the returned wrapper. However, if `mount` is used then `uuid` should be mocked as shown below:
 
 ```js
 // using a variable may result in failures. For best results, hardcode the mock return value.

--- a/packages/terra-form-fieldset/CHANGELOG.md
+++ b/packages/terra-form-fieldset/CHANGELOG.md
@@ -3,12 +3,12 @@
 ## Unreleased
 
 * Changed
-  *  Locked `uuid` to `7.0.3`.
+  *  Locked `uuid` dependency to `7.0.3`.
 
 ## 2.70.0 - (June 14, 2023)
 
 * Changed
-  * Updated `uuid` to `8.2.0` for consistency with other components.
+  * Updated `uuid` dependency to `8.2.0` for consistency with other components.
 
 ## 2.69.0 - (April 27, 2023)
 

--- a/packages/terra-form-fieldset/CHANGELOG.md
+++ b/packages/terra-form-fieldset/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  *  Locked `uuid` to `7.0.3`.
+
 ## 2.70.0 - (June 14, 2023)
 
 * Changed

--- a/packages/terra-form-fieldset/package.json
+++ b/packages/terra-form-fieldset/package.json
@@ -31,7 +31,7 @@
     "terra-form-field": "^4.25.0",
     "terra-form-input": "^4.23.0",
     "terra-theme-context": "^1.0.0",
-    "uuid": "8.2.0"
+    "uuid": "7.0.3"
   },
   "scripts": {
     "compile": "babel --root-mode upward src --out-dir lib --copy-files",


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

Locked `uuid` to `7.0.3` for consistency across Terra repos and maximum compatibility for consumers.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->


---

Thank you for contributing to Terra.
@cerner/terra
