### PR TITLE
[terra-arrange] add reflow support for 400% zoom

### DIFF
--- a/packages/terra-arrange/CHANGELOG.md
+++ b/packages/terra-arrange/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed issue terra arrange support resizing to 400% and viewport is resized to 320x256 px without loss of information or function.
+
 ## 3.51.0 - (February 15, 2023)
 
 * Changed

--- a/packages/terra-arrange/CHANGELOG.md
+++ b/packages/terra-arrange/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
-  * Fixed issue terra arrange support resizing to 400% and viewport is resized to 320x256 px without loss of information or function.
+  * Fixed reflow issue when zoomed to 400% and the viewport is resized to 320x256 px.
 
 ## 3.51.0 - (February 15, 2023)
 

--- a/packages/terra-arrange/src/Arrange.module.scss
+++ b/packages/terra-arrange/src/Arrange.module.scss
@@ -7,6 +7,8 @@
   // Vertically aligns arrange content to the top by default
   .arrange {
     display: flex;
+    max-width: 100%;
+    overflow: auto;
   }
 
   // Makes sure fill expands to fill the remaining space of its parent container
@@ -23,10 +25,12 @@
 
   .center {
     align-self: center;
+    max-height: 100%;
   }
 
   .bottom {
     align-self: flex-end;
+    max-height: 100%;
   }
 
   .stretch {


### PR DESCRIPTION
###  Terra arrange support resizing to 400%
https://github.com/cerner/terra-core/assets/126649018/10e80b85-b6b9-4ab3-8422-2433f8ec5a70
### Terra arrange viewport is resized to 320x256 px without loss of informatio or funtion
https://github.com/cerner/terra-core/assets/126649018/628a35b2-1aee-4a0b-8c98-b3958248e36f

 **Summary**
 Please ensure that to test this with terra arrange:-
1.Ensure that terra arrange support altering multiple CSS attributes without loss of function or information.
2.Ensure that terra arrange support resizing to 400%.
3.Ensure that terra arrange support reflow when the viewport is resized to 320x256 px without loss of information or functio

n**_**Solution**_**
I have made changes in Arrange.module.scss

    max-width: 100%;
    overflow: auto;
    max-height: 100%;
    
   [UXPLATFORM-9326]

Thank you for contributing to Terra.
**@cerner/terra**

