### PR TITLE
[terra-form-field] Updated Regular expression of Email

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * Updated
   * Updated an example for `terra-dropdown-button`.
+  * Updated email field validation for `terra-form-field`.
 
 * Added
   * Added documentation updates for `terra-form-input`.

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-field/example/FieldExamples.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-field/example/FieldExamples.jsx
@@ -14,7 +14,7 @@ const FieldExamples = () => {
   // Function for email validation
   const emailValidation = (e) => {
     e.preventDefault();
-    const regExEmail = /[a-zA-Z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,8}(.[a-z{2,8}])?/g;
+    const regExEmail = /^[-a-z0-9#$%^&'`?{}_=+\/}{\'?]+(\.[-a-z0-9#$%^&'`?{}_=+\/}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.([a-z][a-z]{1,2}))?$/i;
     if (!regExEmail.test(email) && email !== '') {
       setEmailInvalid(true);
       setMessage('The e-mail address entered is invalid');

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-field/example/FieldExamples.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-field/example/FieldExamples.jsx
@@ -14,7 +14,7 @@ const FieldExamples = () => {
   // Function for email validation
   const emailValidation = (e) => {
     e.preventDefault();
-    const regExEmail = /^[-a-z0-9#$%^&'`?{}_=+\/}{\'?]+(\.[-a-z0-9#$%^&'`?{}_=+\/}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.([a-z][a-z]{1,2}))?$/i;
+    const regExEmail = /^[-a-z0-9#$%^&'`?{}_=+/}{'?]+(\.[-a-z0-9#$%^&'`?{}_=+/}{'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.([a-z][a-z]{1,2}))?$/i;
     if (!regExEmail.test(email) && email !== '') {
       setEmailInvalid(true);
       setMessage('The e-mail address entered is invalid');

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-field/example/FieldExamples.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-field/example/FieldExamples.jsx
@@ -14,7 +14,7 @@ const FieldExamples = () => {
   // Function for email validation
   const emailValidation = (e) => {
     e.preventDefault();
-    const regExEmail = /^[-a-z0-9#$%^&'`?{}_=+/}{'?]+(\.[-a-z0-9#$%^&'`?{}_=+/}{'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.([a-z][a-z]{1,2}))?$/i;
+    const regExEmail = /^[-a-z0-9#$%^&'`?{}_=+/}{'?]+(\.[-a-z0-9#$%^&'`?{}_=+/}{'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.([a-z][a-z]{1,62}))?$/i;
     if (!regExEmail.test(email) && email !== '') {
       setEmailInvalid(true);
       setMessage('The e-mail address entered is invalid');


### PR DESCRIPTION
### Summary
Previously email field was accepting n number of characters after dot( . ). Now it has been updated to accept minimum 2 and maximum 63 characters after the dot ( . ) in the email field.


**Why it was changed:**
Because the email field was accepting n number of characters which is not a valid email address.


### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9384

---

Thank you for contributing to Terra.
@cerner/terra
