### PR TITLE
Added isMac helper in terra-dropdown component

### DIFF
--- a/packages/terra-dropdown-button/CHANGELOG.md
+++ b/packages/terra-dropdown-button/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added isMac helper in `_DropdownListUtil.js` file.
+
 ## 1.35.0 - (August 1, 2023)
 
 * Added

--- a/packages/terra-dropdown-button/src/_DropdownList.jsx
+++ b/packages/terra-dropdown-button/src/_DropdownList.jsx
@@ -6,7 +6,6 @@ import * as KeyCode from 'keycode-js';
 import { injectIntl } from 'react-intl';
 import Util from './_DropdownListUtil';
 import styles from './_DropdownList.module.scss';
-import SharedUtil from '../../terra-form-select/src/shared/_SharedUtil';
 
 const cx = classNamesBind.bind(styles);
 
@@ -186,7 +185,7 @@ class DropdownList extends React.Component {
       const activeOption = this.props.intl.formatMessage({ id: 'Terra.dropdownButton.activeOption' }, { currentItemLabel, currentIndex, totalItems });
       let ariaLabel = null;
       if (totalItems) {
-        if (SharedUtil.isMac()) {
+        if (Util.isMac()) {
           ariaLabel = currentIndex === 1 ? `${this.expanded}${activeOption}` : activeOption;
         } else {
           ariaLabel = currentIndex === 1 ? `${this.expanded}${currentItemLabel}` : currentItemLabel;

--- a/packages/terra-dropdown-button/src/_DropdownListUtil.js
+++ b/packages/terra-dropdown-button/src/_DropdownListUtil.js
@@ -81,6 +81,12 @@ class DropdownListUtil {
     const previous = Math.max(index - 1, 0);
     return Math.min(previous, options.length - 1);
   }
+
+  /**
+   * Util to determine if the user agent indicates that it is macOS
+   * @return {boolean}
+   */
+   static isMac = () => navigator.userAgent.indexOf('Mac') !== -1 && navigator.userAgent.indexOf('Win') === -1;
 }
 
 export default DropdownListUtil;

--- a/packages/terra-dropdown-button/tests/jest/DropdownList.test.jsx
+++ b/packages/terra-dropdown-button/tests/jest/DropdownList.test.jsx
@@ -25,6 +25,10 @@ const eventMock = {
   stopPropagation: jest.fn(),
 };
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('Dropdown List', () => {
   it('renders a default dropdown list', () => {
     const wrapper = shallowWithIntl(

--- a/packages/terra-dropdown-button/tests/jest/DropdownList.test.jsx
+++ b/packages/terra-dropdown-button/tests/jest/DropdownList.test.jsx
@@ -7,12 +7,7 @@ import translationsFile from '../../translations/en.json';
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import DropdownList from '../../src/_DropdownList';
 import { Item } from '../../src/DropdownButton';
-import SharedUtil from '../../../terra-form-select/src/shared/_SharedUtil';
-
-// Mock the SharedUtil module
-jest.mock('../../../terra-form-select/src/shared/_SharedUtil', () => ({
-  isMac: jest.fn(),
-}));
+import Util from '../../src/_DropdownListUtil';
 
 const listRefMock = {
   childNodes: [
@@ -118,7 +113,7 @@ describe('Dropdown List', () => {
 
   it('should set the aria-label property to empty on keydown on Mac', () => {
     //  Sets the mock return value for isMac
-    SharedUtil.isMac.mockReturnValue(true);
+    jest.spyOn(Util, 'isMac').mockReturnValue(true);
 
     const wrapper = shallowWithIntl(
       <IntlProvider locale="en" messages={translationsFile}>
@@ -144,7 +139,7 @@ describe('Dropdown List', () => {
 
   it('should set the aria-label property to empty on keydown on non-mac', () => {
     //  Sets the mock return value for isMac
-    SharedUtil.isMac.mockReturnValue(false);
+    jest.spyOn(Util, 'isMac').mockReturnValue(false);
 
     const wrapper = shallowWithIntl(
       <IntlProvider locale="en" messages={translationsFile}>


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
Issues with terra-dropdown-button version 1.35.0

**What was changed:**
Added isMac helper in _DropdownListUtil.js instead of using it from terra-form-select component.  

**Why it was changed:**
Due to use of relative path from different package dropdown button started to break when consumed.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

[UXPLATFORM-9447](https://jira2.cerner.com/browse/UXPLATFORM-9447)

---

Thank you for contributing to Terra.
@cerner/terra
