### PR TITLE
[terra-arrange] Removed scroll at 400% zoom  and custom styles in examples

### DIFF
--- a/packages/terra-arrange/src/Arrange.module.scss
+++ b/packages/terra-arrange/src/Arrange.module.scss
@@ -7,8 +7,6 @@
   // Vertically aligns arrange content to the top by default
   .arrange {
     display: flex;
-    max-width: 100%;
-    overflow: auto;
   }
 
   // Makes sure fill expands to fill the remaining space of its parent container

--- a/packages/terra-core-docs/src/terra-dev-site/doc/arrange/example/ArrangeAlignAllContainers.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/arrange/example/ArrangeAlignAllContainers.jsx
@@ -1,18 +1,13 @@
 import React from 'react';
-import classNames from 'classnames/bind';
 import Arrange from 'terra-arrange';
 import {
   textClinicalData, textHealthSolutionsData, textConsentFormData, homeButton, menuButton, chatButton, settingsButton, twitterButton, backtotopButton,
 } from '../common/examplesetup';
-import styles from './ArrangeExamples.module.scss';
-
-const cx = classNames.bind(styles);
 
 const ArrangeAlignAllContainers = () => (
   <div>
     <h3>Align - Default</h3>
     <Arrange
-      className={cx('arrange')}
       fitStart={homeButton}
       fill={textClinicalData}
       fitEnd={menuButton}
@@ -22,7 +17,6 @@ const ArrangeAlignAllContainers = () => (
     <h3>Align - Center</h3>
     <Arrange
       align="center"
-      className={cx('arrange')}
       fitStart={settingsButton}
       fill={textHealthSolutionsData}
       fitEnd={chatButton}
@@ -32,7 +26,6 @@ const ArrangeAlignAllContainers = () => (
     <h3>Align - Bottom</h3>
     <Arrange
       align="bottom"
-      className={cx('arrange')}
       fitStart={twitterButton}
       fill={textConsentFormData}
       fitEnd={backtotopButton}

--- a/packages/terra-core-docs/src/terra-dev-site/doc/arrange/example/ArrangeAlignFill.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/arrange/example/ArrangeAlignFill.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
-import classNames from 'classnames/bind';
 import Arrange from 'terra-arrange';
 import { alignExampleDiv, textWithBlueBorder } from '../common/examplesetup';
-import styles from './ArrangeExamples.module.scss';
-
-const cx = classNames.bind(styles);
 
 const ArrangeAlignFill = () => (
   <div>
     <h3>Align Fill - Default</h3>
     <Arrange
-      className={cx('arrange')}
       fitStart={alignExampleDiv}
       fill={textWithBlueBorder}
       fitEnd={alignExampleDiv}
@@ -20,7 +15,6 @@ const ArrangeAlignFill = () => (
     <h3>Align Fill - Center</h3>
     <Arrange
       alignFill="center"
-      className={cx('arrange')}
       fitStart={alignExampleDiv}
       fill={textWithBlueBorder}
       fitEnd={alignExampleDiv}
@@ -30,7 +24,6 @@ const ArrangeAlignFill = () => (
     <h3>Align Fill - Bottom</h3>
     <Arrange
       alignFill="bottom"
-      className={cx('arrange')}
       fitStart={alignExampleDiv}
       fill={textWithBlueBorder}
       fitEnd={alignExampleDiv}

--- a/packages/terra-core-docs/src/terra-dev-site/doc/arrange/example/ArrangeAlignFitEnd.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/arrange/example/ArrangeAlignFitEnd.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
-import classNames from 'classnames/bind';
 import Arrange from 'terra-arrange';
 import { alignExampleDivBlue, alignExampleDiv, simpleText } from '../common/examplesetup';
-import styles from './ArrangeExamples.module.scss';
-
-const cx = classNames.bind(styles);
 
 const ArrangeAlignFitStart = () => (
   <div>
     <h3>Align FitEnd - Default</h3>
     <Arrange
-      className={cx('arrange')}
       fitStart={alignExampleDiv}
       fill={simpleText}
       fitEnd={alignExampleDivBlue}
@@ -20,7 +15,6 @@ const ArrangeAlignFitStart = () => (
     <h3>Align FitEnd - Center</h3>
     <Arrange
       alignFitEnd="center"
-      className={cx('arrange')}
       fitStart={alignExampleDiv}
       fill={simpleText}
       fitEnd={alignExampleDivBlue}
@@ -30,7 +24,6 @@ const ArrangeAlignFitStart = () => (
     <h3>Align FitEnd - Bottom</h3>
     <Arrange
       alignFitEnd="bottom"
-      className={cx('arrange')}
       fitStart={alignExampleDiv}
       fill={simpleText}
       fitEnd={alignExampleDivBlue}

--- a/packages/terra-core-docs/src/terra-dev-site/doc/arrange/example/ArrangeAlignFitStart.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/arrange/example/ArrangeAlignFitStart.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
-import classNames from 'classnames/bind';
 import Arrange from 'terra-arrange';
 import { alignExampleDiv, alignExampleDivBlue, simpleText } from '../common/examplesetup';
-import styles from './ArrangeExamples.module.scss';
-
-const cx = classNames.bind(styles);
 
 const ArrangeAlignFitStart = () => (
   <div>
     <h3>Align FitStart - Default</h3>
     <Arrange
-      className={cx('arrange')}
       fitStart={alignExampleDivBlue}
       fill={simpleText}
       fitEnd={alignExampleDiv}
@@ -20,7 +15,6 @@ const ArrangeAlignFitStart = () => (
     <h3>Align FitStart - Center</h3>
     <Arrange
       alignFitStart="center"
-      className={cx('arrange')}
       fitStart={alignExampleDivBlue}
       fill={simpleText}
       fitEnd={alignExampleDiv}
@@ -30,7 +24,6 @@ const ArrangeAlignFitStart = () => (
     <h3>Align FitStart - Bottom</h3>
     <Arrange
       alignFitStart="bottom"
-      className={cx('arrange')}
       fitStart={alignExampleDivBlue}
       fill={simpleText}
       fitEnd={alignExampleDiv}

--- a/packages/terra-core-docs/src/terra-dev-site/doc/arrange/example/ArrangeExamples.module.scss
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/arrange/example/ArrangeExamples.module.scss
@@ -1,7 +1,0 @@
-:local {
-  .arrange {
-    border: 1px solid #000;
-    height: 100px;
-    width: 500px;
-  }
-}


### PR DESCRIPTION
### Summary
Custom styles of arrange control examples (Height, width and border) has been removed. We have reverted the styles (max-width and overflow) which were added to fix reflow issue at zoom level 400%. Because, these custom styles are causing issues in other components where arrange has been used. 
To fix the 400% zoom level issue, we have removed Height and Width of all examples. Previously, we are getting fixed height and width for the examples. So that we're not able see the whole content and it's getting cropped in mobile view or 400% zoom level. Since we removed the height and width of the examples we can see the whole content without any cropping.

**What was changed:**
Custom styles of arrange control examples has been removed.

**Why it was changed:**
These styles are causing errors in other controls where arrange has been used.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9475

---

Thank you for contributing to Terra.
@cerner/terra
