### PR TITLE
[terra-alert] focus on empty element

### DIFF
--- a/packages/terra-alert/CHANGELOG.md
+++ b/packages/terra-alert/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated `terra-alert` focus on the notification banners content when notification is an alert and includes an action element to improve screen reader experience.
+
 ## 4.75.0 - (August 11, 2023)
 
 * Changed

--- a/packages/terra-alert/src/Alert.jsx
+++ b/packages/terra-alert/src/Alert.jsx
@@ -160,7 +160,7 @@ const Alert = ({
     { 'body-narrow': isNarrow && (onDismiss || action) },
   );
 
-  const focusContainerClassName = cx('focusContainer');
+  const focusContainerClassName = cx('focus-container');
 
   const alertId = uuidv4();
   const alertTitleId = `alert-title-${alertId}`;

--- a/packages/terra-alert/src/Alert.jsx
+++ b/packages/terra-alert/src/Alert.jsx
@@ -160,6 +160,8 @@ const Alert = ({
     { 'body-narrow': isNarrow && (onDismiss || action) },
   );
 
+  const focusContainerClassName = cx('focusContainer');
+
   const alertId = uuidv4();
   const alertTitleId = `alert-title-${alertId}`;
   const alertMessageId = `alert-message-${alertId}`;
@@ -227,9 +229,10 @@ const Alert = ({
         {...customProps}
         className={alertClassNames}
       >
-        <div className={bodyClassNameForParent} ref={alertBodyRef} tabIndex="-1">
+        <div className={bodyClassNameForParent}>
           {getAlertIcon(type, customIcon)}
           {alertMessageContent}
+          <div className={focusContainerClassName} ref={alertBodyRef} tabIndex="-1" />
         </div>
         {actionsSection}
       </div>

--- a/packages/terra-alert/src/Alert.module.scss
+++ b/packages/terra-alert/src/Alert.module.scss
@@ -34,7 +34,6 @@
   }
 
   .body {
-    position: relative;
     align-items: flex-start;
     display: flex;
     flex: 1 1 auto;
@@ -44,6 +43,7 @@
     margin-right: var(--terra-alert-body-margin-right, 0.7143rem);
     margin-top: var(--terra-alert-body-margin-top, 0.7143rem);
     padding-top: 0;
+    position: relative;
   }
 
   .body-narrow {
@@ -55,16 +55,16 @@
     margin-right: var(--terra-alert-std-margin-right, 0.6667rem);
   }
 
-  .focusContainer {
-    position: absolute;
+  .focus-container {
+    bottom: 0;
     display: block;
-    top: 0px;
-    bottom: 0px;
-    right: 0px;
-    left: 0px;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
   }
 
-  .focusContainer:focus-visible {
+  .focus-container:focus-visible {
     box-shadow: var(--terra-alert-focus-keyboard-box-shadow, none);
     outline: var(--terra-alert-focus-keyboard-outline, 2px dashed #000);
     outline-offset: var(--terra-alert-focus-keyboard-outline-offset, 1px);

--- a/packages/terra-alert/src/Alert.module.scss
+++ b/packages/terra-alert/src/Alert.module.scss
@@ -34,6 +34,7 @@
   }
 
   .body {
+    position: relative;
     align-items: flex-start;
     display: flex;
     flex: 1 1 auto;
@@ -42,7 +43,6 @@
     margin-left: var(--terra-alert-body-margin-left, 0.64285rem);
     margin-right: var(--terra-alert-body-margin-right, 0.7143rem);
     margin-top: var(--terra-alert-body-margin-top, 0.7143rem);
-    overflow: hidden;
     padding-top: 0;
   }
 
@@ -55,7 +55,16 @@
     margin-right: var(--terra-alert-std-margin-right, 0.6667rem);
   }
 
-  .body:focus-visible {
+  .focusContainer {
+    position: absolute;
+    display: block;
+    top: 0px;
+    bottom: 0px;
+    right: 0px;
+    left: 0px;
+  }
+
+  .focusContainer:focus-visible {
     box-shadow: var(--terra-alert-focus-keyboard-box-shadow, none);
     outline: var(--terra-alert-focus-keyboard-outline, 2px dashed #000);
     outline-offset: var(--terra-alert-focus-keyboard-outline-offset, 1px);

--- a/packages/terra-alert/tests/jest/Alert.test.jsx
+++ b/packages/terra-alert/tests/jest/Alert.test.jsx
@@ -29,7 +29,7 @@ describe('Alert with no props', () => {
     const wrapper = shallowWithIntl(<Alert />).dive();
 
     const alertDiv = wrapper.find('div.alert-base');
-    const alertFocusDiv = wrapper.find('div.focusContainer');
+    const alertFocusDiv = wrapper.find('div.focus-container');
     expect(alertDiv.prop('className')).toEqual('alert-base alert wide');
     expect(alertDiv.prop('role')).toEqual('alert');
     expect(alertFocusDiv.prop('tabIndex')).toEqual('-1');

--- a/packages/terra-alert/tests/jest/Alert.test.jsx
+++ b/packages/terra-alert/tests/jest/Alert.test.jsx
@@ -29,10 +29,10 @@ describe('Alert with no props', () => {
     const wrapper = shallowWithIntl(<Alert />).dive();
 
     const alertDiv = wrapper.find('div.alert-base');
-    const alertContentDiv = wrapper.find('div.body');
+    const alertFocusDiv = wrapper.find('div.focusContainer');
     expect(alertDiv.prop('className')).toEqual('alert-base alert wide');
     expect(alertDiv.prop('role')).toEqual('alert');
-    expect(alertContentDiv.prop('tabIndex')).toEqual('-1');
+    expect(alertFocusDiv.prop('tabIndex')).toEqual('-1');
     expect(wrapper.find(IconAlert).length).toEqual(1);
     expect(wrapper.find('.title').text()).toEqual('Terra.alert.alert');
     expect(wrapper).toMatchSnapshot();

--- a/packages/terra-alert/tests/jest/__snapshots__/Alert.test.jsx.snap
+++ b/packages/terra-alert/tests/jest/__snapshots__/Alert.test.jsx.snap
@@ -25,7 +25,7 @@ exports[`Alert of type advisory with text content should render an Alert compone
         This is an advisory alert.
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>
@@ -66,7 +66,7 @@ exports[`Alert of type alert with text content should render an Alert component 
         This is a test
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>
@@ -107,7 +107,7 @@ exports[`Alert of type custom with custom title and text content should render a
         This is a custom alert.
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>
@@ -148,7 +148,7 @@ exports[`Alert of type error with text content should render an Alert component 
         This is an error.
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>
@@ -229,7 +229,7 @@ exports[`Alert of type info with text content should render an Alert component o
         This is an information alert.
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>
@@ -270,7 +270,7 @@ exports[`Alert of type success with an action button text content should render 
         This is a success alert.
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>
@@ -326,7 +326,7 @@ exports[`Alert of type success with text content should render an Alert componen
         This is a success alert.
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>
@@ -367,7 +367,7 @@ exports[`Alert of type unsatisfied should render an unsatisfied Alert 1`] = `
         This is an unsatisfied alert.
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>
@@ -408,7 +408,7 @@ exports[`Alert of type unverified should render an unverified Alert 1`] = `
         This is an unverified alert.
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>
@@ -449,7 +449,7 @@ exports[`Alert of type warning with text content should render an Alert componen
         This is an warning.
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>
@@ -580,7 +580,7 @@ exports[`Alert with no props should render a default component 1`] = `
             </strong>
           </div>
           <div
-            className="focusContainer"
+            className="focus-container"
             tabIndex="-1"
           />
         </div>
@@ -622,7 +622,7 @@ exports[`Alert with no props should render a default notification banner with de
         </strong>
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>
@@ -662,7 +662,7 @@ exports[`Alert with props should render an alert with provided role 1`] = `
         </strong>
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>
@@ -794,7 +794,7 @@ exports[`Alert with props should render disableAlertActionFocus when provided 1`
             </strong>
           </div>
           <div
-            className="focusContainer"
+            className="focus-container"
             tabIndex="-1"
           />
         </div>
@@ -837,7 +837,7 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
         This is a custom alert.
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>
@@ -905,7 +905,7 @@ exports[`Dismissible Alert that includes actions section should render an alert 
         This is a test
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>
@@ -959,7 +959,7 @@ exports[`correctly applies the theme context className 1`] = `
         </strong>
       </div>
       <div
-        className="focusContainer"
+        className="focus-container"
         tabIndex="-1"
       />
     </div>

--- a/packages/terra-alert/tests/jest/__snapshots__/Alert.test.jsx.snap
+++ b/packages/terra-alert/tests/jest/__snapshots__/Alert.test.jsx.snap
@@ -11,7 +11,6 @@ exports[`Alert of type advisory with text content should render an Alert compone
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <div
         className="section"
@@ -25,6 +24,10 @@ exports[`Alert of type advisory with text content should render an Alert compone
         </strong>
         This is an advisory alert.
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
   </div>
 </ResponsiveElement>
@@ -41,7 +44,6 @@ exports[`Alert of type alert with text content should render an Alert component 
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <span
         className="icon"
@@ -63,6 +65,10 @@ exports[`Alert of type alert with text content should render an Alert component 
         </strong>
         This is a test
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
   </div>
 </ResponsiveElement>
@@ -79,7 +85,6 @@ exports[`Alert of type custom with custom title and text content should render a
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <span
         className="icon"
@@ -101,6 +106,10 @@ exports[`Alert of type custom with custom title and text content should render a
         </strong>
         This is a custom alert.
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
   </div>
 </ResponsiveElement>
@@ -117,7 +126,6 @@ exports[`Alert of type error with text content should render an Alert component 
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <span
         className="icon"
@@ -139,6 +147,10 @@ exports[`Alert of type error with text content should render an Alert component 
         </strong>
         This is an error.
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
   </div>
 </ResponsiveElement>
@@ -195,7 +207,6 @@ exports[`Alert of type info with text content should render an Alert component o
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <span
         className="icon"
@@ -217,6 +228,10 @@ exports[`Alert of type info with text content should render an Alert component o
         </strong>
         This is an information alert.
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
   </div>
 </ResponsiveElement>
@@ -233,7 +248,6 @@ exports[`Alert of type success with an action button text content should render 
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <span
         className="icon"
@@ -255,6 +269,10 @@ exports[`Alert of type success with an action button text content should render 
         </strong>
         This is a success alert.
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
     <div
       className="actions"
@@ -286,7 +304,6 @@ exports[`Alert of type success with text content should render an Alert componen
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <span
         className="icon"
@@ -308,6 +325,10 @@ exports[`Alert of type success with text content should render an Alert componen
         </strong>
         This is a success alert.
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
   </div>
 </ResponsiveElement>
@@ -324,7 +345,6 @@ exports[`Alert of type unsatisfied should render an unsatisfied Alert 1`] = `
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <span
         className="icon unsatisfied-icon"
@@ -346,6 +366,10 @@ exports[`Alert of type unsatisfied should render an unsatisfied Alert 1`] = `
         </strong>
         This is an unsatisfied alert.
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
   </div>
 </ResponsiveElement>
@@ -362,7 +386,6 @@ exports[`Alert of type unverified should render an unverified Alert 1`] = `
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <span
         className="icon unverified-icon"
@@ -384,6 +407,10 @@ exports[`Alert of type unverified should render an unverified Alert 1`] = `
         </strong>
         This is an unverified alert.
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
   </div>
 </ResponsiveElement>
@@ -400,7 +427,6 @@ exports[`Alert of type warning with text content should render an Alert componen
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <span
         className="icon"
@@ -422,6 +448,10 @@ exports[`Alert of type warning with text content should render an Alert componen
         </strong>
         This is an warning.
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
   </div>
 </ResponsiveElement>
@@ -499,7 +529,6 @@ exports[`Alert with no props should render a default component 1`] = `
       >
         <div
           className="body body-std"
-          tabIndex="-1"
         >
           <span
             className="icon"
@@ -550,6 +579,10 @@ exports[`Alert with no props should render a default component 1`] = `
               Terra.alert.alert
             </strong>
           </div>
+          <div
+            className="focusContainer"
+            tabIndex="-1"
+          />
         </div>
       </div>
     </ResponsiveElement>
@@ -568,7 +601,6 @@ exports[`Alert with no props should render a default notification banner with de
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <span
         className="icon"
@@ -589,6 +621,10 @@ exports[`Alert with no props should render a default notification banner with de
           Terra.alert.alert
         </strong>
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
   </div>
 </ResponsiveElement>
@@ -605,7 +641,6 @@ exports[`Alert with props should render an alert with provided role 1`] = `
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <span
         className="icon"
@@ -626,6 +661,10 @@ exports[`Alert with props should render an alert with provided role 1`] = `
           Terra.alert.alert
         </strong>
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
   </div>
 </ResponsiveElement>
@@ -704,7 +743,6 @@ exports[`Alert with props should render disableAlertActionFocus when provided 1`
       >
         <div
           className="body body-std"
-          tabIndex="-1"
         >
           <span
             className="icon"
@@ -755,6 +793,10 @@ exports[`Alert with props should render disableAlertActionFocus when provided 1`
               Terra.alert.alert
             </strong>
           </div>
+          <div
+            className="focusContainer"
+            tabIndex="-1"
+          />
         </div>
       </div>
     </ResponsiveElement>
@@ -773,7 +815,6 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <span
         className="icon"
@@ -795,6 +836,10 @@ exports[`Dismissable Alert of type custom with action button, custom title and t
         </strong>
         This is a custom alert.
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
     <div
       className="actions actions-custom"
@@ -838,7 +883,6 @@ exports[`Dismissible Alert that includes actions section should render an alert 
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <span
         className="icon"
@@ -860,6 +904,10 @@ exports[`Dismissible Alert that includes actions section should render an alert 
         </strong>
         This is a test
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
     <div
       className="actions"
@@ -890,7 +938,6 @@ exports[`correctly applies the theme context className 1`] = `
   >
     <div
       className="body body-std"
-      tabIndex="-1"
     >
       <span
         className="icon"
@@ -911,6 +958,10 @@ exports[`correctly applies the theme context className 1`] = `
           Terra.alert.success
         </strong>
       </div>
+      <div
+        className="focusContainer"
+        tabIndex="-1"
+      />
     </div>
   </div>
 </Fragment>


### PR DESCRIPTION
### Summary
Currently the screen readers read the notification banner's content twice when the notification is an Alert with an action element (custom prop alert). That happens as the alert content receives focus and has a role="alert".  

**What was changed:**
The focus has been shifted to an empty div of the same size as the content div for avoiding the content being read twice.

### Testing
This change was tested using:

- [x] WDIO
- [x] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews
In addition to engineering reviews, this PR needs:
- [x] UX review
- [x] Accessibility review
- [ ] Functional review

**This PR resolves:**

UXPLATFORM-9144