### PR TITLE
[terra-list] Added Drag and Drop Example to Terra List

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* Added
+  * Added drag and drop example for `terra-list`.
 
 * Updated
   * Updated `terra-scroll` to add realistic examples.

--- a/packages/terra-core-docs/src/terra-dev-site/doc/list/About.1.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/list/About.1.doc.mdx
@@ -7,6 +7,7 @@ import AriaDescribedByVisibleList from  './example/AriaDescribedByVisibleList?de
 import AriaDescribedByHiddenList from  './example/AriaDescribedByHiddenList?dev-site-example';
 import AriaDescriptionList from './example/AriaDescriptionList?dev-site-example';
 import AriaDetailsList from './example/AriaDetailsList?dev-site-example';
+import ListDraggableExample from './example/DraggableListItem?dev-site-example';
 
 import ListPropsTable from 'terra-list/lib/List?dev-site-props-table';
 
@@ -76,6 +77,7 @@ import List, { Item } from 'terra-list';
   (in reference to the visible text above the list) to give additional instructions for how the user
   should use this list."
 />
+<ListDraggableExample/>
 
 ## List Props
 <ListPropsTable />


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->
Added drag and drop example in about page for terra list.

**What was changed:**
Added drag and drop example in about page for terra list.

**Why it was changed:**
As there was no example for drag and drop in terra list about doc page.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [x] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-8066 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
