### PR TITLE
jest.mock replaced with spyOn 2

### DIFF
--- a/packages/terra-alert/tests/jest/Alert.test.jsx
+++ b/packages/terra-alert/tests/jest/Alert.test.jsx
@@ -15,7 +15,7 @@ import Alert from '../../src/Alert';
 
 let mockSpyUuid;
 beforeAll(() => {
-  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
 });
 
 afterAll(() => {

--- a/packages/terra-core-docs/src/terra-dev-site/doc/alert/About.1.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/alert/About.1.doc.mdx
@@ -146,7 +146,7 @@ let mockSpyUuid;
 
 // using a variable may result in failures. For best results, mock return value.
 beforeAll(() => {
-  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
 });
 
 // restore the mock

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-fieldset/About.1.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-fieldset/About.1.doc.mdx
@@ -62,7 +62,7 @@ let mockSpyUuid;
 
 // using a variable may result in failures. For best results, mock return value.
 beforeAll(() => {
-  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
 });
 
 // restore the mock

--- a/packages/terra-core-docs/src/terra-dev-site/doc/show-hide/About.1.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/show-hide/About.1.doc.mdx
@@ -220,7 +220,7 @@ let mockSpyUuid;
 
 // using a variable may result in failures. For best results, mock return value.
 beforeAll(() => {
-  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
 });
 
 // restore the mock

--- a/packages/terra-form-fieldset/tests/jest/FormFieldset.test.jsx
+++ b/packages/terra-form-fieldset/tests/jest/FormFieldset.test.jsx
@@ -7,7 +7,7 @@ import Fieldset from '../../src/Fieldset';
 
 let mockSpyUuid;
 beforeAll(() => {
-  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
 });
 
 afterAll(() => {

--- a/packages/terra-show-hide/tests/jest/ShowHide.test.jsx
+++ b/packages/terra-show-hide/tests/jest/ShowHide.test.jsx
@@ -9,7 +9,7 @@ import ShowHide from '../../src/ShowHide';
 describe('ShowHide', () => {
   let mockSpyUuid;
   beforeAll(() => {
-    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
   });
 
   afterAll(() => {

--- a/packages/terra-show-hide/tests/jest/ShowHideFocuser.test.jsx
+++ b/packages/terra-show-hide/tests/jest/ShowHideFocuser.test.jsx
@@ -5,7 +5,7 @@ import ShowHideFocuser from '../../src/ShowHideFocuser';
 describe('ShowHideFocuser', () => {
   let mockSpyUuid;
   beforeAll(() => {
-    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
   });
 
   afterAll(() => {


### PR DESCRIPTION
### Summary
This PR is a follow up for https://github.com/cerner/terra-core/pull/3894

**What was changed:**
The `mockImplementation` was replaced with `mockReturnValue` for cleaner look and consistency across the Terra platform.

### Testing
This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR is a part of following JIRA:**
UXPLATFORM-9515
