### PR TITLE
[Terra-Form-Radio] Update Prop description of form-radio

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
 ## Unreleased
+
 * Added
   * Added drag and drop example for `terra-list`.
+  * Added instruction note for `terra-form-radio` label hidden example
 
 * Updated
-  * Updated `terra-scroll` to add realistic examples.
+  *  Updated `terra-scroll` to add realistic examples.
   *  Updated all paginator examples to use meaningful titles.
   *  Updated testing recommendations to use `jest.spyOn` instead of `jest.mock`.
  

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-radio/example/radio/HiddenLabelRadioExample.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-radio/example/radio/HiddenLabelRadioExample.jsx
@@ -4,9 +4,10 @@ import Radio from 'terra-form-radio';
 const hiddenLabelRadioExample = () => (
   <div>
     <p>
-      <b>Note:</b>
+      <b>Note: </b>
       Radio button should always have label to ensures that people with visual or cognitive disabilities will recognize radio buttons and understand what information to provide to fill in the fields.
-      For example: When we have radio feilds for selection of account types, authors may feel that just providing programmatically determined names of the fields will be sufficient to identify them. However, even if all the fields have programmatically determined names, a text label must also identify the set of fields as a account type.
+      <br />
+      For example: When we have radio fields for selection of account types, authors may feel that just providing programmatically determined names of the fields will be sufficient to identify them. However, even if all the fields have programmatically determined names, a text label must also identify the set of fields as a account type.
     </p>
     <Radio id="hidden-radio" labelText="can you see me?" isLabelHidden />
   </div>

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-radio/example/radio/HiddenLabelRadioExample.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-radio/example/radio/HiddenLabelRadioExample.jsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import Radio from 'terra-form-radio';
 
-const hiddenLabelRadioExample = () => (<Radio id="hidden-radio" labelText="can you see me?" isLabelHidden />);
+const hiddenLabelRadioExample = () => (
+  <div>
+    <p>
+      <b>Note:</b>
+      Radio button should always have label to ensures that people with visual or cognitive disabilities will recognize radio buttons and understand what information to provide to fill in the fields.
+      For example: When we have radio feilds for selection of account types, authors may feel that just providing programmatically determined names of the fields will be sufficient to identify them. However, even if all the fields have programmatically determined names, a text label must also identify the set of fields as a account type.
+    </p>
+    <Radio id="hidden-radio" labelText="can you see me?" isLabelHidden />
+  </div>
+);
 
 export default hiddenLabelRadioExample;

--- a/packages/terra-form-radio/CHANGELOG.md
+++ b/packages/terra-form-radio/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated prop description for `isLabelHidden` prop.
+
 ## 4.41.0 - (August 25, 2023)
 
 * Changed

--- a/packages/terra-form-radio/src/Radio.jsx
+++ b/packages/terra-form-radio/src/Radio.jsx
@@ -35,6 +35,9 @@ const propTypes = {
     */
   isInline: PropTypes.bool,
   /**
+    * ![IMPORTANT](https://badgen.net/badge/UX/Accessibility/blue)
+    * Radio button should always have visible label to meet WCAG 3.3.2 success criterion.
+    * When set to true, ensure meaningfull Text is provided for `labelText` prop.
     * Whether the label is hidden.
     */
   isLabelHidden: PropTypes.bool,

--- a/packages/terra-form-radio/src/Radio.jsx
+++ b/packages/terra-form-radio/src/Radio.jsx
@@ -37,7 +37,7 @@ const propTypes = {
   /**
     * ![IMPORTANT](https://badgen.net/badge/UX/Accessibility/blue)
     * Radio button should always have visible label to meet WCAG 3.3.2 success criterion.
-    * When set to true, ensure meaningfull Text is provided for `labelText` prop.
+    * When set to true, ensure meaningful Text is provided for `labelText` prop.
     * Whether the label is hidden.
     */
   isLabelHidden: PropTypes.bool,


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Updated description and usage guidance for `isLabelHidden`  prop. to ensure radio buttons are always rendered with Label.


**Why it was changed:**
The [TerraUI Dev site forhttps://engineering.cerner.com/terra-ui/components/cerner-terra-core-docs/form-radio/about] Terra-From Radio needs to be updated to include accessibility guidance instructing teams that is a requirement of accessibility to have visible labels and the use of the `isLabelHidden` prop is not recommended.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
NA

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [X] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9562 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
