### PR TITLE
[form-single-select] doc site updates of escape key instruction

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated
+  *  Updated doc site for `terra-form-single-select` and `terra-form-single-select-field`.
+  
 * Added
   * Added drag and drop example for `terra-list`.
   * Added instruction note for `terra-form-radio` label hidden example

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SingleSelect.03.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SingleSelect.03.doc.mdx
@@ -27,7 +27,7 @@ To create an accessible `SingleSelect` component:
 3. Ensure any visible `SelectLabel` matches any artificially applied programmatic label.
 4. Error messaging should provide error suggestions when the system can programmatically understand what is wrong.
 
-To close the combobox in edge browser while using JAWS, user have to press escape key twice. The first escape key press loses the VPC focus and the second escape key press closes the single select as it has control focus.
+To close the combobox in browser while using JAWS with VPC **ON** mode, user have to press escape key twice. The first escape key press loses the VPC focus and the second escape key press closes the single select as it has control focus.
 
 ## Getting Started
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SingleSelect.03.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SingleSelect.03.doc.mdx
@@ -27,6 +27,8 @@ To create an accessible `SingleSelect` component:
 3. Ensure any visible `SelectLabel` matches any artificially applied programmatic label.
 4. Error messaging should provide error suggestions when the system can programmatically understand what is wrong.
 
+To close the combobox in edge browser while using JAWS, user have to press escape key twice. The first escape key press loses the VPC focus and the second escape key press closes the single select as it has control focus.
+
 ## Getting Started
 
 - Install with [npmjs](https://www.npmjs.com):

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SingleSelect.03.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SingleSelect.03.doc.mdx
@@ -27,7 +27,7 @@ To create an accessible `SingleSelect` component:
 3. Ensure any visible `SelectLabel` matches any artificially applied programmatic label.
 4. Error messaging should provide error suggestions when the system can programmatically understand what is wrong.
 
-To close the combobox in browser while using JAWS with VPC **ON** mode, user have to press escape key twice. The first escape key press loses the VPC focus and the second escape key press closes the single select as it has control focus.
+To close the combobox while using JAWS with VPC **ON** mode, user have to press escape key twice. The first escape key press loses the VPC focus and the second escape key press closes the single select as it has control focus.
 
 ## Getting Started
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SingleSelectField.04.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SingleSelectField.04.doc.mdx
@@ -12,7 +12,7 @@ import SingleSelectFieldPropsTable from 'terra-form-select/lib/SingleSelectField
 
 A convenience wrapper assembling a [terra-form-select SingleSelect](https://github.com/cerner/terra-core/tree/main/packages/terra-form-select/src/SingleSelect.jsx) within a [terra-form-field](https://github.com/cerner/terra-core/tree/main/packages/terra-form-field).
 
-To close the combobox in browser while using JAWS with VPC **ON** mode, user have to press escape key twice. The first escape key press loses the VPC focus and the second escape key press closes the single select as it has control focus.
+To close the combobox while using JAWS with VPC **ON** mode, user have to press escape key twice. The first escape key press loses the VPC focus and the second escape key press closes the single select as it has control focus.
 
 ## Getting Started
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SingleSelectField.04.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SingleSelectField.04.doc.mdx
@@ -12,7 +12,7 @@ import SingleSelectFieldPropsTable from 'terra-form-select/lib/SingleSelectField
 
 A convenience wrapper assembling a [terra-form-select SingleSelect](https://github.com/cerner/terra-core/tree/main/packages/terra-form-select/src/SingleSelect.jsx) within a [terra-form-field](https://github.com/cerner/terra-core/tree/main/packages/terra-form-field).
 
-To close the combobox in edge browser while using JAWS, user have to press escape key twice. The first escape key press loses the VPC focus and the second escape key press closes the single select as it has control focus.
+To close the combobox in browser while using JAWS with VPC **ON** mode, user have to press escape key twice. The first escape key press loses the VPC focus and the second escape key press closes the single select as it has control focus.
 
 ## Getting Started
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SingleSelectField.04.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SingleSelectField.04.doc.mdx
@@ -12,6 +12,8 @@ import SingleSelectFieldPropsTable from 'terra-form-select/lib/SingleSelectField
 
 A convenience wrapper assembling a [terra-form-select SingleSelect](https://github.com/cerner/terra-core/tree/main/packages/terra-form-select/src/SingleSelect.jsx) within a [terra-form-field](https://github.com/cerner/terra-core/tree/main/packages/terra-form-field).
 
+To close the combobox in edge browser while using JAWS, user have to press escape key twice. The first escape key press loses the VPC focus and the second escape key press closes the single select as it has control focus.
+
 ## Getting Started
 
 - Install with [npmjs](https://www.npmjs.com):


### PR DESCRIPTION
### Summary
Updated doc site of form single select and single select field with escape key observation with JAWS. Which is we have to press escape key twice to close the combobox while using JAWS + VPC ON mode.

**What was changed:**
Updated the doc site of form single select and single select field.

**Why it was changed:**
To inform consumers of the issue with escape key.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9641

---

Thank you for contributing to Terra.
@cerner/terra
