### PR TITLE
[terra-icon] Add missing icons to exports

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Unreleased
 
+* Changed
+  * Updated icon example. 
+
 ## 1.40.0 - (September 19, 2023)
 
-* Updated
-  *  Updated doc site for `terra-form-single-select` and `terra-form-single-select-field`.
-  
 * Added
   * Added drag and drop example for `terra-list`.
   * Added instruction note for `terra-form-radio` label hidden example
@@ -17,6 +17,8 @@
   * Updated all paginator examples to use meaningful titles.
   * Updated testing recommendations to use `jest.spyOn` instead of `jest.mock`.
   * Updated `terra-alert` long text example for accessible `terra-show-hide`.
+  * Updated doc site for `terra-form-single-select` and `terra-form-single-select-field`.
+
  
 ## 1.39.0 - (August 25, 2023)
 

--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Changed
-  * Updated icon example. 
+  * Updated icon example to specify `IconCeMarking` is private. 
 
 ## 1.40.0 - (September 19, 2023)
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/icon/example/IconThemeable.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/icon/example/IconThemeable.jsx
@@ -30,7 +30,6 @@ IconCaretRight,
 IconCaretUp, 
 IconCatalogueNumber, 
 IconCaution, 
-IconCeMarking, 
 IconChecklist, 
 IconCheckmark, 
 IconChevron, 
@@ -245,6 +244,9 @@ IconXSymbolLight,
 IconZoomIn, 
 IconZoomOut, 
 } from 'terra-icon';
+
+// IconCeMarking is a private icon for internal use
+import IconCeMarking from 'terra-icon/lib/icon/IconCeMarking';
 
 const cellStyle = { padding: '0.5rem' };
 const IconAll = () => (
@@ -2421,9 +2423,6 @@ const IconAll = () => (
         <td style={cellStyle}><IconCeMarking height='2em' width='2em' /></td>
         <td style={cellStyle}>ceMarking</td>
         <td style={{ fontWeight: 'bold', padding: '0.5rem' }}>
-          <code>
-            import { IconCeMarking } from 'terra-icon';
-          </code>
         </td>
       </tr>
       <tr style={{ backgroundColor: '#EEEEEE' }}>

--- a/packages/terra-icon/CHANGELOG.md
+++ b/packages/terra-icon/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed missing exports for `IconPause` and `IconXSymbolLight`.
+
 ## 3.57.0 - (September 19, 2023)
 
 * Added

--- a/packages/terra-icon/CHANGELOG.md
+++ b/packages/terra-icon/CHANGELOG.md
@@ -292,8 +292,7 @@
 ## 3.14.0 - (July 16, 2019)
 
 * Added
-
-  * Added new icon `IconCeMarking`
+  * Added new private icon `IconCeMarking`
   * Added new icon `IconEcRep`
   * Added new icon `IconEnvelopeFill`
   * Added new icon `IconFeaturedOutlineYellow`

--- a/packages/terra-icon/src/index.js
+++ b/packages/terra-icon/src/index.js
@@ -74,9 +74,9 @@ import IconDischargeComplete from './icon/IconDischargeComplete';
 import IconDischargeCompleteLowLight from './icon/IconDischargeCompleteLowLight';
 import IconDischargeOverDue from './icon/IconDischargeOverDue';
 import IconDischargeOverDueLowLight from './icon/IconDischargeOverDueLowLight';
+import IconDoNotDisturb from './icon/IconDoNotDisturb';
 import IconDocumentPlus from './icon/IconDocumentPlus';
 import IconDocuments from './icon/IconDocuments';
-import IconDoNotDisturb from './icon/IconDoNotDisturb';
 import IconDoorOpen from './icon/IconDoorOpen';
 import IconDoubleChevronLeft from './icon/IconDoubleChevronLeft';
 import IconDoubleChevronRight from './icon/IconDoubleChevronRight';
@@ -136,6 +136,7 @@ import IconHighPriority from './icon/IconHighPriority';
 import IconHold from './icon/IconHold';
 import IconHospital from './icon/IconHospital';
 import IconHouse from './icon/IconHouse';
+import IconIPass from './icon/IconIPass';
 import IconImage from './icon/IconImage';
 import IconImplant from './icon/IconImplant';
 import IconIncomingCall from './icon/IconIncomingCall';
@@ -148,7 +149,6 @@ import IconInformationInverseLowLight from './icon/IconInformationInverseLowLigh
 import IconInformationLowLight from './icon/IconInformationLowLight';
 import IconInformationStatic from './icon/IconInformationStatic';
 import IconInformationThemeable from './icon/IconInformationThemeable';
-import IconIPass from './icon/IconIPass';
 import IconItalicI from './icon/IconItalicI';
 import IconKeyboard from './icon/IconKeyboard';
 import IconKnurling from './icon/IconKnurling';
@@ -174,9 +174,9 @@ import IconMediaRecord from './icon/IconMediaRecord';
 import IconMediaRewind from './icon/IconMediaRewind';
 import IconMediaStop from './icon/IconMediaStop';
 import IconMedicationTablet from './icon/IconMedicationTablet';
-import IconMedicationTabletOutline from './icon/IconMedicationTabletOutline';
 import IconMedicationTabletHalf from './icon/IconMedicationTabletHalf';
 import IconMedicationTabletHalfOutline from './icon/IconMedicationTabletHalfOutline';
+import IconMedicationTabletOutline from './icon/IconMedicationTabletOutline';
 import IconMenu from './icon/IconMenu';
 import IconMerge from './icon/IconMerge';
 import IconMicrophone from './icon/IconMicrophone';
@@ -188,21 +188,21 @@ import IconMissedCall from './icon/IconMissedCall';
 import IconModerate from './icon/IconModerate';
 import IconModerateLowLight from './icon/IconModerateLowLight';
 import IconModified from './icon/IconModified';
+import IconMultipleResultsCritical from './icon/IconMultipleResultsCritical';
 import IconMultipleResultsNormal from './icon/IconMultipleResultsNormal';
 import IconMultipleResultsNotNormal from './icon/IconMultipleResultsNotNormal';
-import IconMultipleResultsCritical from './icon/IconMultipleResultsCritical';
 import IconNavStackUp from './icon/IconNavStackUp';
 import IconNext from './icon/IconNext';
 import IconNoResults from './icon/IconNoResults';
 import IconNoRisk from './icon/IconNoRisk';
 import IconNoRiskLowLight from './icon/IconNoRiskLowLight';
 import IconNoSignal from './icon/IconNoSignal';
+import IconNotMet from './icon/IconNotMet';
 import IconNotification from './icon/IconNotification';
 import IconNotificationDisabled from './icon/IconNotificationDisabled';
 import IconNotificationOff from './icon/IconNotificationOff';
-import IconNotMet from './icon/IconNotMet';
-import IconOutgoingCall from './icon/IconOutgoingCall';
 import IconOutOfNetwork from './icon/IconOutOfNetwork';
+import IconOutgoingCall from './icon/IconOutgoingCall';
 import IconOverDue from './icon/IconOverDue';
 import IconOverDueLowLight from './icon/IconOverDueLowLight';
 import IconPadlock from './icon/IconPadlock';
@@ -213,6 +213,7 @@ import IconPaperFolded from './icon/IconPaperFolded';
 import IconPaperPencil from './icon/IconPaperPencil';
 import IconPartiallyMet from './icon/IconPartiallyMet';
 import IconPatientSearch from './icon/IconPatientSearch';
+import IconPause from './icon/IconPause';
 import IconPending from './icon/IconPending';
 import IconPerson from './icon/IconPerson';
 import IconPersonConnection from './icon/IconPersonConnection';
@@ -267,11 +268,11 @@ import IconSortDescending from './icon/IconSortDescending';
 import IconSpinner from './icon/IconSpinner';
 import IconSquareSymbol from './icon/IconSquareSymbol';
 import IconSquareSymbolLight from './icon/IconSquareSymbolLight';
-import IconStatusPositive from './icon/IconStatusPositive';
-import IconStatusPositiveWhite from './icon/IconStatusPositiveWhite';
-import IconStatusPositiveLowLight from './icon/IconStatusPositiveLowLight';
-import IconStatusPositiveWhiteLowLight from './icon/IconStatusPositiveWhiteLowLight';
 import IconStartPresenting from './icon/IconStartPresenting';
+import IconStatusPositive from './icon/IconStatusPositive';
+import IconStatusPositiveLowLight from './icon/IconStatusPositiveLowLight';
+import IconStatusPositiveWhite from './icon/IconStatusPositiveWhite';
+import IconStatusPositiveWhiteLowLight from './icon/IconStatusPositiveWhiteLowLight';
 import IconStopPresenting from './icon/IconStopPresenting';
 import IconSuccess from './icon/IconSuccess';
 import IconSuccessInverse from './icon/IconSuccessInverse';
@@ -310,16 +311,17 @@ import IconUsers from './icon/IconUsers';
 import IconVideoCamera from './icon/IconVideoCamera';
 import IconVideoCameraDisabled from './icon/IconVideoCameraDisabled';
 import IconVisualization from './icon/IconVisualization';
-import IconVolumeSetDefault from './icon/IconVolumeSetDefault';
-import IconVolumeSetMute from './icon/IconVolumeSetMute';
-import IconVolumeSetIncrease from './icon/IconVolumeSetIncrease';
 import IconVolumeSetDecrease from './icon/IconVolumeSetDecrease';
+import IconVolumeSetDefault from './icon/IconVolumeSetDefault';
+import IconVolumeSetIncrease from './icon/IconVolumeSetIncrease';
+import IconVolumeSetMute from './icon/IconVolumeSetMute';
 import IconWarning from './icon/IconWarning';
 import IconWarningLowLight from './icon/IconWarningLowLight';
 import IconWaveform from './icon/IconWaveform';
 import IconWifi from './icon/IconWifi';
 import IconWifiSlash from './icon/IconWifiSlash';
 import IconXSymbol from './icon/IconXSymbol';
+import IconXSymbolLight from './icon/IconXSymbolLight';
 import IconZoomIn from './icon/IconZoomIn';
 import IconZoomOut from './icon/IconZoomOut';
 
@@ -539,6 +541,7 @@ export {
   IconPaperPencil,
   IconPartiallyMet,
   IconPatientSearch,
+  IconPause,
   IconPending,
   IconPerson,
   IconPersonConnection,
@@ -646,6 +649,7 @@ export {
   IconWifi,
   IconWifiSlash,
   IconXSymbol,
+  IconXSymbolLight,
   IconZoomIn,
   IconZoomOut,
-};
+}

--- a/packages/terra-icon/src/index.js
+++ b/packages/terra-icon/src/index.js
@@ -652,4 +652,4 @@ export {
   IconXSymbolLight,
   IconZoomIn,
   IconZoomOut,
-}
+};


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->
This PR adds 2 missing icons to exports: `IconPause` and `IconXSymbolLight`.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->
---

Thank you for contributing to Terra.
@cerner/terra
