### PR TITLE
[terra-progress-bar] Fixes SR response for repeated announcement of progress

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated
+  * Updated test and doc examples for `terra-progress-bar` 
+
 ## 1.43.0 - (October 3, 2023)
 
 * Added

--- a/packages/terra-core-docs/src/terra-dev-site/doc/progress-bar/example/ProgressBarColor.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/progress-bar/example/ProgressBarColor.jsx
@@ -7,13 +7,13 @@ const cx = classNames.bind(styles);
 
 const ProgressBarColor = () => (
   <div>
-    <ProgressBar valueText="5%" value={5} max={10} colorClass={cx(['color-bar-example-1'])} />
+    <ProgressBar value={5} max={10} colorClass={cx(['color-bar-example-1'])} />
     <br />
     <br />
-    <ProgressBar valueText="7.5%" value={7.5} max={10} colorClass={cx(['color-bar-example-2'])} />
+    <ProgressBar value={7.5} max={10} colorClass={cx(['color-bar-example-2'])} />
     <br />
     <br />
-    <ProgressBar valueText="10%" value={10} max={10} colorClass={cx(['color-bar-example-3'])} />
+    <ProgressBar value={10} max={10} colorClass={cx(['color-bar-example-3'])} />
   </div>
 );
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/progress-bar/example/ProgressBarDefault.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/progress-bar/example/ProgressBarDefault.jsx
@@ -26,7 +26,7 @@ const ProgressBarDefault = () => {
   return (
     <div>
       <label aria-live="polite">{`Progress bar: ${val}%`}</label>
-      <ProgressBar id="progressbar" value={val} valueText="Loading" />
+      <ProgressBar id="progressbar" value={val} />
       <br />
       <Button text="Start" onClick={start} />
             &nbsp;

--- a/packages/terra-core-docs/src/terra-dev-site/doc/progress-bar/example/ProgressBarDefault.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/progress-bar/example/ProgressBarDefault.jsx
@@ -25,8 +25,8 @@ const ProgressBarDefault = () => {
 
   return (
     <div>
-      <label>{`Progress bar: ${val}%`}</label>
-      <ProgressBar id="progressbar" value={val} valueText={`Loading ${val}%`} />
+      <label aria-live="polite">{`Progress bar: ${val}%`}</label>
+      <ProgressBar id="progressbar" value={val} valueText="Loading" />
       <br />
       <Button text="Start" onClick={start} />
             &nbsp;

--- a/packages/terra-core-docs/src/terra-dev-site/doc/progress-bar/example/ProgressBarSize.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/progress-bar/example/ProgressBarSize.jsx
@@ -3,19 +3,19 @@ import ProgressBar from 'terra-progress-bar';
 
 const ProgressBarSize = () => (
   <div>
-    <ProgressBar heightSize="tiny" valueText="15%" value={15} />
+    <ProgressBar heightSize="tiny" value={15} />
     <br />
     <br />
-    <ProgressBar heightSize="small" valueText="30%" value={30} />
+    <ProgressBar heightSize="small" value={30} />
     <br />
     <br />
-    <ProgressBar heightSize="medium" valueText="45%" value={45} />
+    <ProgressBar heightSize="medium" value={45} />
     <br />
     <br />
-    <ProgressBar heightSize="large" valueText="60%" value={60} />
+    <ProgressBar heightSize="large" value={60} />
     <br />
     <br />
-    <ProgressBar heightSize="huge" valueText="75%" value={75} />
+    <ProgressBar heightSize="huge" value={75} />
   </div>
 );
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/progress-bar/example/ProgressBarTwoColors.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/progress-bar/example/ProgressBarTwoColors.jsx
@@ -7,13 +7,13 @@ const cx = classNames.bind(styles);
 
 const ProgressBarGradient = () => (
   <div>
-    <ProgressBar valueText="5%" value={5} max={10} colorClass={cx(['two-colors-bar-example-1'])} />
+    <ProgressBar value={5} max={10} colorClass={cx(['two-colors-bar-example-1'])} />
     <br />
     <br />
-    <ProgressBar valueText="3%" value={3} max={10} colorClass={cx(['two-colors-bar-example-2'])} />
+    <ProgressBar value={3} max={10} colorClass={cx(['two-colors-bar-example-2'])} />
     <br />
     <br />
-    <ProgressBar valueText="8%" value={8} max={10} colorClass={cx(['two-colors-bar-example-3'])} />
+    <ProgressBar value={8} max={10} colorClass={cx(['two-colors-bar-example-3'])} />
   </div>
 );
 

--- a/packages/terra-core-docs/src/terra-dev-site/test/progress-bar/ProgressBarColor.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/progress-bar/ProgressBarColor.test.jsx
@@ -7,13 +7,13 @@ const cx = classNames.bind(styles);
 
 const ProgressBarColor = () => (
   <div>
-    <ProgressBar id="progressbarWithNamedColor" valueText="5%" value={5} max={10} colorClass={cx(['color-bar-example-1'])} />
+    <ProgressBar id="progressbarWithNamedColor" value={5} max={10} colorClass={cx(['color-bar-example-1'])} />
     <br />
     <br />
-    <ProgressBar id="progressbarWithHexColor" valueText="7.5%" value={7.5} max={10} colorClass={cx(['color-bar-example-2'])} />
+    <ProgressBar id="progressbarWithHexColor" value={7.5} max={10} colorClass={cx(['color-bar-example-2'])} />
     <br />
     <br />
-    <ProgressBar id="progressbarWithRGBColor" valueText="10%" value={10} max={10} colorClass={cx(['color-bar-example-3'])} />
+    <ProgressBar id="progressbarWithRGBColor" value={10} max={10} colorClass={cx(['color-bar-example-3'])} />
   </div>
 );
 

--- a/packages/terra-core-docs/src/terra-dev-site/test/progress-bar/ProgressBarCustomizedColors.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/progress-bar/ProgressBarCustomizedColors.test.jsx
@@ -7,6 +7,6 @@ const cx = classNames.bind(styles);
 
 export default () => (
   <div>
-    <ProgressBar valueText="8%" value={8} max={10} colorClass={cx(['customized-color-bar-example-2'])} />
+    <ProgressBar value={8} max={10} colorClass={cx(['customized-color-bar-example-2'])} />
   </div>
 );

--- a/packages/terra-core-docs/src/terra-dev-site/test/progress-bar/ProgressBarDefault.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/progress-bar/ProgressBarDefault.test.jsx
@@ -26,7 +26,7 @@ const ProgressBarDefault = () => {
   return (
     <div>
       <label aria-live="polite">{`Progress bar: ${val}%`}</label>
-      <ProgressBar id="progressbar" value={val} valueText="Loading" />
+      <ProgressBar id="progressbar" value={val} />
       <br />
       <Button text="Start" onClick={start} />
       &nbsp;

--- a/packages/terra-core-docs/src/terra-dev-site/test/progress-bar/ProgressBarDefault.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/progress-bar/ProgressBarDefault.test.jsx
@@ -25,8 +25,8 @@ const ProgressBarDefault = () => {
 
   return (
     <div>
-      <label>{`Progress bar: ${val}%`}</label>
-      <ProgressBar id="progressbar" value={val} valueText={`Loading ${val}%`} />
+      <label aria-live="polite">{`Progress bar: ${val}%`}</label>
+      <ProgressBar id="progressbar" value={val} valueText="Loading" />
       <br />
       <Button text="Start" onClick={start} />
       &nbsp;

--- a/packages/terra-core-docs/src/terra-dev-site/test/progress-bar/ProgressBarSize.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/progress-bar/ProgressBarSize.test.jsx
@@ -3,19 +3,19 @@ import ProgressBar from 'terra-progress-bar';
 
 const ProgressBarSize = () => (
   <div>
-    <ProgressBar id="progressbarTiny" heightSize="tiny" valueText="15%" value={15} />
+    <ProgressBar id="progressbarTiny" heightSize="tiny" value={15} />
     <br />
     <br />
-    <ProgressBar id="progressbarSmall" heightSize="small" valueText="30%" value={30} />
+    <ProgressBar id="progressbarSmall" heightSize="small" value={30} />
     <br />
     <br />
-    <ProgressBar id="progressbarMedium" heightSize="medium" valueText="45%" value={45} />
+    <ProgressBar id="progressbarMedium" heightSize="medium" value={45} />
     <br />
     <br />
-    <ProgressBar id="progressbarLarge" heightSize="large" valueText="60%" value={60} />
+    <ProgressBar id="progressbarLarge" heightSize="large" value={60} />
     <br />
     <br />
-    <ProgressBar id="progressbarHuge" heightSize="huge" valueText="75%" value={75} />
+    <ProgressBar id="progressbarHuge" heightSize="huge" value={75} />
   </div>
 );
 

--- a/packages/terra-progress-bar/CHANGELOG.md
+++ b/packages/terra-progress-bar/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
-  * Removed visually hidden component to fix repeated announcement of progress.
+  * Removed visually hidden component to fix repeated announcement of progress
 
 ## 4.34.0 - (April 5, 2023)
 

--- a/packages/terra-progress-bar/CHANGELOG.md
+++ b/packages/terra-progress-bar/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
-  * Removed visually hidden component to fix repeated announcement of progress
+  * Removed visually hidden component to fix repeated announcement of progress.
 
 ## 4.34.0 - (April 5, 2023)
 

--- a/packages/terra-progress-bar/CHANGELOG.md
+++ b/packages/terra-progress-bar/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Removed visually hidden component to fix repeated announcement of progress.
+
 ## 4.34.0 - (April 5, 2023)
 
 * Changed

--- a/packages/terra-progress-bar/src/ProgressBar.jsx
+++ b/packages/terra-progress-bar/src/ProgressBar.jsx
@@ -2,9 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import classNamesBind from 'classnames/bind';
-import { injectIntl } from 'react-intl';
 import ThemeContext from 'terra-theme-context';
-import VisuallyHiddenText from 'terra-visually-hidden-text';
 import styles from './ProgressBar.module.scss';
 
 const cx = classNamesBind.bind(styles);
@@ -78,11 +76,9 @@ const ProgressBar = ({
   );
 
   const normalizedValue = (value / max) * 100;
-  const valText = valueText || intl.formatMessage({ id: 'Terra.progress.bar.percentage' }, { value: normalizedValue });
 
   return (
     <div>
-      <VisuallyHiddenText aria-live="polite" text={valText} />
       <progress
         {...customProps}
         className={classes}
@@ -91,7 +87,7 @@ const ProgressBar = ({
         aria-valuemax={100}
         aria-valuemin={0}
         aria-valuenow={normalizedValue}
-        aria-valuetext={valText}
+        aria-valuetext={valueText}
         tabIndex="-1"
       />
     </div>
@@ -102,5 +98,5 @@ ProgressBar.propTypes = propTypes;
 
 ProgressBar.defaultProps = defaultProps;
 
-export default injectIntl(ProgressBar);
+export default ProgressBar;
 export { ProgressBarHeightSize };

--- a/packages/terra-progress-bar/src/ProgressBar.jsx
+++ b/packages/terra-progress-bar/src/ProgressBar.jsx
@@ -29,7 +29,8 @@ const propTypes = {
    */
   max: PropTypes.number,
   /**
-   * Value passed to aria-valuetext for accessibility. You can view more about this attribute
+   * ![IMPORTANT](https://badgen.net/badge/prop/deprecated/red)
+   * valueText has been deprecated and will be removed on next major version release.
    * at https://www.w3.org/WAI/PF/aria/states_and_properties#aria-valuetext.
    */
   valueText: PropTypes.string,
@@ -77,6 +78,8 @@ const ProgressBar = ({
 
   const normalizedValue = (value / max) * 100;
 
+  const isMac = () => navigator.userAgent.indexOf('Mac') !== -1 && navigator.userAgent.indexOf('Win') === -1;
+
   return (
     <div>
       <progress
@@ -87,7 +90,7 @@ const ProgressBar = ({
         aria-valuemax={100}
         aria-valuemin={0}
         aria-valuenow={normalizedValue}
-        aria-valuetext={valueText}
+        aria-valuetext={!isMac ? `${normalizedValue}%` : undefined}
         tabIndex="-1"
       />
     </div>

--- a/packages/terra-progress-bar/src/ProgressBar.jsx
+++ b/packages/terra-progress-bar/src/ProgressBar.jsx
@@ -90,7 +90,7 @@ const ProgressBar = ({
         aria-valuemax={100}
         aria-valuemin={0}
         aria-valuenow={normalizedValue}
-        aria-valuetext={!isMac ? `${normalizedValue}%` : undefined}
+        aria-valuetext={!isMac() ? `${normalizedValue}%` : undefined}
         tabIndex="-1"
       />
     </div>

--- a/packages/terra-progress-bar/tests/jest/ProgressBar.test.jsx
+++ b/packages/terra-progress-bar/tests/jest/ProgressBar.test.jsx
@@ -1,42 +1,41 @@
 import React from 'react';
 import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 /* eslint-disable-next-line import/no-extraneous-dependencies */
-import { shallowWithIntl, mountWithIntl } from 'terra-enzyme-intl';
 import ProgressBar from '../../src/ProgressBar';
 
 // Snapshot Tests
 it('should render a default component', () => {
-  const wrapper = shallowWithIntl(<ProgressBar value={15} />).dive();
+  const wrapper = shallow(<ProgressBar value={15} />);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a ProgressBar component with tiny heightSize and 15% fill', () => {
-  const wrapper = shallowWithIntl(<ProgressBar heightSize="tiny" valueText="15%" value={15} />).dive();
+  const wrapper = shallow(<ProgressBar heightSize="tiny" valueText="15%" value={15} />);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a ProgressBar component with large heightSize and 60% fill', () => {
-  const wrapper = shallowWithIntl(<ProgressBar heightSize="large" valueText="15%" value={60} />).dive();
+  const wrapper = shallow(<ProgressBar heightSize="large" valueText="15%" value={60} />);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a ProgressBar component with default heightSize and 50% fill and colorClass prop', () => {
-  const wrapper = shallowWithIntl(<ProgressBar value={60} valueText="60%" max={120} colorClass="yellow-bar" />).dive();
+  const wrapper = shallow(<ProgressBar value={60} valueText="60%" max={120} colorClass="yellow-bar" />);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a ProgressBar component with default heightSize 50% fill and custom props and style', () => {
-  const wrapper = shallowWithIntl(<ProgressBar value={6} valueText="6%" max={12} dir="rtl" />).dive();
+  const wrapper = shallow(<ProgressBar value={6} valueText="6%" max={12} dir="rtl" />);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a ProgressBar component with default heightSize 50% fill and valueText', () => {
-  const wrapper = shallowWithIntl(<ProgressBar value={5} valueText="Progress is 6%" max={10} />).dive();
+  const wrapper = shallow(<ProgressBar value={5} valueText="Progress is 6%" max={10} />);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('correctly applies the theme context className', () => {
-  const wrapper = mountWithIntl(
+  const wrapper = mount(
     <ThemeContextProvider theme={{ className: 'orion-fusion-theme' }}>
       <ProgressBar value={15} />
     </ThemeContextProvider>,
@@ -47,7 +46,7 @@ it('correctly applies the theme context className', () => {
 // Prop Tests
 describe('Default progress bar', () => {
   it('should have classes progressbar, small and zero fill value', () => {
-    const wrapper = shallowWithIntl(<ProgressBar value={0} valueText="0%" id="progressbar" />).dive();
+    const wrapper = shallow(<ProgressBar value={0} valueText="0%" id="progressbar" />);
     expect(wrapper.find('#progressbar').prop('className')).toContain('progress-bar small default-color');
     expect(wrapper.find('#progressbar').prop('value')).toEqual(0);
   });
@@ -55,17 +54,17 @@ describe('Default progress bar', () => {
 
 describe('Progress bar with default heightSize prop', () => {
   it('should have progressbar, small classes and 50% fill value', () => {
-    const wrapper = shallowWithIntl(<ProgressBar value={5} valueText="5%" max={10} id="progressbar" />).dive();
+    const wrapper = shallow(<ProgressBar value={5} valueText="5%" max={10} id="progressbar" />);
     expect(wrapper.find('#progressbar').prop('value')).toEqual(50);
     expect(wrapper.find('#progressbar').prop('max')).toEqual(100);
   });
   it('should have progressbar, small classes and 75% fill value', () => {
-    const wrapper = shallowWithIntl(<ProgressBar value={7.5} valueText="7.5%" max={10} id="progressbar" />).dive();
+    const wrapper = shallow(<ProgressBar value={7.5} valueText="7.5%" max={10} id="progressbar" />);
     expect(wrapper.find('#progressbar').prop('value')).toEqual(75);
     expect(wrapper.find('#progressbar').prop('max')).toEqual(100);
   });
   it('should have progressbar, small classes and 100% fill value', () => {
-    const wrapper = shallowWithIntl(<ProgressBar value={10} valueText="10%" max={10} id="progressbar" />).dive();
+    const wrapper = shallow(<ProgressBar value={10} valueText="10%" max={10} id="progressbar" />);
     expect(wrapper.find('#progressbar').prop('value')).toEqual(100);
     expect(wrapper.find('#progressbar').prop('max')).toEqual(100);
   });
@@ -73,7 +72,7 @@ describe('Progress bar with default heightSize prop', () => {
 
 describe('Progress bar with colorClass prop', () => {
   it('value=3, max=10; should have class yellow-bar, small and 30% fill value', () => {
-    const wrapper = shallowWithIntl(<ProgressBar title="ProgressBarTest" value={3} valueText="30%" max={10} colorClass="yellow-bar" id="progressbar" />).dive();
+    const wrapper = shallow(<ProgressBar title="ProgressBarTest" value={3} valueText="30%" max={10} colorClass="yellow-bar" id="progressbar" />);
     expect(wrapper.find('#progressbar').prop('value')).toEqual(30);
     expect(wrapper.find('#progressbar').prop('max')).toEqual(100);
     expect(wrapper.find('#progressbar').prop('className')).toContain('yellow-bar');
@@ -82,7 +81,7 @@ describe('Progress bar with colorClass prop', () => {
 
 describe('Progress bar with title as custom prop', () => {
   it('value=3, max=10; should have classes progressbar, small and 30% fill value', () => {
-    const wrapper = shallowWithIntl(<ProgressBar title="ProgressBarTest" value={3} valueText="30%" max={10} id="progressbar" />).dive();
+    const wrapper = shallow(<ProgressBar title="ProgressBarTest" value={3} valueText="30%" max={10} id="progressbar" />);
     expect(wrapper.find('#progressbar').prop('value')).toEqual(30);
     expect(wrapper.find('#progressbar').prop('max')).toEqual(100);
     expect(wrapper.find('#progressbar').prop('title')).toEqual('ProgressBarTest');

--- a/packages/terra-progress-bar/tests/jest/__snapshots__/ProgressBar.test.jsx.snap
+++ b/packages/terra-progress-bar/tests/jest/__snapshots__/ProgressBar.test.jsx.snap
@@ -19,6 +19,7 @@ exports[`correctly applies the theme context className 1`] = `
         aria-valuemax={100}
         aria-valuemin={0}
         aria-valuenow={15}
+        aria-valuetext="15%"
         className="progress-bar small default-color orion-fusion-theme"
         max={100}
         tabIndex="-1"
@@ -35,6 +36,7 @@ exports[`should render a ProgressBar component with default heightSize 50% fill 
     aria-valuemax={100}
     aria-valuemin={0}
     aria-valuenow={50}
+    aria-valuetext="50%"
     className="progress-bar small default-color"
     dir="rtl"
     max={100}
@@ -50,6 +52,7 @@ exports[`should render a ProgressBar component with default heightSize 50% fill 
     aria-valuemax={100}
     aria-valuemin={0}
     aria-valuenow={50}
+    aria-valuetext="50%"
     className="progress-bar small default-color"
     max={100}
     tabIndex="-1"
@@ -64,6 +67,7 @@ exports[`should render a ProgressBar component with default heightSize and 50% f
     aria-valuemax={100}
     aria-valuemin={0}
     aria-valuenow={50}
+    aria-valuetext="50%"
     className="progress-bar small yellow-bar"
     max={100}
     tabIndex="-1"
@@ -78,6 +82,7 @@ exports[`should render a ProgressBar component with large heightSize and 60% fil
     aria-valuemax={100}
     aria-valuemin={0}
     aria-valuenow={60}
+    aria-valuetext="60%"
     className="progress-bar large default-color"
     max={100}
     tabIndex="-1"
@@ -92,6 +97,7 @@ exports[`should render a ProgressBar component with tiny heightSize and 15% fill
     aria-valuemax={100}
     aria-valuemin={0}
     aria-valuenow={15}
+    aria-valuetext="15%"
     className="progress-bar tiny default-color"
     max={100}
     tabIndex="-1"
@@ -106,6 +112,7 @@ exports[`should render a default component 1`] = `
     aria-valuemax={100}
     aria-valuemin={0}
     aria-valuenow={15}
+    aria-valuetext="15%"
     className="progress-bar small default-color"
     max={100}
     tabIndex="-1"

--- a/packages/terra-progress-bar/tests/jest/__snapshots__/ProgressBar.test.jsx.snap
+++ b/packages/terra-progress-bar/tests/jest/__snapshots__/ProgressBar.test.jsx.snap
@@ -35,7 +35,6 @@ exports[`should render a ProgressBar component with default heightSize 50% fill 
     aria-valuemax={100}
     aria-valuemin={0}
     aria-valuenow={50}
-    aria-valuetext="6%"
     className="progress-bar small default-color"
     dir="rtl"
     max={100}
@@ -51,7 +50,6 @@ exports[`should render a ProgressBar component with default heightSize 50% fill 
     aria-valuemax={100}
     aria-valuemin={0}
     aria-valuenow={50}
-    aria-valuetext="Progress is 6%"
     className="progress-bar small default-color"
     max={100}
     tabIndex="-1"
@@ -66,7 +64,6 @@ exports[`should render a ProgressBar component with default heightSize and 50% f
     aria-valuemax={100}
     aria-valuemin={0}
     aria-valuenow={50}
-    aria-valuetext="60%"
     className="progress-bar small yellow-bar"
     max={100}
     tabIndex="-1"
@@ -81,7 +78,6 @@ exports[`should render a ProgressBar component with large heightSize and 60% fil
     aria-valuemax={100}
     aria-valuemin={0}
     aria-valuenow={60}
-    aria-valuetext="15%"
     className="progress-bar large default-color"
     max={100}
     tabIndex="-1"
@@ -96,7 +92,6 @@ exports[`should render a ProgressBar component with tiny heightSize and 15% fill
     aria-valuemax={100}
     aria-valuemin={0}
     aria-valuenow={15}
-    aria-valuetext="15%"
     className="progress-bar tiny default-color"
     max={100}
     tabIndex="-1"

--- a/packages/terra-progress-bar/tests/jest/__snapshots__/ProgressBar.test.jsx.snap
+++ b/packages/terra-progress-bar/tests/jest/__snapshots__/ProgressBar.test.jsx.snap
@@ -2,109 +2,35 @@
 
 exports[`correctly applies the theme context className 1`] = `
 <ThemeContextProvider
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": null,
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": null,
-    }
-  }
   theme={
     Object {
       "className": "orion-fusion-theme",
     }
   }
 >
-  <InjectIntl(ProgressBar)
+  <ProgressBar
+    colorClass="default-color"
+    heightSize="small"
+    max={100}
     value={15}
   >
-    <ProgressBar
-      colorClass="default-color"
-      heightSize="small"
-      intl={
-        Object {
-          "defaultFormats": Object {},
-          "defaultLocale": "en",
-          "formatDate": [Function],
-          "formatHTMLMessage": [Function],
-          "formatMessage": [Function],
-          "formatNumber": [Function],
-          "formatPlural": [Function],
-          "formatRelative": [Function],
-          "formatTime": [Function],
-          "formats": Object {},
-          "formatters": Object {
-            "getDateTimeFormat": [Function],
-            "getMessageFormat": [Function],
-            "getNumberFormat": [Function],
-            "getPluralFormat": [Function],
-            "getRelativeFormat": [Function],
-          },
-          "locale": "en",
-          "messages": null,
-          "now": [Function],
-          "onError": [Function],
-          "textComponent": "span",
-          "timeZone": null,
-        }
-      }
-      max={100}
-      value={15}
-    >
-      <div>
-        <VisuallyHiddenText
-          aria-live="polite"
-          text="Terra.progress.bar.percentage"
-        >
-          <span
-            aria-live="polite"
-            className="visually-hidden-text"
-          >
-            Terra.progress.bar.percentage
-          </span>
-        </VisuallyHiddenText>
-        <progress
-          aria-valuemax={100}
-          aria-valuemin={0}
-          aria-valuenow={15}
-          aria-valuetext="Terra.progress.bar.percentage"
-          className="progress-bar small default-color orion-fusion-theme"
-          max={100}
-          tabIndex="-1"
-          value={15}
-        />
-      </div>
-    </ProgressBar>
-  </InjectIntl(ProgressBar)>
+    <div>
+      <progress
+        aria-valuemax={100}
+        aria-valuemin={0}
+        aria-valuenow={15}
+        className="progress-bar small default-color orion-fusion-theme"
+        max={100}
+        tabIndex="-1"
+        value={15}
+      />
+    </div>
+  </ProgressBar>
 </ThemeContextProvider>
 `;
 
 exports[`should render a ProgressBar component with default heightSize 50% fill and custom props and style 1`] = `
 <div>
-  <VisuallyHiddenText
-    aria-live="polite"
-    text="6%"
-  />
   <progress
     aria-valuemax={100}
     aria-valuemin={0}
@@ -121,10 +47,6 @@ exports[`should render a ProgressBar component with default heightSize 50% fill 
 
 exports[`should render a ProgressBar component with default heightSize 50% fill and valueText 1`] = `
 <div>
-  <VisuallyHiddenText
-    aria-live="polite"
-    text="Progress is 6%"
-  />
   <progress
     aria-valuemax={100}
     aria-valuemin={0}
@@ -140,10 +62,6 @@ exports[`should render a ProgressBar component with default heightSize 50% fill 
 
 exports[`should render a ProgressBar component with default heightSize and 50% fill and colorClass prop 1`] = `
 <div>
-  <VisuallyHiddenText
-    aria-live="polite"
-    text="60%"
-  />
   <progress
     aria-valuemax={100}
     aria-valuemin={0}
@@ -159,10 +77,6 @@ exports[`should render a ProgressBar component with default heightSize and 50% f
 
 exports[`should render a ProgressBar component with large heightSize and 60% fill 1`] = `
 <div>
-  <VisuallyHiddenText
-    aria-live="polite"
-    text="15%"
-  />
   <progress
     aria-valuemax={100}
     aria-valuemin={0}
@@ -178,10 +92,6 @@ exports[`should render a ProgressBar component with large heightSize and 60% fil
 
 exports[`should render a ProgressBar component with tiny heightSize and 15% fill 1`] = `
 <div>
-  <VisuallyHiddenText
-    aria-live="polite"
-    text="15%"
-  />
   <progress
     aria-valuemax={100}
     aria-valuemin={0}
@@ -197,15 +107,10 @@ exports[`should render a ProgressBar component with tiny heightSize and 15% fill
 
 exports[`should render a default component 1`] = `
 <div>
-  <VisuallyHiddenText
-    aria-live="polite"
-    text="Terra.progress.bar.percentage"
-  />
   <progress
     aria-valuemax={100}
     aria-valuemin={0}
     aria-valuenow={15}
-    aria-valuetext="Terra.progress.bar.percentage"
     className="progress-bar small default-color"
     max={100}
     tabIndex="-1"

--- a/packages/terra-progress-bar/translations/de.json
+++ b/packages/terra-progress-bar/translations/de.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value} %"
-}

--- a/packages/terra-progress-bar/translations/en-AU.json
+++ b/packages/terra-progress-bar/translations/en-AU.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value}%"
-}

--- a/packages/terra-progress-bar/translations/en-CA.json
+++ b/packages/terra-progress-bar/translations/en-CA.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value}%"
-}

--- a/packages/terra-progress-bar/translations/en-GB.json
+++ b/packages/terra-progress-bar/translations/en-GB.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value}%"
-}

--- a/packages/terra-progress-bar/translations/en-US.json
+++ b/packages/terra-progress-bar/translations/en-US.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value}%"
-}

--- a/packages/terra-progress-bar/translations/en.json
+++ b/packages/terra-progress-bar/translations/en.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value}%"
-}

--- a/packages/terra-progress-bar/translations/es-ES.json
+++ b/packages/terra-progress-bar/translations/es-ES.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value}%"
-}

--- a/packages/terra-progress-bar/translations/es-US.json
+++ b/packages/terra-progress-bar/translations/es-US.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value}%"
-}

--- a/packages/terra-progress-bar/translations/es.json
+++ b/packages/terra-progress-bar/translations/es.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value}%"
-}

--- a/packages/terra-progress-bar/translations/fi-FI.json
+++ b/packages/terra-progress-bar/translations/fi-FI.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value}%"
-}

--- a/packages/terra-progress-bar/translations/fr-FR.json
+++ b/packages/terra-progress-bar/translations/fr-FR.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value} %"
-}

--- a/packages/terra-progress-bar/translations/fr.json
+++ b/packages/terra-progress-bar/translations/fr.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value} %"
-}

--- a/packages/terra-progress-bar/translations/nl-BE.json
+++ b/packages/terra-progress-bar/translations/nl-BE.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value}%"
-}

--- a/packages/terra-progress-bar/translations/nl.json
+++ b/packages/terra-progress-bar/translations/nl.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value}%"
-}

--- a/packages/terra-progress-bar/translations/pt-BR.json
+++ b/packages/terra-progress-bar/translations/pt-BR.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value}%"
-}

--- a/packages/terra-progress-bar/translations/pt.json
+++ b/packages/terra-progress-bar/translations/pt.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value}%"
-}

--- a/packages/terra-progress-bar/translations/sv-SE.json
+++ b/packages/terra-progress-bar/translations/sv-SE.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value} %"
-}

--- a/packages/terra-progress-bar/translations/sv.json
+++ b/packages/terra-progress-bar/translations/sv.json
@@ -1,3 +1,0 @@
-{
-  "Terra.progress.bar.percentage": "{value} %"
-}


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**

- Removed visually hidden text under progress-bar.
- Updated test/doc example by adding `aria-live` to label to convey status update of progress.

**Why it was changed:**

- Removed visually hidden text to avoid repeated announcement of progress. Progress was announced twice upon arrow navigation.
- Label used alongside progress-bar would update SR about change in progress value.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9727 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
