### PR TITLE
Revert "Build Failure lint error fix"

### DIFF
--- a/packages/terra-badge/CHANGELOG.md
+++ b/packages/terra-badge/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## Unreleased
 
-* Fixed
-  * Fixed lint errors
-
 ## 3.58.0 - (October 16, 2023)
 
 * Added

--- a/packages/terra-badge/src/_mixins.scss
+++ b/packages/terra-badge/src/_mixins.scss
@@ -1,6 +1,4 @@
-/* stylelint-disable scss/no-global-function-names */
 @mixin terra-badge-color($color-map) {
   background-color: map-get($color-map, background-color);
   color: map-get($color-map, color);
 }
-/* stylelint-enable scss/no-global-function-names */

--- a/packages/terra-button/CHANGELOG.md
+++ b/packages/terra-button/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## Unreleased
 
-* Fixed
-  * Fixed lint errors
-
 ## 3.69.0 - (October 23, 2023)
 
 * Changed

--- a/packages/terra-button/src/_mixins.scss
+++ b/packages/terra-button/src/_mixins.scss
@@ -1,6 +1,6 @@
 //  Map Button Variant's Color Schemes
 // ==========================
-/* stylelint-disable scss/no-global-function-names */
+
 @mixin terra-button-variant-color($color-map) {
   background-color: map-get($color-map, background-color);
   border-color: map-get($color-map, border-color);
@@ -45,4 +45,3 @@
     box-shadow: map-get($color-map, active-and-focus-box-shadow);
   }
 }
-/* stylelint-enable scss/no-global-function-names */

--- a/packages/terra-dropdown-button/CHANGELOG.md
+++ b/packages/terra-dropdown-button/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## Unreleased
 
-* Fixed
-  * Fixed lint errors
-
 ## 1.37.0 - (October 26, 2023)
 
 * Changed

--- a/packages/terra-dropdown-button/src/_mixins.scss
+++ b/packages/terra-dropdown-button/src/_mixins.scss
@@ -2,7 +2,7 @@
 
 //  Map Dropdown Button Variant's Color Schemes
 // ==========================
-/* stylelint-disable scss/no-global-function-names */
+
 @mixin terra-dropdown-button-variant-color($color-map) {
   &.dropdown-button,
   &.split-button-primary,
@@ -112,4 +112,3 @@
     background-image: map-get($color-map, disabled-caret-icon-background-image);
   }
 }
-/* stylelint-enable scss/no-global-function-names */

--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## Unreleased
 
-* Fixed
-  * Fixed lint errors
-
 ## 4.66.0 - (October 23, 2023)
 
 * Added

--- a/packages/terra-list/src/List.module.scss
+++ b/packages/terra-list/src/List.module.scss
@@ -1,5 +1,4 @@
 /* stylelint-disable selector-max-compound-selectors */
-/* stylelint-disable scss/no-global-function-names */
 
 // Themes
 @import './clinical-lowlight-theme/List.module';

--- a/packages/terra-mixins/CHANGELOG.md
+++ b/packages/terra-mixins/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## Unreleased
 
-* Fixed
-  * Fixed lint errors
-
 ## 1.40.0 - (April 6, 2021)
 
 * Changed

--- a/packages/terra-mixins/src/Mixins.scss
+++ b/packages/terra-mixins/src/Mixins.scss
@@ -3,7 +3,6 @@
 // Mixins
 // ====================================================
 /* stylelint-disable scss/at-mixin-pattern  */
-/* stylelint-disable scss/no-global-function-names */
 
 $default-theme: false !default;
 $bundled-themes: false !default;


### PR DESCRIPTION
Reverts cerner/terra-core#3957

Another PR to fix the build by updating to new package-lock which was used to overcome an issue with compilation because of acorn package issues last week: https://github.com/cerner/terra-core/pull/3960 
