### PR TITLE
[Terra-Tag] Fix for Build failures happening due to use of @supports CSS rule

### DIFF
--- a/packages/terra-tag/CHANGELOG.md
+++ b/packages/terra-tag/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Removed unused `@supports` css rule from terra-tag-list.
+
 ## 2.64.0 - (November 13, 2023)
 
 * Added

--- a/packages/terra-tag/src/RollupTag.module.scss
+++ b/packages/terra-tag/src/RollupTag.module.scss
@@ -3,29 +3,6 @@
 @import './orion-fusion-theme/RollupTag.module';
 
 :local {
-  .rollup-tag-label {
-    font-family: inherit; // Button reset
-    left: 0; // Button reset for IE
-    min-width: 0;
-    overflow: hidden;
-    position: relative; // Button reset for IE
-    text-overflow: ellipsis;
-    top: 0;  // Button reset for IE
-    white-space: nowrap;  
-  }
-
-  @supports (not (-webkit-hyphens:none)) {
-    .rollup-tag-label {
-      top: var(--terra-tags-rollup-tag-label-not-ms-top, -0.01em); // Text alignment for all but IE + Safari
-    }
-  }
-
-  @supports selector(:-moz-is-html) {
-    .rollup-tag-label { 
-      top: var(--terra-tags-rollup-tag-label-moz-top, -0.02em); // Text alignment for Firefox
-    }
-  }
-
   .rollup-tag:not(.is-active) {
     background-color: var(--terra-tags-rollup-tag-background-color, rgba(28, 31, 33, 0.04));
     border: var(--terra-tags-rollup-tag-border, 1px solid rgba(28, 31, 33, 0.1));

--- a/packages/terra-tag/src/clinical-lowlight-theme/RollupTag.module.scss
+++ b/packages/terra-tag/src/clinical-lowlight-theme/RollupTag.module.scss
@@ -1,8 +1,5 @@
 :local {
   .clinical-lowlight-theme {
-    --terra-tags-rollup-tag-label-not-ms-top: -0.01em;
-    --terra-tags-rollup-tag-label-moz-top: -0.02em;
-
     // Rollup Tag
     --terra-tags-rollup-tag-background-color: rgba(232, 239, 244, 0.04);
     --terra-tags-rollup-tag-border: 1px solid rgba(28, 31, 33, 0.1);

--- a/packages/terra-tag/src/orion-fusion-theme/RollupTag.module.scss
+++ b/packages/terra-tag/src/orion-fusion-theme/RollupTag.module.scss
@@ -1,8 +1,5 @@
 :local {
   .orion-fusion-theme {
-    --terra-tags-rollup-tag-label-not-ms-top: -0.01em;
-    --terra-tags-rollup-tag-label-moz-top: -0.02em;
-      
     // Rollup Tag
     --terra-tags-rollup-tag-background-color: rgba(28, 31, 33, 0.04);
     --terra-tags-rollup-tag-border: 1px solid rgba(28, 31, 33, 0.1);


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->
Removed unreferenced @supports css rule which was causing build issue on the application using old version of Webpack < 5 

**What was changed:**
Removed unreferenced CSS code from RollupTag.scss

**Why it was changed:**
CSS class was not used anywhere on terra-tag component.
@supports rule causes `SassError: Invalid CSS after "  @supports ": expected` 

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [X] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-XXXX <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
