### PR TITLE
[Terra-Tag] SR announces instructions twice with VPC ON Mode 

### DIFF
--- a/packages/terra-tag/CHANGELOG.md
+++ b/packages/terra-tag/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed Terra-Tag SR announces instructions twice with VPC ON Mode
+
 ## 2.64.1 - (November 16, 2023)
 
 * Fixed

--- a/packages/terra-tag/src/_RollupTag.jsx
+++ b/packages/terra-tag/src/_RollupTag.jsx
@@ -74,7 +74,7 @@ const RollUpTag = (props) => {
       onBlur={handleOnBlur}
       refCallback={(ref) => { rollUpTagRef.current = ref; }}
       isCompact
-      aria-live={(isCollapsed) ? 'polite' : 'off'}
+      aria-live={(navigator.userAgent.indexOf('Edg') === -1 && isCollapsed) ? 'polite' : 'off'}
       aria-label={rollUpHint}
       aria-describedby={rollUpHint}
       aria-atomic="true"

--- a/packages/terra-tag/src/_RollupTag.jsx
+++ b/packages/terra-tag/src/_RollupTag.jsx
@@ -75,7 +75,6 @@ const RollUpTag = (props) => {
       refCallback={(ref) => { rollUpTagRef.current = ref; }}
       isCompact
       aria-label={rollUpHint}
-      aria-describedby={rollUpHint}
       aria-atomic="true"
       data-terra-rollup-tag-show-focus-styles
       data-terra-rollup-tag

--- a/packages/terra-tag/src/_RollupTag.jsx
+++ b/packages/terra-tag/src/_RollupTag.jsx
@@ -74,7 +74,6 @@ const RollUpTag = (props) => {
       onBlur={handleOnBlur}
       refCallback={(ref) => { rollUpTagRef.current = ref; }}
       isCompact
-      aria-live={(navigator.userAgent.indexOf('Edg') === -1 && isCollapsed && !/^(?=.*\bSafari\b)(?!.*\bChrome\b).*/i.test(navigator.userAgent)) ? 'polite' : 'off'}
       aria-label={rollUpHint}
       aria-describedby={rollUpHint}
       aria-atomic="true"

--- a/packages/terra-tag/src/_RollupTag.jsx
+++ b/packages/terra-tag/src/_RollupTag.jsx
@@ -74,7 +74,7 @@ const RollUpTag = (props) => {
       onBlur={handleOnBlur}
       refCallback={(ref) => { rollUpTagRef.current = ref; }}
       isCompact
-      aria-live={(navigator.userAgent.indexOf('Edg') === -1 && isCollapsed) ? 'polite' : 'off'}
+      aria-live={(navigator.userAgent.indexOf('Edg') === -1 && isCollapsed && !/^(?=.*\bSafari\b)(?!.*\bChrome\b).*/i.test(navigator.userAgent)) ? 'polite' : 'off'}
       aria-label={rollUpHint}
       aria-describedby={rollUpHint}
       aria-atomic="true"

--- a/packages/terra-tag/tests/jest/__snapshots__/RollUpTag.test.jsx.snap
+++ b/packages/terra-tag/tests/jest/__snapshots__/RollUpTag.test.jsx.snap
@@ -65,9 +65,7 @@ exports[`Rollup Tag should render rollup tag with the label "4 more" 1`] = `
   >
     <Button
       aria-atomic="true"
-      aria-describedby="Terra.tags.hint.rollupTag"
       aria-label="Terra.tags.hint.rollupTag"
-      aria-live="polite"
       className="rollup-tag"
       data-terra-rollup-tag={true}
       data-terra-rollup-tag-show-focus-styles={true}
@@ -88,10 +86,8 @@ exports[`Rollup Tag should render rollup tag with the label "4 more" 1`] = `
     >
       <button
         aria-atomic="true"
-        aria-describedby="Terra.tags.hint.rollupTag"
         aria-disabled={false}
         aria-label="Terra.tags.hint.rollupTag"
-        aria-live="polite"
         className="button neutral compact rollup-tag"
         data-terra-rollup-tag={true}
         data-terra-rollup-tag-show-focus-styles={true}
@@ -185,9 +181,7 @@ exports[`Rollup Tag should render rollup tag with the label "show less" when isC
   >
     <Button
       aria-atomic="true"
-      aria-describedby="Terra.tags.hint.showLess"
       aria-label="Terra.tags.hint.showLess"
-      aria-live="off"
       className="rollup-tag"
       data-terra-rollup-tag={true}
       data-terra-rollup-tag-show-focus-styles={true}
@@ -208,10 +202,8 @@ exports[`Rollup Tag should render rollup tag with the label "show less" when isC
     >
       <button
         aria-atomic="true"
-        aria-describedby="Terra.tags.hint.showLess"
         aria-disabled={false}
         aria-label="Terra.tags.hint.showLess"
-        aria-live="off"
         className="button neutral compact rollup-tag"
         data-terra-rollup-tag={true}
         data-terra-rollup-tag-show-focus-styles={true}
@@ -305,9 +297,7 @@ exports[`Rollup Tag should render rollup tag with the label "show less" when isC
   >
     <Button
       aria-atomic="true"
-      aria-describedby="Terra.tags.hint.rollupTag"
       aria-label="Terra.tags.hint.rollupTag"
-      aria-live="polite"
       className="rollup-tag"
       data-terra-rollup-tag={true}
       data-terra-rollup-tag-show-focus-styles={true}
@@ -328,10 +318,8 @@ exports[`Rollup Tag should render rollup tag with the label "show less" when isC
     >
       <button
         aria-atomic="true"
-        aria-describedby="Terra.tags.hint.rollupTag"
         aria-disabled={false}
         aria-label="Terra.tags.hint.rollupTag"
-        aria-live="polite"
         className="button neutral compact rollup-tag"
         data-terra-rollup-tag={true}
         data-terra-rollup-tag-show-focus-styles={true}


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
Fixed-SR announces instructions twice with VPC ON Mode

**What was changed:**
Removed the `aria-live` property to prevent JAWS (screen reader) from announcing twice in the Edge browser.
**Why it was changed:**
When VPC  is in ON mode, screen reader announces instruction "11 items are hidden" twice .


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

[UXPLATFORM-9812](https://jira2.cerner.com/browse/UXPLATFORM-9812)
---

Thank you for contributing to Terra.
@cerner/terra
