### PR TITLE
[terra-section-header] Add Ability to Fix Section Header Title

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 * Added
+  * Added test to `terra-section-header` for the fixed section header title.
+
+* Added
   * Added visual label and associated with input field using 'for' and 'id'.
 ## 1.51.0 - (November 16, 2023)
 

--- a/packages/terra-core-docs/src/terra-dev-site/test/section-header/FixedTitleSectionHeader.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/section-header/FixedTitleSectionHeader.test.jsx
@@ -1,0 +1,18 @@
+/* eslint-disable react/forbid-dom-props */
+import React from 'react';
+import SectionHeader from 'terra-section-header';
+
+export default () => (
+  <div style={{
+    width: '400px', height: '200px', background: 'gray', margin: '10px', overflow: 'scroll',
+  }}
+  >
+    <div style={{ width: '600px' }}>
+      <SectionHeader
+        text="Closed Section Header"
+        isTitleFixed
+        onClick={() => {}}
+      />
+    </div>
+  </div>
+);

--- a/packages/terra-section-header/CHANGELOG.md
+++ b/packages/terra-section-header/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added the ability to fix the position of the title of the `terra-section-header`.
+
 ## 2.64.0 - (November 13, 2023)
 
   * Changed

--- a/packages/terra-section-header/src/SectionHeader.jsx
+++ b/packages/terra-section-header/src/SectionHeader.jsx
@@ -42,6 +42,11 @@ const propTypes = {
    * Sets the background of the section header to transparent.
    */
   isTransparent: PropTypes.bool,
+  /**
+   * @private
+   * Specifies whether the section header title position should be fixed
+   */
+  isTitleFixed: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -100,6 +105,7 @@ class SectionHeader extends React.Component {
       isOpen,
       isTransparent,
       level,
+      isTitleFixed,
       ...customProps
     } = this.props;
 
@@ -159,7 +165,7 @@ class SectionHeader extends React.Component {
 
     return (
       <Element {...headerAttributes} className={sectionHeaderClassNames} aria-label={!onClick ? headerText : undefined}>
-        <ArrangeWrapper {...buttonAttributes} className={cx('arrange-wrapper')}>
+        <ArrangeWrapper {...buttonAttributes} className={cx('arrange-wrapper', { 'title-fixed': isTitleFixed })}>
           <Arrange
             fitStart={onClick && accordionIcon}
             fill={<span aria-hidden={(onClick !== undefined)} className={cx('title')}>{headerText}</span>}

--- a/packages/terra-section-header/src/SectionHeader.module.scss
+++ b/packages/terra-section-header/src/SectionHeader.module.scss
@@ -151,5 +151,10 @@
     &:focus {
       outline: none;
     }
+
+    // Fix the position of the section header title
+    &.title-fixed {
+      position: absolute;
+    }
   }
 }

--- a/packages/terra-section-header/tests/jest/SectionHeader.test.jsx
+++ b/packages/terra-section-header/tests/jest/SectionHeader.test.jsx
@@ -142,4 +142,17 @@ describe('SectionHeader', () => {
     const sectionHeader = wrapper.find('.section-header').at(0);
     expect(sectionHeader.props().tabIndex).toBe('-1');
   });
+
+  it('verifies that section header with a fixed title has appropriate classes', () => {
+    const wrapper = shallow(
+      <SectionHeader
+        text="foo"
+        level={2}
+        isTitleFixed
+      />,
+    );
+
+    const sectionHeader = wrapper.find('.arrange-wrapper.title-fixed').at(0);
+    expect(sectionHeader).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Added the ability to fix the position of the section header title.

**Why it was changed:**
The change was made so that the title does not scroll out of the viewport when inside a scrollable container.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [X] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [X] Functional review

### Additional Details
N/A

**This PR resolves:**

UXPLATFORM-9898 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
