### PR TITLE
Release for Nov 21, 2023

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38789,7 +38789,7 @@
     },
     "packages/terra-core-docs": {
       "name": "@cerner/terra-core-docs",
-      "version": "1.51.0",
+      "version": "1.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cerner/terra-docs": "^1.10.0",
@@ -38817,7 +38817,7 @@
         "terra-form-fieldset": "^2.78.0",
         "terra-form-input": "^4.29.0",
         "terra-form-radio": "^4.46.0",
-        "terra-form-select": "^6.50.0",
+        "terra-form-select": "^6.51.0",
         "terra-form-textarea": "^5.30.0",
         "terra-grid": "^6.35.0",
         "terra-heading": "^4.54.0",
@@ -38834,7 +38834,7 @@
         "terra-responsive-element": "^5.39.0",
         "terra-scroll": "^2.36.0",
         "terra-search-field": "^3.97.0",
-        "terra-section-header": "^2.64.0",
+        "terra-section-header": "^2.65.0",
         "terra-show-hide": "^2.67.0",
         "terra-signature": "^2.41.0",
         "terra-slide-panel": "^3.46.0",
@@ -38847,7 +38847,7 @@
         "terra-theme-context": "^1.0.0",
         "terra-toggle": "^3.61.0",
         "terra-toggle-button": "^3.81.0",
-        "terra-toggle-section-header": "^2.72.0",
+        "terra-toggle-section-header": "^2.73.0",
         "terra-toolbar": "^1.41.0",
         "terra-visually-hidden-text": "^2.37.0"
       },
@@ -39031,7 +39031,7 @@
       }
     },
     "packages/terra-form-select": {
-      "version": "6.50.0",
+      "version": "6.51.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -39571,7 +39571,7 @@
       }
     },
     "packages/terra-section-header": {
-      "version": "2.64.0",
+      "version": "2.65.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -39747,13 +39747,13 @@
       }
     },
     "packages/terra-toggle-section-header": {
-      "version": "2.72.0",
+      "version": "2.73.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
         "prop-types": "^15.5.8",
         "terra-mixins": "^1.41.0",
-        "terra-section-header": "^2.64.0",
+        "terra-section-header": "^2.65.0",
         "terra-toggle": "^3.61.0"
       },
       "peerDependencies": {

--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.52.0 - (November 21, 2023)
+
 * Added
   * Added test to `terra-section-header` for the fixed section header title.
 

--- a/packages/terra-core-docs/package.json
+++ b/packages/terra-core-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-core-docs",
-  "version": "1.51.0",
+  "version": "1.52.0",
   "description": "Contains documentation for packages in the terra-core monorepo",
   "author": "Cerner Corporation",
   "repository": {
@@ -55,7 +55,7 @@
     "terra-form-fieldset": "^2.78.0",
     "terra-form-input": "^4.29.0",
     "terra-form-radio": "^4.46.0",
-    "terra-form-select": "^6.50.0",
+    "terra-form-select": "^6.51.0",
     "terra-form-textarea": "^5.30.0",
     "terra-grid": "^6.35.0",
     "terra-heading": "^4.54.0",
@@ -72,7 +72,7 @@
     "terra-responsive-element": "^5.39.0",
     "terra-scroll": "^2.36.0",
     "terra-search-field": "^3.97.0",
-    "terra-section-header": "^2.64.0",
+    "terra-section-header": "^2.65.0",
     "terra-show-hide": "^2.67.0",
     "terra-signature": "^2.41.0",
     "terra-slide-panel": "^3.46.0",
@@ -85,7 +85,7 @@
     "terra-theme-context": "^1.0.0",
     "terra-toggle": "^3.61.0",
     "terra-toggle-button": "^3.81.0",
-    "terra-toggle-section-header": "^2.72.0",
+    "terra-toggle-section-header": "^2.73.0",
     "terra-toolbar": "^1.41.0",
     "terra-visually-hidden-text": "^2.37.0"
   },

--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 6.51.0 - (November 21, 2023)
+
 * Added
   * Added 'aria-invalid' attribute which will be set to true for error input fields and false when resolving errors. 
 

--- a/packages/terra-form-select/package.json
+++ b/packages/terra-form-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-form-select",
-  "version": "6.50.0",
+  "version": "6.51.0",
   "description": "Provides a drop down of selectable options.",
   "author": "Cerner Corporation",
   "repository": {

--- a/packages/terra-section-header/CHANGELOG.md
+++ b/packages/terra-section-header/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.65.0 - (November 21, 2023)
+
 * Added
   * Added the ability to fix the position of the title of the `terra-section-header`.
 

--- a/packages/terra-section-header/package.json
+++ b/packages/terra-section-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-section-header",
-  "version": "2.64.0",
+  "version": "2.65.0",
   "description": "Section Header component that contains text and can be optionally interacted with.",
   "author": "Cerner Corporation",
   "repository": {

--- a/packages/terra-toggle-section-header/CHANGELOG.md
+++ b/packages/terra-toggle-section-header/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 2.73.0 - (November 21, 2023)
+
+* Changed
+  * Minor dependency version bump
+
 ## 2.72.0 - (November 13, 2023)
 
 * Changed

--- a/packages/terra-toggle-section-header/package.json
+++ b/packages/terra-toggle-section-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-toggle-section-header",
-  "version": "2.72.0",
+  "version": "2.73.0",
   "description": "Toggle section header component that transitions content in and out with a click on the header.",
   "author": "Cerner Corporation",
   "repository": {
@@ -25,7 +25,7 @@
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
     "terra-mixins": "^1.41.0",
-    "terra-section-header": "^2.64.0",
+    "terra-section-header": "^2.65.0",
     "terra-toggle": "^3.61.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

The following packages will be released:

  - @cerner/terra-core-docs@1.52.0
  - terra-form-select@6.51.0
  - terra-section-header@2.65.0
  - terra-toggle-section-header@2.73.0


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

---

Thank you for contributing to Terra.
@cerner/terra
