### PR TITLE
[terra-form-field] Added aria-invalid for invalid entry

### DIFF
--- a/packages/terra-form-field/CHANGELOG.md
+++ b/packages/terra-form-field/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added `aria-invalid` for invalid entry.
+
 ## 4.31.0 - (November 13, 2023)
 
 * Changed

--- a/packages/terra-form-field/src/Field.jsx
+++ b/packages/terra-form-field/src/Field.jsx
@@ -170,7 +170,7 @@ const Field = (props) => {
     if ((required || isInvalid) && child && (child.type.isInput || child.type.isSelect || child.type.isTextarea)) {
       return React.cloneElement(child, {
         ...required && { required: true },
-        ...isInvalid && { isInvalid: true },
+        ...isInvalid && { isInvalid: true, 'aria-invalid': true },
       });
     }
     return child;

--- a/packages/terra-form-field/tests/jest/__snapshots__/Field.test.jsx.snap
+++ b/packages/terra-form-field/tests/jest/__snapshots__/Field.test.jsx.snap
@@ -1562,11 +1562,13 @@ exports[`should render an invalid and required field with a Select 1`] = `
       </label>
     </div>
     <Select
+      aria-invalid={true}
       isInvalid={true}
       key=".0"
       required={true}
     >
       <select
+        aria-invalid={true}
         invalid="true"
         required={true}
       />
@@ -1707,11 +1709,13 @@ exports[`should render an invalid and required field with a Textarea 1`] = `
       </label>
     </div>
     <Textarea
+      aria-invalid={true}
       isInvalid={true}
       key=".0"
       required={true}
     >
       <textarea
+        aria-invalid={true}
         invalid="true"
         required={true}
       />
@@ -1852,11 +1856,13 @@ exports[`should render an invalid and required field with an Input 1`] = `
       </label>
     </div>
     <Input
+      aria-invalid={true}
       isInvalid={true}
       key=".0"
       required={true}
     >
       <input
+        aria-invalid={true}
         invalid="true"
         required={true}
       />
@@ -1991,10 +1997,12 @@ exports[`should render an invalid field with a Select 1`] = `
       </label>
     </div>
     <Select
+      aria-invalid={true}
       isInvalid={true}
       key=".0"
     >
       <select
+        aria-invalid={true}
         invalid="true"
       />
     </Select>
@@ -2128,10 +2136,12 @@ exports[`should render an invalid field with an Input 1`] = `
       </label>
     </div>
     <Input
+      aria-invalid={true}
       isInvalid={true}
       key=".0"
     >
       <input
+        aria-invalid={true}
         invalid="true"
       />
     </Input>
@@ -2265,10 +2275,12 @@ exports[`should render an invalid field with an Textarea 1`] = `
       </label>
     </div>
     <Textarea
+      aria-invalid={true}
       isInvalid={true}
       key=".0"
     >
       <textarea
+        aria-invalid={true}
         invalid="true"
       />
     </Textarea>


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**

Added `aria-invalid` for invalid entry.

**Why it was changed:**

To allow screen reader to announce invalid entry.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9885 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra

<img width="1680" alt="form-feld" src="https://github.com/cerner/terra-core/assets/40137430/2dfeb401-4083-430c-a47d-63aa09be329c">

