### PR TITLE
[terra-form-search-select] Added instruction note for invalid example

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added instruction note for invalid example in `terra-search-select` and `terra-combo-box`.
+
 ## 1.53.0 - (December 11, 2023)
 
  * Changed 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/Combobox.05.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/Combobox.05.doc.mdx
@@ -20,6 +20,14 @@ import OptGroupPropsTable from 'terra-form-select/lib/shared/_OptGroup?dev-site-
 
 The Combobox component allows a user to enter a single free text entry or select a single option from the dropdown of a selectable options.
 
+Consumers are encouraged to use the `ComboboxField` component over the `Combobox` component wherever possible, as the latter does not provide the labels necessary to support accessibility.
+
+To create an accessible `Combobox` component:
+1. Ensure that `SelectField` can receive keyboard focus.
+2. Ensure that `SelectField` programmatically associates all related content (such as visible label, helper text & error messaging) to the field.
+3. Ensure any visible `SelectLabel` matches any artificially applied programmatic label.
+4. Error messaging should provide error suggestions when the system can programmatically understand what is wrong.
+
 ## Getting Started
 
 - Install with [npmjs](https://www.npmjs.com):

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/Combobox.05.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/Combobox.05.doc.mdx
@@ -23,9 +23,9 @@ The Combobox component allows a user to enter a single free text entry or select
 Consumers are encouraged to use the `ComboboxField` component over the `Combobox` component wherever possible, as the latter does not provide the labels necessary to support accessibility.
 
 To create an accessible `Combobox` component:
-1. Ensure that `SelectField` can receive keyboard focus.
-2. Ensure that `SelectField` programmatically associates all related content (such as visible label, helper text & error messaging) to the field.
-3. Ensure any visible `SelectLabel` matches any artificially applied programmatic label.
+1. Ensure that `ComboboxField` can receive keyboard focus.
+2. Ensure that `ComboboxField` programmatically associates all related content (such as visible label, helper text & error messaging) to the field.
+3. Ensure any visible `Combobox Label` matches any artificially applied programmatic label.
 4. Error messaging should provide error suggestions when the system can programmatically understand what is wrong.
 
 ## Getting Started

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SearchSelect.11.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SearchSelect.11.doc.mdx
@@ -20,6 +20,14 @@ import OptGroupPropsTable from 'terra-form-select/lib/shared/_OptGroup?dev-site-
 
 The Search Select component allows selecting a single option from a dropdown of selectable options.
 
+Consumers are encouraged to use the `SearchSelectField` component over the `SearchSelect` component wherever possible, as the latter does not provide the labels necessary to support accessibility.
+
+To create an accessible `SearchSelect` component:
+1. Ensure that `SelectField` can receive keyboard focus.
+2. Ensure that `SelectField` programmatically associates all related content (such as visible label, helper text & error messaging) to the field.
+3. Ensure any visible `SelectLabel` matches any artificially applied programmatic label.
+4. Error messaging should provide error suggestions when the system can programmatically understand what is wrong.
+
 ## Getting Started
 
 - Install with [npmjs](https://www.npmjs.com):

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SearchSelect.11.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/SearchSelect.11.doc.mdx
@@ -23,9 +23,9 @@ The Search Select component allows selecting a single option from a dropdown of 
 Consumers are encouraged to use the `SearchSelectField` component over the `SearchSelect` component wherever possible, as the latter does not provide the labels necessary to support accessibility.
 
 To create an accessible `SearchSelect` component:
-1. Ensure that `SelectField` can receive keyboard focus.
-2. Ensure that `SelectField` programmatically associates all related content (such as visible label, helper text & error messaging) to the field.
-3. Ensure any visible `SelectLabel` matches any artificially applied programmatic label.
+1. Ensure that `SearchSelectField` can receive keyboard focus.
+2. Ensure that `SearchSelectField` programmatically associates all related content (such as visible label, helper text & error messaging) to the field.
+3. Ensure any visible `Select Label` matches any artificially applied programmatic label.
 4. Error messaging should provide error suggestions when the system can programmatically understand what is wrong.
 
 ## Getting Started

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/example/combobox/Combobox.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/example/combobox/Combobox.jsx
@@ -1,24 +1,18 @@
 import React from 'react';
 import Combobox from 'terra-form-select/lib/Combobox';
-import Field from 'terra-form-field';
 import classNames from 'classnames/bind';
 import styles from '../FormSelectDocCommon.module.scss';
 
 const cx = classNames.bind(styles);
 
 const ComboboxExample = () => (
-  <Field
-    label="Colors"
-    htmlFor="color-field-1"
-  >
-    <Combobox placeholder="Select a color" ariaLabel="Colors" className={cx('form-select')} inputId="color-field-1">
-      <Combobox.Option value="blue" display="Blue" />
-      <Combobox.Option value="green" display="Green" />
-      <Combobox.Option value="purple" display="Purple" />
-      <Combobox.Option value="red" display="Red" />
-      <Combobox.Option value="violet" display="Violet" />
-    </Combobox>
-  </Field>
+  <Combobox placeholder="Select a color" ariaLabel="Colors" className={cx('form-select')}>
+    <Combobox.Option value="blue" display="Blue" />
+    <Combobox.Option value="green" display="Green" />
+    <Combobox.Option value="purple" display="Purple" />
+    <Combobox.Option value="red" display="Red" />
+    <Combobox.Option value="violet" display="Violet" />
+  </Combobox>
 );
 
 export default ComboboxExample;

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/example/combobox/Invalid.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/example/combobox/Invalid.jsx
@@ -13,7 +13,7 @@ const InvalidExample = () => {
   };
   return (
     <>
-      <Combobox placeholder="Select a color" isInvalid={isInvalid} ariaLabel={(isInvalid) ? 'Please select a color' : undefined} className={cx('form-select')} onSearch={handleOnChange} onChange={handleOnChange}>
+      <Combobox placeholder="Select a color" required isInvalid={isInvalid} ariaLabel={(isInvalid) ? 'Please select a color' : undefined} className={cx('form-select')} onSearch={handleOnChange} onChange={handleOnChange}>
         <Combobox.Option value="blue" display="Blue" />
         <Combobox.Option value="green" display="Green" />
         <Combobox.Option value="purple" display="Purple" />

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/example/combobox/Invalid.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/example/combobox/Invalid.jsx
@@ -21,6 +21,7 @@ const InvalidExample = () => {
         <Combobox.Option value="violet" display="Violet" />
       </Combobox>
       {isInvalid && <span className={cx('error-text')}>Please select a color</span>}
+      <p>Required: Please select a color from above list</p>
     </>
   );
 };

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/example/search/Invalid.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/example/search/Invalid.jsx
@@ -20,6 +20,7 @@ const InvalidExample = () => {
         <SearchSelect.Option value="violet" display="Violet" />
       </SearchSelect>
       {isInvalid && <span className={cx('error-text')}>Please select a color</span>}
+      <p>Required: Please select a color from above list</p>
     </>
   );
 };

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/example/search/Invalid.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/example/search/Invalid.jsx
@@ -12,7 +12,7 @@ const InvalidExample = () => {
   };
   return (
     <>
-      <SearchSelect placeholder="Select a color" isInvalid={isInvalid} ariaLabel={(isInvalid) ? 'Please select a color' : undefined} className={cx('form-select')} onSearch={handleOnChange} onChange={handleOnChange}>
+      <SearchSelect placeholder="Select a color" required isInvalid={isInvalid} ariaLabel={(isInvalid) ? 'Please select a color' : undefined} className={cx('form-select')} onSearch={handleOnChange} onChange={handleOnChange}>
         <SearchSelect.Option value="blue" display="Blue" />
         <SearchSelect.Option value="green" display="Green" />
         <SearchSelect.Option value="purple" display="Purple" />

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-select/example/search/Search.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-select/example/search/Search.jsx
@@ -6,16 +6,13 @@ import styles from '../FormSelectDocCommon.module.scss';
 const cx = classNames.bind(styles);
 
 const SearchSelectExample = () => (
-  <>
-    <label htmlFor="color-field-1"><strong>Colors</strong></label>
-    <SearchSelect placeholder="Select a color" ariaLabel="Colors" className={cx('form-select')} inputId="color-field-1">
-      <SearchSelect.Option value="blue" display="Blue" />
-      <SearchSelect.Option value="green" display="Green" />
-      <SearchSelect.Option value="purple" display="Purple" />
-      <SearchSelect.Option value="red" display="Red" />
-      <SearchSelect.Option value="violet" display="Violet" />
-    </SearchSelect>
-  </>
+  <SearchSelect placeholder="Select a color" ariaLabel="Colors" className={cx('form-select')}>
+    <SearchSelect.Option value="blue" display="Blue" />
+    <SearchSelect.Option value="green" display="Green" />
+    <SearchSelect.Option value="purple" display="Purple" />
+    <SearchSelect.Option value="red" display="Red" />
+    <SearchSelect.Option value="violet" display="Violet" />
+  </SearchSelect>
 );
 
 export default SearchSelectExample;


### PR DESCRIPTION
### Summary
Added the instruction note below the invalid example which says that the user should select the one of the option from the list.

**What was changed:**


**Why it was changed:**



### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9841

---

Thank you for contributing to Terra.
@cerner/terra
