### PR TITLE
[Terra-List] Added null check to avoid application crash when list item is null

### DIFF
--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
-  * Added valid element check in clone method to avoid application crash.
+  * Fixed runtime exception that occurred when children on the terra-list were rendered with a `null` value.
 
 ## 4.68.0 - (December 11, 2023)
 

--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Added valid element check in clone method to avoid application crash.
+
 ## 4.68.0 - (December 11, 2023)
 
  * Changed 

--- a/packages/terra-list/src/List.jsx
+++ b/packages/terra-list/src/List.jsx
@@ -276,9 +276,9 @@ const List = ({
     style: getStyleforDrag(ListItem, snapshot, provider),
   });
 
-  const clone = (object) => React.Children.map(object, (listitem) => React.cloneElement(listitem, {
+  const clone = (object) => React.Children.map(object, (listitem) => ((React.isValidElement(listitem)) ? React.cloneElement(listitem, {
     isTabFocusDisabled,
-  }));
+  }) : null));
 
   const renderListDom = () => (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/role-supports-aria-props

--- a/packages/terra-list/tests/jest/List.test.jsx
+++ b/packages/terra-list/tests/jest/List.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import { shallowWithIntl, mountWithIntl } from 'terra-enzyme-intl';
-import List, { Item } from '../../src/index';
+import List, { Item, Section } from '../../src/index';
 
 // Snapshot Tests
 it('should render with items', () => {
@@ -177,6 +177,21 @@ it('should render with mutli select aria attributes with ariaSelectionStyle mutl
   const shallowComponent = shallowWithIntl(
     <List ariaSelectionStyle="multi-select">{items}</List>,
   ).dive();
+  expect(shallowComponent).toMatchSnapshot();
+});
+
+it('should render with sections', () => {
+  const shallowComponent = shallowWithIntl(
+    <List dividerStyle="standard" role="listbox">
+      <Section title="section 1" isCollapsed />
+      <Section title="section 2" isCollapsed />
+      { null }
+    </List>,
+  );
+  const listSection = shallowComponent.find('ListSection');
+  const list = shallowComponent.find('List');
+  expect(listSection).toBeDefined();
+  expect(list.children().length).toBe(2);
   expect(shallowComponent).toMatchSnapshot();
 });
 

--- a/packages/terra-list/tests/jest/List.test.jsx
+++ b/packages/terra-list/tests/jest/List.test.jsx
@@ -180,7 +180,7 @@ it('should render with mutli select aria attributes with ariaSelectionStyle mutl
   expect(shallowComponent).toMatchSnapshot();
 });
 
-it('should render with sections', () => {
+it('should render with null sections', () => {
   const shallowComponent = shallowWithIntl(
     <List dividerStyle="standard" role="listbox">
       <Section title="section 1" isCollapsed />

--- a/packages/terra-list/tests/jest/__snapshots__/List.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/List.test.jsx.snap
@@ -466,7 +466,7 @@ exports[`should render with no items 1`] = `
 />
 `;
 
-exports[`should render with sections 1`] = `
+exports[`should render with null sections 1`] = `
 <List
   ariaSelectionStyle="none"
   dividerStyle="standard"

--- a/packages/terra-list/tests/jest/__snapshots__/List.test.jsx.snap
+++ b/packages/terra-list/tests/jest/__snapshots__/List.test.jsx.snap
@@ -466,6 +466,53 @@ exports[`should render with no items 1`] = `
 />
 `;
 
+exports[`should render with sections 1`] = `
+<List
+  ariaSelectionStyle="none"
+  dividerStyle="standard"
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": null,
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": null,
+    }
+  }
+  isTabFocusDisabled={false}
+  paddingStyle="none"
+  role="listbox"
+  zIndex={6001}
+>
+  <InjectIntl(ListSection)
+    isCollapsed={true}
+    title="section 1"
+  />
+  <InjectIntl(ListSection)
+    isCollapsed={true}
+    title="section 2"
+  />
+</List>
+`;
+
 exports[`should render with single select aria attributes with ariaSelectionStyle single-select 1`] = `
 <ul
   aria-label="Terra.list.singleSelect"


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**

Added null check in the clone method to avoid application crash.

**Why it was changed:**

terra-list version v4.66.0 is causing application crash. We are getting the following error when rendering the component:
"The system encountered an error: Minified React error #267; visit https://reactjs.org/docs/error-decoder.html?invariant=267&args[]=null for the full message or use the non-minified dev environment for full errors and additional helpful warnings."


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10117 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
