### PR TITLE
[terra-native-select] Reverted Changes to announce selected state.

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Reverted changes to announce selected state in `native-select`.
+
 ## 6.53.1 - (January 4, 2024)
 
 * Fixed

--- a/packages/terra-form-select/src/native-select/NativeSelect.jsx
+++ b/packages/terra-form-select/src/native-select/NativeSelect.jsx
@@ -216,23 +216,9 @@ const NativeSelect = ({
     currentValue = getFirstValue(options, isFilterStyle);
     currentDisplay = getDisplay(currentValue, options, isFilterStyle, intl);
   }
-  const groupHeading = options.filter(groupValue => (groupValue.options)).find(element => element.options.find(childElement => childElement.value === currentValue));
-
-  const selectedText = intl.formatMessage({ id: 'Terra.form.select.selected' });
-
-  let displayText;
-  if (currentValue) {
-    if (groupHeading) {
-      displayText = intl.formatMessage({ id: 'Terra.form.select.optGroup' }, { text: `${groupHeading.display}, ${ariaLabel}, ${selectedText}` });
-    } else {
-      displayText = `${ariaLabel}, ${selectedText}`;
-    }
-  } else {
-    displayText = ariaLabel;
-  }
   const selectAttrs = {
     'aria-describedby': ariaDescribedBy,
-    'aria-label': displayText,
+    'aria-label': ariaLabel,
     id,
     disabled,
     'aria-invalid': isInvalid || undefined,

--- a/packages/terra-form-select/tests/jest/native-select/__snapshots__/NativeSelect.test.jsx.snap
+++ b/packages/terra-form-select/tests/jest/native-select/__snapshots__/NativeSelect.test.jsx.snap
@@ -1723,7 +1723,7 @@ exports[`NativeSelect should render a NativeSelect with options and defaultValue
         </div>
       </div>
       <select
-        aria-label="test-label, Terra.form.select.selected"
+        aria-label="test-label"
         className="select"
         disabled={false}
         onBlur={[Function]}
@@ -1898,7 +1898,7 @@ exports[`NativeSelect should render a NativeSelect with options and value 1`] = 
         </div>
       </div>
       <select
-        aria-label="test-label, Terra.form.select.selected"
+        aria-label="test-label"
         className="select"
         disabled={false}
         onBlur={[Function]}


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->
Reverting the aria-label changes made in PR #3860 . As discussed offline, selection states will be marked as a known limitation of HTML native select.

**What was changed:**

Changes for announcement of selected state were reverted.

**Why it was changed:**

It was not working as expected.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-XXXX <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
