### PR TITLE
[terra-section-header] Allow sticky header title

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added test to `terra-section-header` for the sticky section header title.
+
 ## 1.58.0 - (February 20, 2024)
 
 * Changed

--- a/packages/terra-core-docs/src/terra-dev-site/test/section-header/StickyTitleSectionHeader.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/section-header/StickyTitleSectionHeader.test.jsx
@@ -1,0 +1,29 @@
+/* eslint-disable react/forbid-dom-props */
+import React from 'react';
+import SectionHeader from 'terra-section-header';
+
+export default () => (
+  <div style={{
+    width: '400px', height: '200px', background: 'gray', margin: '10px', overflow: 'scroll',
+  }}
+  >
+    <div style={{ width: '600px', height: '400px' }}>
+      <SectionHeader
+        text="Closed Section Header 1"
+        isTitleSticky
+        onClick={() => {}}
+      />
+      <br />
+      <SectionHeader
+        text="Closed Section Header 2"
+        isTitleSticky
+        onClick={() => {}}
+      />
+      <br />
+      <SectionHeader
+        text="Section Header 3"
+        isTitleSticky
+      />
+    </div>
+  </div>
+);

--- a/packages/terra-section-header/CHANGELOG.md
+++ b/packages/terra-section-header/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Allow the title of the `terra-section-header` to be sticky. 
+
 ## 2.66.0 - (February 15, 2024)
 
 * Changed

--- a/packages/terra-section-header/src/SectionHeader.jsx
+++ b/packages/terra-section-header/src/SectionHeader.jsx
@@ -166,7 +166,7 @@ class SectionHeader extends React.Component {
 
     return (
       <Element {...headerAttributes} className={sectionHeaderClassNames} aria-label={!onClick ? headerText : undefined}>
-        <ArrangeWrapper {...buttonAttributes} className={cx('arrange-wrapper', { 'title-fixed': isTitleFixed })}>
+        <ArrangeWrapper {...buttonAttributes} className={cx('arrange-wrapper', { 'title-fixed': isTitleFixed, 'title-sticky': headerAttributes.isTitleSticky })}>
           <Arrange
             fitStart={onClick && accordionIcon}
             fill={<span aria-hidden={(onClick !== undefined)} className={cx('title')}>{headerText}</span>}

--- a/packages/terra-section-header/src/SectionHeader.module.scss
+++ b/packages/terra-section-header/src/SectionHeader.module.scss
@@ -156,5 +156,12 @@
     &.title-fixed {
       position: absolute;
     }
+
+    // Make the section header title sticky
+    &.title-sticky {
+      position: sticky;
+      left: 12px;
+      width: auto;
+    }
   }
 }

--- a/packages/terra-section-header/tests/jest/SectionHeader.test.jsx
+++ b/packages/terra-section-header/tests/jest/SectionHeader.test.jsx
@@ -147,4 +147,17 @@ describe('SectionHeader', () => {
     const sectionHeader = wrapper.find('.arrange-wrapper.title-fixed').at(0);
     expect(sectionHeader).toHaveLength(1);
   });
+
+  it('verifies that section header with a sticky title has appropriate classes', () => {
+    const wrapper = enzyme.shallow(
+      <SectionHeader
+        text="foo"
+        level={2}
+        isTitleSticky
+      />,
+    );
+
+    const sectionHeader = wrapper.find('.arrange-wrapper.title-sticky').at(0);
+    expect(sectionHeader).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**

Allow section header title to be sticky when position is not absolute.


**Why it was changed:**

- This change came was introduced to allow headers to be sticky in cases where its position is not fixed/absolute.
- Issue was identified in a case where flowsheet with sections (`terra-section-header`) had to be relative when height restricted and had more cells in row. In this scenario, header had to be fixed/sticky to prevent horizontal scroll of header title.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10215 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
