### PR TITLE
[terra-section-header] Fixes header title width for sticky header

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated
+  * Updated test example in `terra-section-header` for sticky section header title.
+
 ## 1.60.0 - (February 27, 2024)
 
 * Changed

--- a/packages/terra-core-docs/src/terra-dev-site/test/section-header/StickyTitleSectionHeader.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/section-header/StickyTitleSectionHeader.test.jsx
@@ -12,14 +12,14 @@ export default () => (
         text="Closed Section Header 1"
         isTitleSticky
         onClick={() => {}}
-        boundedWidth="350px"
+        boundedWidth="350"
       />
       <br />
       <SectionHeader
         text="Closed Section Header 2"
         isTitleSticky
         onClick={() => {}}
-        boundedWidth="350px"
+        boundedWidth="350"
       />
       <br />
       <SectionHeader

--- a/packages/terra-core-docs/src/terra-dev-site/test/section-header/StickyTitleSectionHeader.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/section-header/StickyTitleSectionHeader.test.jsx
@@ -12,12 +12,14 @@ export default () => (
         text="Closed Section Header 1"
         isTitleSticky
         onClick={() => {}}
+        boundedWidth="350px"
       />
       <br />
       <SectionHeader
         text="Closed Section Header 2"
         isTitleSticky
         onClick={() => {}}
+        boundedWidth="350px"
       />
       <br />
       <SectionHeader

--- a/packages/terra-core-docs/src/terra-dev-site/test/section-header/StickyTitleSectionHeader.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/section-header/StickyTitleSectionHeader.test.jsx
@@ -1,31 +1,40 @@
 /* eslint-disable react/forbid-dom-props */
-import React from 'react';
+import React, { useState } from 'react';
 import SectionHeader from 'terra-section-header';
 
-export default () => (
-  <div style={{
-    width: '400px', height: '200px', background: 'gray', margin: '10px', overflow: 'scroll',
-  }}
-  >
-    <div style={{ width: '600px', height: '400px' }}>
-      <SectionHeader
-        text="Closed Section Header 1"
-        isTitleSticky
-        onClick={() => {}}
-        boundedWidth="350"
-      />
-      <br />
-      <SectionHeader
-        text="Closed Section Header 2"
-        isTitleSticky
-        onClick={() => {}}
-        boundedWidth="350"
-      />
-      <br />
-      <SectionHeader
-        text="Section Header 3"
-        isTitleSticky
-      />
+const StickyTitleSectionHeader = () => {
+  const [isOpen1, setIsOpen1] = useState(false);
+  const [isOpen2, setIsOpen2] = useState(false);
+
+  return (
+    <div style={{
+      width: '400px', height: '200px', background: 'gray', margin: '10px', overflow: 'scroll',
+    }}
+    >
+      <div style={{ width: '600px', height: '400px' }}>
+        <SectionHeader
+          text="Closed Section Header 1"
+          isTitleSticky
+          onClick={() => { setIsOpen1(!isOpen1); }}
+          isOpen={isOpen1}
+          boundedWidth="350"
+        />
+        <br />
+        <SectionHeader
+          text="Closed Section Header 2"
+          isTitleSticky
+          onClick={() => { setIsOpen2(!isOpen2); }}
+          isOpen={isOpen2}
+          boundedWidth="350"
+        />
+        <br />
+        <SectionHeader
+          text="Section Header 3"
+          isTitleSticky
+        />
+      </div>
     </div>
-  </div>
-);
+  );
+};
+
+export default StickyTitleSectionHeader;

--- a/packages/terra-section-header/CHANGELOG.md
+++ b/packages/terra-section-header/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed width of arrange wrapper when header is sticky.
+
 ## 2.67.0 - (February 23, 2024)
 
 * Changed

--- a/packages/terra-section-header/src/SectionHeader.jsx
+++ b/packages/terra-section-header/src/SectionHeader.jsx
@@ -154,15 +154,15 @@ class SectionHeader extends React.Component {
       buttonAttributes.onKeyDown = this.wrapOnKeyDown(headerAttributes.onKeyDown);
       buttonAttributes.onKeyUp = this.wrapOnKeyUp(headerAttributes.onKeyUp);
       buttonAttributes.onClick = onClick;
-      if (headerAttributes.isTitleSticky && headerAttributes.boundedWidth) {
-        buttonAttributes.style = { width: `${headerAttributes.boundedWidth}px` };
+      if (customProps.isTitleSticky && customProps.boundedWidth) {
+        buttonAttributes.style = { width: `${customProps.boundedWidth}px` };
       }
 
       // Specify button element for header content
       ArrangeWrapper = 'button';
     } else {
       headerAttributes.ref = refCallback;
-      if (headerAttributes.isTitleSticky) {
+      if (customProps.isTitleSticky) {
         buttonAttributes.style = { width: 'auto' };
       }
 
@@ -170,9 +170,12 @@ class SectionHeader extends React.Component {
       ArrangeWrapper = 'span';
     }
 
+    delete headerAttributes?.boundedWidth;
+    delete headerAttributes?.isTitleSticky;
+
     return (
       <Element {...headerAttributes} className={sectionHeaderClassNames} aria-label={!onClick ? headerText : undefined}>
-        <ArrangeWrapper {...buttonAttributes} className={cx('arrange-wrapper', { 'title-fixed': isTitleFixed, 'title-sticky': headerAttributes.isTitleSticky })}>
+        <ArrangeWrapper {...buttonAttributes} className={cx('arrange-wrapper', { 'title-fixed': isTitleFixed, 'title-sticky': customProps.isTitleSticky })}>
           <Arrange
             fitStart={onClick && accordionIcon}
             fill={<span aria-hidden={(onClick !== undefined)} className={cx('title')}>{headerText}</span>}

--- a/packages/terra-section-header/src/SectionHeader.jsx
+++ b/packages/terra-section-header/src/SectionHeader.jsx
@@ -154,11 +154,17 @@ class SectionHeader extends React.Component {
       buttonAttributes.onKeyDown = this.wrapOnKeyDown(headerAttributes.onKeyDown);
       buttonAttributes.onKeyUp = this.wrapOnKeyUp(headerAttributes.onKeyUp);
       buttonAttributes.onClick = onClick;
+      if (headerAttributes.isTitleSticky && headerAttributes.boundedWidth) {
+        buttonAttributes.style = { width: `${headerAttributes.boundedWidth}px` };
+      }
 
       // Specify button element for header content
       ArrangeWrapper = 'button';
     } else {
       headerAttributes.ref = refCallback;
+      if (headerAttributes.isTitleSticky) {
+        buttonAttributes.style = { width: 'auto' };
+      }
 
       // Specify span element for header content
       ArrangeWrapper = 'span';

--- a/packages/terra-section-header/src/SectionHeader.module.scss
+++ b/packages/terra-section-header/src/SectionHeader.module.scss
@@ -161,7 +161,6 @@
     &.title-sticky {
       position: sticky;
       left: 12px;
-      width: auto;
     }
   }
 }


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**

Sets width of header title element when section headers are bounded by width and have sticky header. 

**Why it was changed:**

This fixes issue when auto width was set to collapsible section headers causing the onclick action to fail due to insufficient size of clickable area of section-header.
Sticky headers which are bounded have width set to bounded width, else set to auto.
Non-sticky headers have width as 100%

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10215 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
