### PR TITLE
[terra-hyperlink] Fixed hyperlink import path error

### DIFF
--- a/packages/terra-hyperlink/CHANGELOG.md
+++ b/packages/terra-hyperlink/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed scss import path error.
+
 ## 2.67.0 - (February 20, 2024)
 
 * Changed

--- a/packages/terra-hyperlink/src/redwood-theme/Hyperlink.module.scss
+++ b/packages/terra-hyperlink/src/redwood-theme/Hyperlink.module.scss
@@ -1,4 +1,4 @@
-@import 'terra-theme-properties/lib/scss/redwood-mixins';
+@import '~terra-theme-properties/lib/scss/redwood-mixins';
 
 :local {
   .redwood-theme {


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

This PR tweaks the scss import path in terra-hyperlink to resolve a potential "path not found" error by webpack.

Adding a `~` at the start causes webpack to recognize the path as a node_module. 
https://github.com/PatrickJS/MFE-starter/issues/727


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [x] Other (please describe below)
- [ ] No tests are needed

This was tested by running `npm start` and ensuring that the dev site still compiles.

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->



---

Thank you for contributing to Terra.
@cerner/terra
