### PR TITLE
[terra-alert] Add ID prop

### DIFF
--- a/packages/terra-alert/CHANGELOG.md
+++ b/packages/terra-alert/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added `id` prop.
+
 ## 4.90.0 - (February 27, 2024)
 
 * Changed

--- a/packages/terra-alert/src/Alert.jsx
+++ b/packages/terra-alert/src/Alert.jsx
@@ -64,6 +64,12 @@ const propTypes = {
    */
   onDismiss: PropTypes.func,
   /**
+   * The unique ID of the alert that is used to identify the alert title and message content.
+   * These IDs can be used to associate action elements with the alert via aria-describedby, in the format
+   * `alert-title-${id}` or `alert-message-${id}`.
+   * */
+  id: PropTypes.string,
+  /**
    * @private
    * intl object programmatically imported through injectIntl from react-intl.
    * */
@@ -136,6 +142,7 @@ const Alert = ({
   disableAlertActionFocus,
   onDismiss,
   intl,
+  id,
   role,
   title,
   type,
@@ -169,7 +176,7 @@ const Alert = ({
   const focusContainerClassName = cx('focus-container');
   const contentContainerClassName = cx('content-container');
 
-  const alertId = uuidv4();
+  const alertId = id || uuidv4();
   const alertTitleId = `alert-title-${alertId}`;
   const alertMessageId = `alert-message-${alertId}`;
 

--- a/packages/terra-alert/src/Alert.jsx
+++ b/packages/terra-alert/src/Alert.jsx
@@ -241,6 +241,7 @@ const Alert = ({
     >
       <div
         role={role || defaultRole}
+        id={id}
         {...customProps}
         className={alertClassNames}
       >

--- a/packages/terra-alert/src/Alert.jsx
+++ b/packages/terra-alert/src/Alert.jsx
@@ -66,7 +66,7 @@ const propTypes = {
   /**
    * The unique ID of the alert that is used to identify the alert title and message content.
    * These IDs can be used to associate action elements with the alert via aria-describedby, in the format
-   * `alert-title-${id}` or `alert-message-${id}`.
+   * `alert-title-${id}`.
    * */
   id: PropTypes.string,
   /**

--- a/packages/terra-alert/tests/jest/Alert.test.jsx
+++ b/packages/terra-alert/tests/jest/Alert.test.jsx
@@ -79,6 +79,13 @@ describe('Alert with props', () => {
     expect(alertTitle.text()).toEqual('<VisuallyHiddenText />Custom Title');
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should render an alert with provided id', () => {
+    const wrapper = enzymeIntl.shallowWithIntl(<Alert id="alert-id" />).dive();
+
+    expect(wrapper.find('.title').prop('id')).toEqual('alert-title-alert-id');
+    expect(wrapper.find('.section').prop('id')).toEqual('alert-message-alert-id');
+  });
 });
 
 describe('Dismissible Alert that includes actions section', () => {

--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added documentation on using new `id` prop with action elements in `terra-alert`.
+
 ## 1.61.0 - (February 28, 2024)
 
 * Updated

--- a/packages/terra-core-docs/src/terra-dev-site/doc/alert/AccessibilityGuide.2.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/alert/AccessibilityGuide.2.doc.mdx
@@ -4,6 +4,7 @@ import Whitespace from '../../common/layout-helpers/Whitespace';
 import AlertActionFocusDemo from './example/AlertActionFocusDemo';
 import CustomExample from './example/CustomExample?dev-site-example';
 import CustomExampleNoTitle from './example/CustomExampleNoTitle?dev-site-example';
+import ActionExample from './example/ActionExample?dev-site-example';
 
 import Hyperlink from 'terra-hyperlink';
 
@@ -115,6 +116,19 @@ In combination with the notification criticality, screen reader users should und
 
 <CustomExampleNoTitle title="Bad: Avoid notifications with no titles" />
 <CustomExample title="Good: Titles help users understand notifications" />
+
+#### Actions
+
+- Interactable elements belonging to notification banners (such as dismiss buttons and action elements) must be associated with the banner.
+  This is handled by default for dismiss buttons, but not consumer-defined action elements.
+- Terra provides an optional `id` prop to facilitate associating action elements to the notification banner. Action elements should set
+  `aria-describedby` to the title of the notification banner.
+  - `alert-title-${id}` - The ID of the title of the notification banner (e.g. "Alert", "Error", "Warning", custom titles, etc.)
+
+<ActionExample
+  title="Notification Banner with Action"
+  description="This example uses the id prop and aria-describedby to associate an action element with the notification banner."
+/>
 
 ## Linked References:
 1. ["Accessible Rich Internet Applications (WAI-ARIA) 1.3"](https://w3c.github.io/aria/). World Wide Web Consortium. Last updated 01 May 2023. Retrieved 2 May 2023.

--- a/packages/terra-core-docs/src/terra-dev-site/doc/alert/example/ActionExample.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/alert/example/ActionExample.jsx
@@ -19,6 +19,7 @@ const AlertActionButton = () => {
       customIcon={<IconHazardLow />}
       action={(
         <Button
+          aria-describedby="alert-title-actionAlert"
           text="Action"
           variant="emphasis"
           onClick={action}


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

This PR adds an `id` prop to `terra-alert` so that consumers are able to access the ID of the notification banner title in order to associate the banner with action elements.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [x] Other (please describe below)
- [ ] No tests are needed

Tested with Voiceover and JAWS using the action button example on the About page.

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

---

Thank you for contributing to Terra.
@cerner/terra
