### PR TITLE
[terra-list] Reverted refCallback from div to li

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -97,6 +97,7 @@ Cerner Corporation
 - Quan Le [@leducquan]
 - Yixuan Chen [@chenyixuan625]
 - Madalina Stelea [@MadalinaStelea]
+- Avijit Das [@adavijit]
 
 Community
 
@@ -221,3 +222,4 @@ Community
 [@leducquan]: https://github.com/leducquan
 [@chenyixuan625]: https://github.com/chenyixuan625
 [@MadalinaStelea]: https://github.com/MadalinaStelea
+[@adavijit]: https://github.com/adavijit

--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Changed
-  * Restored the `refCallback` prop for the ListSectionHeader component to be applied to the intended `li` element instead of the inner `div` tag. 
+  * Restored the `refCallback` prop for the ListSectionHeader and ListSubSectionHeader component to be applied to the intended `li` element instead of the inner `div` tag. 
 
 ## 4.71.0 - (February 27, 2024)
 

--- a/packages/terra-list/CHANGELOG.md
+++ b/packages/terra-list/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Restored the `refCallback` prop for the ListSectionHeader component to be applied to the intended `li` element instead of the inner `div` tag. 
+
 ## 4.71.0 - (February 27, 2024)
 
 * Changed

--- a/packages/terra-list/src/ListSectionHeader.jsx
+++ b/packages/terra-list/src/ListSectionHeader.jsx
@@ -113,9 +113,9 @@ const ListSectionHeader = ({
   /* eslint-disable-next-line no-param-reassign */
   delete customProps?.isTabFocusDisabled;
   return (
-    <li {...customProps} className={cx('list-item', theme.className)}>
+    <li {...customProps} className={cx('list-item', theme.className)} ref={refCallback}>
       <Element className={cx('title')}>
-        <div {...attrSpread} className={sectionHeaderClassNames} ref={refCallback}>
+        <div {...attrSpread} className={sectionHeaderClassNames}>
           {accordionIcon}
           {titleElement}
         </div>

--- a/packages/terra-list/src/ListSubsectionHeader.jsx
+++ b/packages/terra-list/src/ListSubsectionHeader.jsx
@@ -110,9 +110,9 @@ const ListSubsectionHeader = ({
   /* eslint-disable-next-line no-param-reassign */
   delete customProps?.isTabFocusDisabled;
   return (
-    <li {...customProps} className={cx('list-item', theme.className)}>
+    <li {...customProps} className={cx('list-item', theme.className)} ref={refCallback}>
       <Element className={cx('title')}>
-        <div {...attrSpread} className={sectionHeaderClassNames} ref={refCallback}>
+        <div {...attrSpread} className={sectionHeaderClassNames}>
           {accordionIcon}
           {titleElement}
         </div>


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Restored the `refCallback` prop for the ListSectionHeader and ListSubsectionHeader components to be applied to the intended `li` element instead of the inner `div` tag. 

**Why it was changed:**
This aligns with the correct purpose of the prop as specified in both the source code and Terra documentation.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [x] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10248 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
