### PR TITLE
[terra-form-select] Added left padding to NativeSelect select element

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Added left padding to the NativeSelect select element for proper display on Windows devices.
+
 ## 6.56.1 - (March 5, 2024)
 
 * Fixed

--- a/packages/terra-form-select/src/native-select/NativeSelect.module.scss
+++ b/packages/terra-form-select/src/native-select/NativeSelect.module.scss
@@ -146,7 +146,10 @@
     line-height: var(--terra-form-select-native-select-line-height, 1.75);
     opacity: 0;
     outline: none;
-    padding: 0;
+    padding-bottom: 0;
+    padding-left: var(--terra-form-select-native-frame-padding-left, 0.4286rem);
+    padding-right: 0;
+    padding-top: 0;
     top: 0;
     width: 100%;
     z-index: 1;


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Added left padding to NativeSelect select element.

**Why it was changed:**
The change was made to allow proper padding of the options of the select element on Windows devices.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [X] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [X] Functional review

### Additional Details
N/A

**This PR resolves:**

UXPLATFORM-10293 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
