### PR TITLE
[terra-alert] Add titleID prop

### DIFF
--- a/packages/terra-alert/CHANGELOG.md
+++ b/packages/terra-alert/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Added
-  * Added `titleID` prop.
+  * Added `titleID` prop so that consumers can specify the ID of the alert title without using the `alert-title-${id}` string.
 
 ## 4.92.0 - (March 4, 2024)
 

--- a/packages/terra-alert/CHANGELOG.md
+++ b/packages/terra-alert/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added `titleID` prop.
+
 ## 4.92.0 - (March 4, 2024)
 
 * Changed

--- a/packages/terra-alert/src/Alert.jsx
+++ b/packages/terra-alert/src/Alert.jsx
@@ -86,6 +86,10 @@ const propTypes = {
    */
   title: PropTypes.string,
   /**
+   * The unique ID that is used to identify the alert title.
+   * */
+  titleID: PropTypes.string,
+  /**
    * The type of notification banner to be rendered. One of `alert`, `error`, `warning`, `unsatisfied`, `unverified`, `advisory`,
    * `info`, `success`, or `custom`.
    * A default title is provided for all notification types except `custom`.
@@ -145,6 +149,7 @@ const Alert = ({
   id,
   role,
   title,
+  titleID,
   type,
   ...customProps
 }) => {
@@ -177,7 +182,7 @@ const Alert = ({
   const contentContainerClassName = cx('content-container');
 
   const alertId = id || uuidv4();
-  const alertTitleId = `alert-title-${alertId}`;
+  const alertTitleId = titleID || `alert-title-${alertId}`;
   const alertMessageId = `alert-message-${alertId}`;
 
   const dismissButtonAriaDescribedBy = (title || defaultTitle) ? alertTitleId : alertMessageId;

--- a/packages/terra-alert/tests/jest/Alert.test.jsx
+++ b/packages/terra-alert/tests/jest/Alert.test.jsx
@@ -83,7 +83,24 @@ describe('Alert with props', () => {
   it('should render an alert with provided id', () => {
     const wrapper = enzymeIntl.shallowWithIntl(<Alert id="alert-id" />).dive();
 
+    expect(wrapper.find('.alert-base').prop('id')).toEqual('alert-id');
     expect(wrapper.find('.title').prop('id')).toEqual('alert-title-alert-id');
+    expect(wrapper.find('.section').prop('id')).toEqual('alert-message-alert-id');
+  });
+
+  it('should render an alert with provided titleID', () => {
+    const wrapper = enzymeIntl.shallowWithIntl(<Alert titleID="alertTitleID" />).dive();
+
+    expect(wrapper.find('.alert-base').prop('id')).toBeUndefined();
+    expect(wrapper.find('.title').prop('id')).toEqual('alertTitleID');
+    expect(wrapper.find('.section').prop('id')).toEqual('alert-message-00000000-0000-0000-0000-000000000000');
+  });
+
+  it('should render an alert with provided id and titleID', () => {
+    const wrapper = enzymeIntl.shallowWithIntl(<Alert id="alert-id" titleID="alertTitleID" />).dive();
+
+    expect(wrapper.find('.alert-base').prop('id')).toEqual('alert-id');
+    expect(wrapper.find('.title').prop('id')).toEqual('alertTitleID');
     expect(wrapper.find('.section').prop('id')).toEqual('alert-message-alert-id');
   });
 });

--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated `terra-alert` example to use `titleID` prop.
+
 ## 1.66.0 - (March 12, 2024)
 
 * Updated

--- a/packages/terra-core-docs/src/terra-dev-site/doc/alert/AccessibilityGuide.2.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/alert/AccessibilityGuide.2.doc.mdx
@@ -124,10 +124,11 @@ In combination with the notification criticality, screen reader users should und
 - Terra provides an optional `id` prop to facilitate associating action elements to the notification banner. Action elements should set
   `aria-describedby` to the title of the notification banner.
   - `alert-title-${id}` - The ID of the title of the notification banner (e.g. "Alert", "Error", "Warning", custom titles, etc.)
+- Terra also provides an option `titleID` prop for the same purpose.
 
 <ActionExample
   title="Notification Banner with Action"
-  description="This example uses the id prop and aria-describedby to associate an action element with the notification banner."
+  description="This example uses the titleID prop and aria-describedby to associate an action element with the notification banner."
 />
 
 ## Linked References:

--- a/packages/terra-core-docs/src/terra-dev-site/doc/alert/example/ActionExample.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/alert/example/ActionExample.jsx
@@ -15,11 +15,12 @@ const AlertActionButton = () => {
     <Alert
       id="actionAlert"
       title="Action Required."
+      titleID="actionAlert-title"
       type="custom"
       customIcon={<IconHazardLow />}
       action={(
         <Button
-          aria-describedby="alert-title-actionAlert"
+          aria-describedby="actionAlert-title"
           text="Action"
           variant="emphasis"
           onClick={action}


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

This PR adds a `titleID` prop to terra-alert so that consumers can directly define the ID of the alert title instead of using the `alert-title-${id}` string.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [x] Other (please describe below)
- [ ] No tests are needed

Tested in Voiceover with the Action example.

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10306 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
