### PR TITLE
Add named exports for field components

### DIFF
--- a/packages/terra-core-docs/CHANGELOG.md
+++ b/packages/terra-core-docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Changed
   * Changed `terra responsive element` docs to include reflow details.
   * Updated `terra-alert` example to use `titleID` prop.
+  * Updated usage documentation for terra-form-checkbox, terra-form-input, terra-form-radio & terra-form-textarea.
 
 ## 1.66.0 - (March 12, 2024)
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/arrange/common/examplesetup.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/arrange/common/examplesetup.jsx
@@ -3,8 +3,7 @@ import Button from 'terra-button';
 import classNames from 'classnames/bind';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { KEY_SPACE } from 'keycode-js';
-import Radio from 'terra-form-radio';
-import RadioField from 'terra-form-radio/lib/RadioField';
+import Radio, { RadioField } from 'terra-form-radio';
 import styles from './examplesetup.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-core-docs/src/terra-dev-site/doc/content-container/example/ContentContainerFill.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/content-container/example/ContentContainerFill.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import ContentContainer from 'terra-content-container';
 import Button from 'terra-button';
 import classNames from 'classnames/bind';
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 import styles from './ContentContainerDocCommon.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-core-docs/src/terra-dev-site/doc/content-container/example/ContentContainerScrollRef.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/content-container/example/ContentContainerScrollRef.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import Button from 'terra-button';
 import ContentContainer from 'terra-content-container';
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 import classNames from 'classnames/bind';
 import styles from './ContentContainerDocCommon.module.scss';
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/content-container/example/ContentContainerStandard.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/content-container/example/ContentContainerStandard.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import ContentContainer from 'terra-content-container';
 import classNames from 'classnames/bind';
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 import Button from 'terra-button';
 import styles from './ContentContainerDocCommon.module.scss';
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-checkbox/About.1.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-checkbox/About.1.doc.mdx
@@ -19,8 +19,10 @@ The Terra Form Checkbox is a responsive input component rendered as a box next t
 ## Getting Started
 
 - Install with [npmjs](https://www.npmjs.com):
-  - `npm install terra-form-checkbox`
 
+  ```bash
+  npm install terra-form-checkbox
+  ```
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-checkbox/CheckboxField.2.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-checkbox/CheckboxField.2.doc.mdx
@@ -17,7 +17,7 @@ CheckboxField is a component of terra-form-checkbox that provides a container fo
 ## Usage
 
 ```jsx
-import CheckboxField from 'terra-form-checkbox/lib/CheckboxField';
+import { CheckboxField } from 'terra-form-checkbox';
 ```
 
 ## Component Features

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-checkbox/example/field/ControlledCheckboxField.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-checkbox/example/field/ControlledCheckboxField.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Checkbox from 'terra-form-checkbox';
-import CheckboxField from 'terra-form-checkbox/lib/CheckboxField';
+import Checkbox, { CheckboxField } from 'terra-form-checkbox';
 
 export default class extends React.Component {
   constructor(props) {

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-checkbox/example/field/DefaultCheckboxField.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-checkbox/example/field/DefaultCheckboxField.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Checkbox from 'terra-form-checkbox';
-import CheckboxField from 'terra-form-checkbox/lib/CheckboxField';
+import Checkbox, { CheckboxField } from 'terra-form-checkbox';
 
 class DefaultCheckboxField extends React.Component {
   constructor(props) {

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-checkbox/example/field/InlineCheckboxField.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-checkbox/example/field/InlineCheckboxField.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Checkbox from 'terra-form-checkbox';
-import CheckboxField from 'terra-form-checkbox/lib/CheckboxField';
+import Checkbox, { CheckboxField } from 'terra-form-checkbox';
 import classNames from 'classnames/bind';
 import styles from './InlineCheckboxField.module.scss';
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-checkbox/example/field/OptionalCheckboxField.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-checkbox/example/field/OptionalCheckboxField.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Checkbox from 'terra-form-checkbox';
-import CheckboxField from 'terra-form-checkbox/lib/CheckboxField';
+import Checkbox, { CheckboxField } from 'terra-form-checkbox';
 
 export default class extends React.Component {
   constructor(props) {

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-field/About.1.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-field/About.1.doc.mdx
@@ -13,8 +13,9 @@ The Form Field component handles the layout of the label, help text and error te
 ## Getting Started
 
 - Install with [npmjs](https://www.npmjs.com):
-  - `npm install terra-form-field`
-
+  ```bash
+  npm install terra-form-field
+  ```
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-fieldset/About.1.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-fieldset/About.1.doc.mdx
@@ -31,7 +31,7 @@ This component requires the following peer dependencies be installed in your app
 ## Usage
 
 ```jsx
-import Fieldset from 'terra-form-fieldset/lib/Fieldset';
+import Fieldset from 'terra-form-fieldset';
 ```
 
 ## Component Features

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-input/About.1.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-input/About.1.doc.mdx
@@ -42,7 +42,10 @@ However, this will not have the built-in validity checks or keyboard commands th
 ## Getting Started
 
 - Install with [npmjs](https://www.npmjs.com):
-  - `npm install terra-form-input`
+
+  ```bash
+  npm install terra-form-input
+  ```
 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-input/InputField.2.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-input/InputField.2.doc.mdx
@@ -25,7 +25,7 @@ import FormInputFieldPropsTable from 'terra-form-input/lib/InputField?dev-site-p
 ## Usage
 
 ```jsx
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 ```
 
 ## Component Features

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-input/example/IncompleteInputField.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-input/example/IncompleteInputField.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 
 const RequiredInputField = () => (
   <InputField

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-input/example/InlineLabelField.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-input/example/InlineLabelField.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames/bind';
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 import styles from '../common/InputFieldDocCommon.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-input/example/InputField.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-input/example/InputField.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 
 const DefaultInputField = () => (
   <InputField

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-input/example/NumberInputField.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-input/example/NumberInputField.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 
 const NumberInputField = () => (
   <InputField

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-input/example/RequiredInputField.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-input/example/RequiredInputField.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 
 const RequiredInputField = () => (
   <InputField

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-radio/RadioField.2.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-radio/RadioField.2.doc.mdx
@@ -16,7 +16,7 @@ RadioField is a component of terra-form-radio that provides a container for rend
 ## Usage
 
 ```jsx
-import RadioField from 'terra-form-radio/lib/RadioField';
+import { RadioField } from 'terra-form-radio';
 ```
 
 ## Component Features

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-radio/example/field/ControlledRadioField.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-radio/example/field/ControlledRadioField.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Radio from 'terra-form-radio';
-import RadioField from 'terra-form-radio/lib/RadioField';
+import Radio, { RadioField } from 'terra-form-radio';
 import classNames from 'classnames/bind';
 import styles from './RadioFieldCommon.module.scss';
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-radio/example/field/DefaultRadioField.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-radio/example/field/DefaultRadioField.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Radio from 'terra-form-radio';
-import RadioField from 'terra-form-radio/lib/RadioField';
+import Radio, { RadioField } from 'terra-form-radio';
 
 export default class extends React.Component {
   constructor(props) {

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-radio/example/field/InlineRadioField.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-radio/example/field/InlineRadioField.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Radio from 'terra-form-radio';
-import RadioField from 'terra-form-radio/lib/RadioField';
+import Radio, { RadioField } from 'terra-form-radio';
 import classNames from 'classnames/bind';
 import styles from './RadioFieldCommon.module.scss';
 

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-radio/example/field/OptionalRadioField.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-radio/example/field/OptionalRadioField.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Radio from 'terra-form-radio';
-import RadioField from 'terra-form-radio/lib/RadioField';
+import Radio, { RadioField } from 'terra-form-radio';
 
 export default class extends React.Component {
   constructor(props) {

--- a/packages/terra-core-docs/src/terra-dev-site/doc/form-textarea/TextareaField.2.doc.mdx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/form-textarea/TextareaField.2.doc.mdx
@@ -23,7 +23,7 @@ import FormTextareaFieldPropsTable from 'terra-form-textarea/lib/TextareaField?d
 ## Usage
 
 ```jsx
-import TextareaField from 'terra-form-textarea/lib/TextareaField';
+import { TextareaField } from 'terra-form-textarea';
 ```
 
 ## Component Features

--- a/packages/terra-core-docs/src/terra-dev-site/doc/scroll/example/ScrollHorizontal.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/doc/scroll/example/ScrollHorizontal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Scroll from 'terra-scroll';
 import Button from 'terra-button';
 import classNames from 'classnames/bind';
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 import styles from './ScrollCommon.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-checkbox/checkbox-field/ControlledCheckboxField.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-checkbox/checkbox-field/ControlledCheckboxField.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Checkbox from 'terra-form-checkbox';
-import CheckboxField from 'terra-form-checkbox/lib/CheckboxField';
+import Checkbox, { CheckboxField } from 'terra-form-checkbox';
 
 export default class extends React.Component {
   constructor(props) {

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-checkbox/checkbox-field/HiddenLegend.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-checkbox/checkbox-field/HiddenLegend.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Checkbox from 'terra-form-checkbox';
-import CheckboxField from 'terra-form-checkbox/lib/CheckboxField';
+import Checkbox, { CheckboxField } from 'terra-form-checkbox';
 
 const checkboxField = () => (
   <CheckboxField legend="Desired Department" isLegendHidden>

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-checkbox/checkbox-field/HideRequiredInvalidCheckboxField.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-checkbox/checkbox-field/HideRequiredInvalidCheckboxField.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Checkbox from 'terra-form-checkbox';
-import CheckboxField from 'terra-form-checkbox/lib/CheckboxField';
+import Checkbox, { CheckboxField } from 'terra-form-checkbox';
 
 export default class extends React.Component {
   constructor(props) {

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-checkbox/checkbox-field/LongTextLegend.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-checkbox/checkbox-field/LongTextLegend.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Checkbox from 'terra-form-checkbox';
-import CheckboxField from 'terra-form-checkbox/lib/CheckboxField';
+import Checkbox, { CheckboxField } from 'terra-form-checkbox';
 
 const LongTextLegend = () => (
   <CheckboxField

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-checkbox/checkbox-field/OptionalCheckboxField.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-checkbox/checkbox-field/OptionalCheckboxField.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Checkbox from 'terra-form-checkbox';
-import CheckboxField from 'terra-form-checkbox/lib/CheckboxField';
+import Checkbox, { CheckboxField } from 'terra-form-checkbox';
 
 const checkboxField = () => (
   <CheckboxField legend="Desired Department" showOptional>

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-input/DisabledInputField.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-input/DisabledInputField.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames/bind';
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 import styles from './common/Input.test.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-input/InputField.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-input/InputField.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames/bind';
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 import styles from './common/Input.test.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-input/InputFieldWidth.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-input/InputFieldWidth.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames/bind';
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 import styles from './common/Input.test.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-input/SupportedTypesInputField.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-input/SupportedTypesInputField.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames/bind';
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 import styles from './common/Input.test.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-input/UnsupportedTypesInputField.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-input/UnsupportedTypesInputField.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames/bind';
-import InputField from 'terra-form-input/lib/InputField';
+import { InputField } from 'terra-form-input';
 import styles from './common/Input.test.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-radio/field/ControlledRadioField.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-radio/field/ControlledRadioField.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Radio from 'terra-form-radio';
-import RadioField from 'terra-form-radio/lib/RadioField';
+import Radio, { RadioField } from 'terra-form-radio';
 
 export default class extends React.Component {
   constructor(props) {

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-radio/field/HiddenLegend.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-radio/field/HiddenLegend.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Radio from 'terra-form-radio';
-import RadioField from 'terra-form-radio/lib/RadioField';
+import Radio, { RadioField } from 'terra-form-radio';
 
 const exampleRadioField = () => (
   <RadioField legend="Desired Department" isLegendHidden>

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-radio/field/HideRequiredInvalidRadioField.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-radio/field/HideRequiredInvalidRadioField.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Radio from 'terra-form-radio';
-import RadioField from 'terra-form-radio/lib/RadioField';
+import Radio, { RadioField } from 'terra-form-radio';
 
 export default class extends React.Component {
   constructor(props) {

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-radio/field/LongTextLegend.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-radio/field/LongTextLegend.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Radio from 'terra-form-radio';
-import RadioField from 'terra-form-radio/lib/RadioField';
+import Radio, { RadioField } from 'terra-form-radio';
 
 const LongTextLegend = () => (
   <RadioField

--- a/packages/terra-core-docs/src/terra-dev-site/test/form-radio/field/OptionalRadioField.test.jsx
+++ b/packages/terra-core-docs/src/terra-dev-site/test/form-radio/field/OptionalRadioField.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Radio from 'terra-form-radio';
-import RadioField from 'terra-form-radio/lib/RadioField';
+import Radio, { RadioField } from 'terra-form-radio';
 
 const exampleRadioField = () => (
   <RadioField legend="Desired Department" showOptional>

--- a/packages/terra-form-checkbox/CHANGELOG.md
+++ b/packages/terra-form-checkbox/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added named export for `CheckboxField`. It can now be imported as `import { CheckboxField } from 'terra-form-checkbox';`.
+
 ## 4.24.0 - (March 4, 2024)
 
 * Changed

--- a/packages/terra-form-checkbox/package.json
+++ b/packages/terra-form-checkbox/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
-    "react-intl": ">=2.8.0 <6.0.0"
+    "react-intl": "^2.8.0 || 3 || 4 || 5"
   },
   "scripts": {
     "compile": "babel --root-mode upward src --out-dir lib --copy-files",

--- a/packages/terra-form-checkbox/package.json
+++ b/packages/terra-form-checkbox/package.json
@@ -20,7 +20,7 @@
     "terra-form-checkbox",
     "UI"
   ],
-  "main": "lib/Checkbox.js",
+  "main": "lib/index.js",
   "dependencies": {
     "classnames": "^2.2.5",
     "lodash.uniqueid": "^4.0.1",

--- a/packages/terra-form-checkbox/package.json
+++ b/packages/terra-form-checkbox/package.json
@@ -21,6 +21,15 @@
     "UI"
   ],
   "main": "lib/index.js",
+  "files": [
+    "lib",
+    "src",
+    "translations",
+    "CHANGELOG.md",
+    "LICENSE",
+    "NOTICE",
+    "README.md"
+  ],
   "dependencies": {
     "classnames": "^2.2.5",
     "lodash.uniqueid": "^4.0.1",
@@ -46,14 +55,5 @@
     "wdio:lowlight": "cd ../.. && terra wdio --themes clinical-lowlight-theme",
     "wdio:fusion": "cd ../.. && terra wdio --themes orion-fusion-theme",
     "wdio": "npm run wdio:default && npm run wdio:lowlight && npm run wdio:fusion"
-  },
-  "files": [
-    "lib",
-    "src",
-    "translations",
-    "CHANGELOG.md",
-    "LICENSE",
-    "NOTICE",
-    "README.md"
-  ]
+  }
 }

--- a/packages/terra-form-checkbox/src/index.js
+++ b/packages/terra-form-checkbox/src/index.js
@@ -1,0 +1,5 @@
+import Checkbox from './Checkbox';
+import CheckboxField from './CheckboxField';
+
+export default Checkbox;
+export { CheckboxField };

--- a/packages/terra-form-checkbox/tests/jest/Checkbox.test.jsx
+++ b/packages/terra-form-checkbox/tests/jest/Checkbox.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 
-import Checkbox from '../../src/Checkbox';
+import Checkbox from '../../src';
 
 window.matchMedia = () => ({ matches: true });
 

--- a/packages/terra-form-checkbox/tests/jest/CheckboxField.test.jsx
+++ b/packages/terra-form-checkbox/tests/jest/CheckboxField.test.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 
-import CheckboxField from '../../src/CheckboxField';
-import Checkbox from '../../src/Checkbox';
+import Checkbox, { CheckboxField } from '../../src';
 
 window.matchMedia = () => ({ matches: true });
 

--- a/packages/terra-form-input/CHANGELOG.md
+++ b/packages/terra-form-input/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added named export for `InputField`. It can now be imported as `import { InputField } from 'terra-form-input';`.
+
 ## 4.31.0 - (February 15, 2024)
 
 * Changed

--- a/packages/terra-form-input/package.json
+++ b/packages/terra-form-input/package.json
@@ -21,6 +21,14 @@
     "UI"
   ],
   "main": "lib/index.js",
+  "files": [
+    "lib",
+    "src",
+    "CHANGELOG.md",
+    "LICENSE",
+    "NOTICE",
+    "README.md"
+  ],
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
@@ -44,13 +52,5 @@
     "wdio:lowlight": "cd ../.. && terra wdio --themes clinical-lowlight-theme",
     "wdio:fusion": "cd ../.. && terra wdio --themes orion-fusion-theme",
     "wdio": "npm run wdio:default && npm run wdio:lowlight && npm run wdio:fusion"
-  },
-  "files": [
-    "lib",
-    "src",
-    "CHANGELOG.md",
-    "LICENSE",
-    "NOTICE",
-    "README.md"
-  ]
+  }
 }

--- a/packages/terra-form-input/package.json
+++ b/packages/terra-form-input/package.json
@@ -20,7 +20,7 @@
     "terra-form-input",
     "UI"
   ],
-  "main": "lib/Input.js",
+  "main": "lib/index.js",
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",

--- a/packages/terra-form-input/src/index.js
+++ b/packages/terra-form-input/src/index.js
@@ -1,0 +1,5 @@
+import Input from './Input';
+import InputField from './InputField';
+
+export default Input;
+export { InputField };

--- a/packages/terra-form-input/tests/jest/Input.test.jsx
+++ b/packages/terra-form-input/tests/jest/Input.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
-import Input from '../../src/Input';
+
+import Input from '../../src';
 
 describe('Input', () => {
   const defaultRender = <Input ariaLabel="label" />;

--- a/packages/terra-form-input/tests/jest/InputField.test.jsx
+++ b/packages/terra-form-input/tests/jest/InputField.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import IconHelp from 'terra-icon/lib/icon/IconHelp';
-import InputField from '../../src/InputField';
+import { IconHelp } from 'terra-icon';
+
+import { InputField } from '../../src';
 
 describe('InputField', () => {
   it('should render a default InputField component', () => {

--- a/packages/terra-form-radio/CHANGELOG.md
+++ b/packages/terra-form-radio/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added named export for `RadioField`. It can now be imported as `import { RadioField } from 'terra-form-radio';`.
+
 ## 4.51.0 - (February 28, 2024)
 
 * Fixed

--- a/packages/terra-form-radio/package.json
+++ b/packages/terra-form-radio/package.json
@@ -20,7 +20,7 @@
     "terra-form-radio",
     "UI"
   ],
-  "main": "lib/Radio.js",
+  "main": "lib/index.js",
   "dependencies": {
     "classnames": "^2.2.5",
     "lodash.uniqueid": "^4.0.1",
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
-    "react-intl": ">=2.8.0 <6.0.0"
+    "react-intl": "^2.8.0 || 3 || 4 || 5"
   },
   "scripts": {
     "compile": "babel --root-mode upward src --out-dir lib --copy-files",

--- a/packages/terra-form-radio/package.json
+++ b/packages/terra-form-radio/package.json
@@ -21,6 +21,15 @@
     "UI"
   ],
   "main": "lib/index.js",
+  "files": [
+    "lib",
+    "src",
+    "translations",
+    "CHANGELOG.md",
+    "LICENSE",
+    "NOTICE",
+    "README.md"
+  ],
   "dependencies": {
     "classnames": "^2.2.5",
     "lodash.uniqueid": "^4.0.1",
@@ -47,14 +56,5 @@
     "wdio:lowlight": "cd ../.. && terra wdio --themes clinical-lowlight-theme",
     "wdio:fusion": "cd ../.. && terra wdio --themes orion-fusion-theme",
     "wdio": "npm run wdio:default && npm run wdio:lowlight && npm run wdio:fusion"
-  },
-  "files": [
-    "lib",
-    "src",
-    "translations",
-    "CHANGELOG.md",
-    "LICENSE",
-    "NOTICE",
-    "README.md"
-  ]
+  }
 }

--- a/packages/terra-form-radio/src/index.js
+++ b/packages/terra-form-radio/src/index.js
@@ -1,0 +1,5 @@
+import Radio from './Radio';
+import RadioField from './RadioField';
+
+export default Radio;
+export { RadioField };

--- a/packages/terra-form-radio/tests/jest/Radio.test.jsx
+++ b/packages/terra-form-radio/tests/jest/Radio.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 
-import Radio from '../../src/Radio';
+import Radio from '../../src';
 
 window.matchMedia = () => ({ matches: true });
 

--- a/packages/terra-form-radio/tests/jest/RadioField.test.jsx
+++ b/packages/terra-form-radio/tests/jest/RadioField.test.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 import uniqueid from 'lodash.uniqueid';
-import RadioField from '../../src/RadioField';
-import Radio from '../../src/Radio';
+
+import Radio, { RadioField } from '../../src';
 
 window.matchMedia = () => ({ matches: true });
 jest.mock('lodash.uniqueid');

--- a/packages/terra-form-textarea/CHANGELOG.md
+++ b/packages/terra-form-textarea/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added named export for `TextareaField`. It can now be imported as `import { TextareaField } from 'terra-form-textarea';`.
+
 ## 5.32.0 - (February 15, 2024)
 
 * Changed

--- a/packages/terra-form-textarea/package.json
+++ b/packages/terra-form-textarea/package.json
@@ -21,6 +21,14 @@
     "UI"
   ],
   "main": "lib/index.js",
+  "files": [
+    "lib",
+    "src",
+    "CHANGELOG.md",
+    "LICENSE",
+    "NOTICE",
+    "README.md"
+  ],
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
@@ -44,13 +52,5 @@
     "wdio:lowlight": "cd ../.. && terra wdio --themes clinical-lowlight-theme",
     "wdio:fusion": "cd ../.. && terra wdio --themes orion-fusion-theme",
     "wdio": "npm run wdio:default && npm run wdio:lowlight && npm run wdio:fusion"
-  },
-  "files": [
-    "lib",
-    "src",
-    "CHANGELOG.md",
-    "LICENSE",
-    "NOTICE",
-    "README.md"
-  ]
+  }
 }

--- a/packages/terra-form-textarea/package.json
+++ b/packages/terra-form-textarea/package.json
@@ -20,7 +20,7 @@
     "terra-form-textarea",
     "UI"
   ],
-  "main": "lib/Textarea.js",
+  "main": "lib/index.js",
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",

--- a/packages/terra-form-textarea/src/index.js
+++ b/packages/terra-form-textarea/src/index.js
@@ -1,0 +1,5 @@
+import Textarea from './Textarea';
+import TextareaField from './TextareaField';
+
+export default Textarea;
+export { TextareaField };

--- a/packages/terra-form-textarea/tests/jest/Textarea.test.jsx
+++ b/packages/terra-form-textarea/tests/jest/Textarea.test.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 
-import Textarea from '../../src/Textarea';
+import Textarea from '../../src';
 
 window.matchMedia = () => ({ matches: true });
 

--- a/packages/terra-form-textarea/tests/jest/TextareaField.test.jsx
+++ b/packages/terra-form-textarea/tests/jest/TextareaField.test.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 
-import IconHelp from 'terra-icon/lib/icon/IconHelp';
-import TextareaField from '../../src/TextareaField';
+import { IconHelp } from 'terra-icon';
+import { TextareaField } from '../../src';
 
 window.matchMedia = () => ({ matches: true });
 


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

This PR adds named exports for `terra-form-checkbox`, `terra-form-input`, `terra-form-radio` & `terra-form-textarea` to meet JavaScript best practices and to avoid bad import patterns.

This PR also runs the [prettifyJSON](https://github.com/cerner/terra-toolkit/tree/main/scripts/prettifyJSON) script on those components.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

This was tested by using Jest to ensure that the imports are working correctly.

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->


---

Thank you for contributing to Terra.
@cerner/terra
