### PR TITLE
[terra-arrange] Use long-hand flex properties for IE compatibility

### DIFF
--- a/packages/terra-arrange/CHANGELOG.md
+++ b/packages/terra-arrange/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Changed flex property to be compatible with IE.
+
 ## 3.56.0 - (February 15, 2024)
 
 * Changed

--- a/packages/terra-arrange/src/Arrange.module.scss
+++ b/packages/terra-arrange/src/Arrange.module.scss
@@ -11,14 +11,18 @@
 
   // Makes sure fill expands to fill the remaining space of its parent container
   .fill {
-    flex: 1 1 auto;
+    flex-grow: 1;
+    flex-shrink: 1;
+    flex-basis: auto;
     min-width: 0;
   }
 
   // Styles specific to align items independently of each other
   .fit {
     align-self: flex-start;
-    flex: 0 0 auto;
+    flex-grow: 0;
+    flex-shrink: 0;
+    flex-basis: auto;
   }
 
   .center {
@@ -41,7 +45,9 @@
 
   @media (max-width: 320px), (max-height: 256px) {
     .fit {
-      flex: 0 0;
+      flex-grow: 0;
+      flex-shrink: 0;
+      flex-basis: 0;
     }
   }
 }


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Expands the flex property to use the long-hand version. IE has supposedly has trouble parsing the short-hand method, so this will hopefully fix it.

**Why it was changed:**
`flex` got split into 3 properties: `flex-grow`, `flex-shrink`, and `flex-basis`.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10305 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
