### PR TITLE
[terra-form-select] Fix Search field value clears out issue

### DIFF
--- a/packages/terra-form-select/CHANGELOG.md
+++ b/packages/terra-form-select/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
+* Fixed
+  * Search field value now persists when navigating to another component.
+
 ## 6.62.1 - (May 13, 2024)
 
 * Fixed
   * Fixed a "prop not recognized" console error.
-
 
 ## 6.62.0 - (May 8, 2024)
 

--- a/packages/terra-form-select/src/search/Frame.jsx
+++ b/packages/terra-form-select/src/search/Frame.jsx
@@ -231,13 +231,6 @@ class Frame extends React.Component {
 
     this.setState({ isFocused: false, focusedByTouch: false });
 
-    if (this.state.hasSearchChanged) {
-      this.setState({
-        searchValue: this.props.display,
-        hasSearchChanged: false,
-      });
-    }
-
     this.closeDropdown();
 
     if (this.props.onBlur) {


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
- When moving to some other component the Search Field gets onBlur event. onBlur event the state change is now removed.

**Why it was changed:**
Ensured search field value persists when navigating to another component to improve user experience by retaining search context.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10430<!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
